### PR TITLE
Implement #34 AI components stabilization order

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -30,7 +30,11 @@ jobs:
         run: |
           yarn test --maxWorkers=2 --coverage \
             --coverageReporters=json-summary \
-            --coverageReporters=text-summary
+            --coverageReporters=text-summary \
+            --collectCoverageFrom='src/**/*.{ts,tsx}' \
+            --collectCoverageFrom='packages/amaryllis/src/**/*.{ts,tsx}' \
+            --collectCoverageFrom='!**/__tests__/**' \
+            --collectCoverageFrom='!**/*.test.{ts,tsx}'
 
       - name: Validate coverage thresholds
         id: validate_coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,6 +120,10 @@ jobs:
         run: npm run lint
         working-directory: packages/amaryllis-components
 
+      - name: Typecheck components library
+        run: npm run typecheck
+        working-directory: packages/amaryllis-components
+
       - name: Build components library
         run: npm run build
         working-directory: packages/amaryllis-components

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -47,6 +47,10 @@ jobs:
         run: npm run lint
         working-directory: packages/amaryllis-components
 
+      - name: Typecheck components library
+        run: npm run typecheck
+        working-directory: packages/amaryllis-components
+
       - name: Build components library
         run: npm run build
         working-directory: packages/amaryllis-components
@@ -63,16 +67,17 @@ jobs:
           test -d packages/amaryllis-components/dist
           ls -la packages/amaryllis-components/dist/
 
-      - name: Test npm pack commands (dry run)
+      - name: Test components library npm pack command (dry run)
         if: github.event.inputs.dry_run == 'true'
         run: |
-          echo "Testing npm publish preparation"
+          echo "Testing components package publish preparation"
           npm pack --dry-run
         working-directory: packages/amaryllis-components
 
       - name: Test main library npm pack command (dry run)
         if: github.event.inputs.dry_run == 'true'
         run: |
+          echo "Testing main package publish preparation"
           npm pack --dry-run
           echo "npm pack dry run successful"
 

--- a/docs/ai-components-stabilization.md
+++ b/docs/ai-components-stabilization.md
@@ -1,0 +1,111 @@
+# AI Components Stabilization Notes
+
+This document records the implementation boundary for the ordered parent issue #34.
+
+## Status
+
+`@micrantha/amaryllis-components` remains experimental while the `amaryllis/v1alpha1` contract stabilizes. The module is intended to make AI-enabled components governable by keeping AI output inside deterministic schema, policy, runtime, and generation boundaries.
+
+## Ordered implementation mapping
+
+| Issue | Implementation boundary |
+| --- | --- |
+| #35 | `ComponentSpec` schema validation, required-property checks, safe generated identifiers, and unsafe layout rejection. |
+| #36 | Structured policy errors, fail-closed device execution checks, executable-output review gating, and explicit runtime policy. |
+| #37 | Runtime personalization diagnostics, constrained JSON Patch paths, unsafe object-key rejection, and deterministic fallback behavior. |
+| #38 | Deterministic generated provenance, richer TypeScript type generation, and generator-side layout hardening. |
+| #39 | Components workspace `typecheck` script and explicit CI/publish typecheck steps. |
+| #40 | Example and documentation flow for spec validation, policy validation, generation, and runtime personalization. |
+
+## ComponentSpec contract notes
+
+`amaryllis/v1alpha1` is a narrow contract, not a full general-purpose UI DSL.
+
+Required invariants:
+
+- `metadata.name` is kebab-case and suitable for deterministic generated component naming.
+- `props.required` entries must reference declared `props.properties` keys.
+- prop, slot, variant, and design token names must be safe generated-code identifiers.
+- device execution cannot scaffold TSX or executable code.
+- layouts must not contain script tags, imports, exports, `require`, `eval`, or `Function` constructors.
+
+Unsupported JSON Schema features may be passed through only where they are non-policy-critical. Generator and runtime behavior should only rely on documented fields.
+
+## Policy model
+
+Policy evaluation is deterministic and side-effect free.
+
+Device execution is the strictest mode:
+
+- output must be structured data only: `props-json`, `variant-selection`, or `json-patch`
+- runtime network access must be declared as `restricted` or `none`
+- runtime DOM access must be declared as `restricted` or `none`
+- executable, raw markup, import, network, DOM, and native-module operations are forbidden on device
+
+Executable TSX output is build/CI-only and requires explicit human review policy.
+
+## Runtime personalization model
+
+Runtime personalization behaves as a safe overlay:
+
+```text
+base props
+  + schema-validated structured AI output
+  + constrained patch application
+  -> final props
+  -> deterministic render
+```
+
+Runtime AI output is never authoritative state. Invalid personalization data falls back to base props and may report diagnostics through `onValidation`.
+
+Diagnostics intentionally avoid logging raw prompts or raw model inputs. Callers that need telemetry should log aggregate validation outcomes, error counts, and whether patches were used.
+
+## Generator provenance model
+
+Generated source is a build artifact. Provenance comments describe the generation context but should not claim perfect reproducibility unless callers provide enough pinned inputs.
+
+Generated provenance includes:
+
+- spec version
+- spec hash
+- generator version
+- model identifier, when applicable
+- prompt version, when applicable
+- validation summary
+- generated timestamp, only when explicitly supplied
+
+When `generatedAt` is omitted, generated output uses `Generated At: unavailable` to avoid injecting wall-clock nondeterminism into snapshots or generated code.
+
+## Example verification flow
+
+Use a static structured fixture rather than a live model provider:
+
+```text
+component.yaml
+  -> parse + schema validate
+  -> policy validate
+  -> generate personalization contract
+  -> generate React component or apply runtime personalization
+  -> show deterministic fallback on invalid AI output
+```
+
+Suggested commands:
+
+```sh
+yarn workspace @micrantha/amaryllis-components typecheck
+yarn workspace @micrantha/amaryllis-components test --runInBand
+yarn workspace @micrantha/amaryllis-components build
+```
+
+## Security notes
+
+Primary risks:
+
+- prompt injection into generated or personalized output
+- generated-code injection through layouts or executable output modes
+- data leakage through telemetry or runtime model calls
+- unsafe JSON Patch paths mutating policy or component identity
+- prototype pollution through structured output keys
+- false reproducibility claims when model/prompt/spec inputs are not pinned
+
+Default posture: fail closed for device execution and treat all AI output as a proposal accepted only after deterministic validation.

--- a/packages/amaryllis-components/package.json
+++ b/packages/amaryllis-components/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "prepare": "npm run build"

--- a/packages/amaryllis-components/src/__tests__/Generator.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.test.ts
@@ -25,14 +25,71 @@ describe('ReactGenerator', () => {
       modelId: 'test-model',
       promptVersion: 'prompt-v1',
       validationSummary: 'test-validation',
+      generatorVersion: 'test-generator',
       generatedAt: new Date('2026-01-01T00:00:00.000Z'),
     });
     expect(code).toContain('export const MyButton');
     expect(code).toContain('label: string');
     expect(code).toContain('Spec Hash: sha256-test');
+    expect(code).toContain('Generator Version: test-generator');
     expect(code).toContain('Model: test-model');
     expect(code).toContain('Prompt Version: prompt-v1');
     expect(code).toContain('Validation: test-validation');
+    expect(code).toContain('Generated At: 2026-01-01T00:00:00.000Z');
+  });
+
+  it('should not inject wall-clock time when generatedAt is omitted', () => {
+    const spec: ValidatedComponentSpec = {
+      apiVersion: 'amaryllis/v1alpha1',
+      kind: 'ComponentSpec',
+      metadata: { name: 'stable-card', version: '1.0.0' },
+      props: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+        },
+      },
+      target: { framework: 'react', runtime: 'web' },
+      ai: { mode: 'scaffold', execution: 'build' },
+    };
+
+    const code = generator.generate(spec);
+    expect(code).toContain('Generated At: unavailable');
+  });
+
+  it('should generate richer TypeScript from enums, arrays, integers, and objects', () => {
+    const spec: ValidatedComponentSpec = {
+      apiVersion: 'amaryllis/v1alpha1',
+      kind: 'ComponentSpec',
+      metadata: { name: 'typed-card', version: '1.0.0' },
+      props: {
+        type: 'object',
+        properties: {
+          tone: { type: 'string', enum: ['info', 'warning'] },
+          count: { type: 'integer' },
+          tags: { type: 'array', items: { type: 'string' } },
+          meta: {
+            type: 'object',
+            properties: {
+              source: { type: 'string' },
+            },
+            required: ['source'],
+          },
+        },
+        required: ['tone'],
+      },
+      target: { framework: 'react', runtime: 'web' },
+      ai: { mode: 'scaffold', execution: 'build' },
+    };
+
+    const code = generator.generate(spec, {
+      generatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    expect(code).toContain('tone: "info" | "warning";');
+    expect(code).toContain('count?: number;');
+    expect(code).toContain('tags?: string[];');
+    expect(code).toContain('source: string;');
   });
 
   it('should expose declared design tokens as typed component props', () => {
@@ -95,5 +152,28 @@ describe('ReactGenerator', () => {
     expect(code).toContain("import { View, Text } from 'react-native';");
     expect(code).toContain('<View>{children}</View>');
     expect(code).not.toContain('<div>{children}</div>');
+  });
+
+  it('should fail closed on unsafe layout strings', () => {
+    const spec: ValidatedComponentSpec = {
+      apiVersion: 'amaryllis/v1alpha1',
+      kind: 'ComponentSpec',
+      metadata: { name: 'unsafe-card', version: '1.0.0' },
+      props: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+        },
+      },
+      target: { framework: 'react', runtime: 'web' },
+      ui: {
+        layout: "<script>alert('x')</script>",
+      },
+      ai: { mode: 'scaffold', execution: 'build' },
+    };
+
+    expect(() => generator.generate(spec)).toThrow(
+      'Unsafe layout contains executable code or import/export syntax.'
+    );
   });
 });

--- a/packages/amaryllis-components/src/__tests__/Generator.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.test.ts
@@ -92,6 +92,33 @@ describe('ReactGenerator', () => {
     expect(code).toContain('source: string;');
   });
 
+  it('should quote nested object keys that are not TypeScript identifiers', () => {
+    const spec: ValidatedComponentSpec = {
+      apiVersion: 'amaryllis/v1alpha1',
+      kind: 'ComponentSpec',
+      metadata: { name: 'quoted-card', version: '1.0.0' },
+      props: {
+        type: 'object',
+        properties: {
+          meta: {
+            type: 'object',
+            properties: {
+              'source-id': { type: 'string' },
+            },
+            required: ['source-id'],
+          },
+        },
+      },
+      target: { framework: 'react', runtime: 'web' },
+      ai: { mode: 'scaffold', execution: 'build' },
+    };
+
+    const code = generator.generate(spec);
+
+    expect(code).toContain('"source-id": string;');
+    expect(code).not.toContain('source-id: string;');
+  });
+
   it('should expose declared design tokens as typed component props', () => {
     const spec: ValidatedComponentSpec = {
       apiVersion: 'amaryllis/v1alpha1',

--- a/packages/amaryllis-components/src/__tests__/Personalization.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Personalization.test.ts
@@ -37,6 +37,7 @@ describe('Personalization', () => {
     policy: {
       runtime: {
         networkAccess: 'none',
+        domAccess: 'restricted',
       },
     },
   };
@@ -55,6 +56,12 @@ describe('Personalization', () => {
     const result = engine.validate(contract, aiOutput);
     expect(result.valid).toBe(true);
     expect(result.data).toEqual(aiOutput);
+    expect(result.diagnostics).toEqual({
+      accepted: true,
+      errorCount: 0,
+      usedPatchOverlay: false,
+      sanitizedKeys: [],
+    });
   });
 
   test('should fail validation for incorrect data types', () => {
@@ -65,6 +72,7 @@ describe('Personalization', () => {
     const result = engine.validate(contract, aiOutput);
     expect(result.valid).toBe(false);
     expect(result.errors?.length).toBeGreaterThan(0);
+    expect(result.diagnostics?.accepted).toBe(false);
   });
 
   test('should fail validation for missing required props', () => {
@@ -168,6 +176,7 @@ describe('Personalization', () => {
 
     const result = engine.validate(contract, aiOutput);
     expect(result.valid).toBe(true);
+    expect(result.diagnostics?.usedPatchOverlay).toBe(true);
     expect(result.data).toEqual({
       props: { title: 'Patched title' },
       variant: 'compact',
@@ -216,6 +225,26 @@ describe('Personalization', () => {
     const result = engine.validate(contract, aiOutput);
     expect(result.valid).toBe(false);
     expect(result.errors?.join('\n')).toContain('/props/title must be string');
+  });
+
+  test('should reject unsafe JSON Patch values', () => {
+    const aiOutput = {
+      props: { title: 'Hello' },
+      patches: [
+        {
+          op: 'add',
+          path: '/props/title',
+          value: JSON.parse('{"__proto__":{"polluted":true}}'),
+        },
+      ],
+    };
+
+    const result = engine.validate(contract, aiOutput);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      '/patches/0/value contains an unsafe object key'
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
   test('should register and retrieve components in registry', () => {

--- a/packages/amaryllis-components/src/__tests__/Policy.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Policy.test.ts
@@ -18,6 +18,10 @@ describe('PolicyEngine', () => {
     expect(result.errors).toContain(
       "Operation 'test' is both allowed and forbidden."
     );
+    expect(result.issues).toContainEqual({
+      code: 'operation_conflict',
+      message: "Operation 'test' is both allowed and forbidden.",
+    });
   });
 
   it('should pass valid policy', () => {
@@ -37,6 +41,7 @@ describe('PolicyEngine', () => {
       spec as unknown as ValidatedComponentSpec
     );
     expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
   });
 
   it('should require human approval for executable generation', () => {
@@ -62,6 +67,9 @@ describe('PolicyEngine', () => {
     expect(result.errors).toContain(
       'Executable generated output requires human approval.'
     );
+    expect(result.issues.map((issue) => issue.code)).toContain(
+      'executable_output_review_required'
+    );
   });
 
   it('should reject forbidden runtime operations on device', () => {
@@ -70,6 +78,35 @@ describe('PolicyEngine', () => {
         mode: 'personalize',
         execution: 'device',
         allowedOperations: ['setSlotText', 'executeCode'],
+        generationContract: {
+          output: 'props-json',
+        },
+      },
+      policy: {
+        runtime: {
+          networkAccess: 'none',
+          domAccess: 'none',
+        },
+      },
+    };
+
+    const result = engine.validateSpec(
+      spec as unknown as ValidatedComponentSpec
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "Runtime operation 'executeCode' is forbidden on device."
+    );
+    expect(result.issues.map((issue) => issue.code)).toContain(
+      'device_runtime_operation_forbidden'
+    );
+  });
+
+  it('should require explicit runtime policy for device execution', () => {
+    const spec = {
+      ai: {
+        mode: 'personalize',
+        execution: 'device',
         generationContract: {
           output: 'props-json',
         },
@@ -86,7 +123,34 @@ describe('PolicyEngine', () => {
     );
     expect(result.valid).toBe(false);
     expect(result.errors).toContain(
-      "Runtime operation 'executeCode' is forbidden on device."
+      'Device execution must declare runtime.domAccess as restricted or none.'
     );
+    expect(result.issues.map((issue) => issue.code)).toContain(
+      'device_runtime_policy_required'
+    );
+  });
+
+  it('should allow structured device personalization with explicit runtime policy', () => {
+    const spec = {
+      ai: {
+        mode: 'personalize',
+        execution: 'device',
+        allowedOperations: ['setSlotText'],
+        generationContract: {
+          output: 'json-patch',
+        },
+      },
+      policy: {
+        runtime: {
+          networkAccess: 'none',
+          domAccess: 'restricted',
+        },
+      },
+    };
+
+    const result = engine.validateSpec(
+      spec as unknown as ValidatedComponentSpec
+    );
+    expect(result.valid).toBe(true);
   });
 });

--- a/packages/amaryllis-components/src/__tests__/Spec.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Spec.test.ts
@@ -16,6 +16,8 @@ props:
   properties:
     label:
       type: string
+  required:
+    - label
 ai:
   mode: scaffold
   execution: build
@@ -84,6 +86,66 @@ ai:
 
     expect(() => parseComponentSpec(yaml)).toThrow(
       'generated component prop names must be valid JavaScript identifiers'
+    );
+  });
+
+  it('should reject required props that are not declared', () => {
+    const yaml = `
+apiVersion: amaryllis/v1alpha1
+kind: ComponentSpec
+metadata:
+  name: invalid-required
+  version: 1.0.0
+target:
+  framework: react
+  runtime: web
+props:
+  type: object
+  properties:
+    title:
+      type: string
+  required:
+    - title
+    - missing
+ai:
+  mode: scaffold
+  execution: build
+`;
+
+    expect(() => parseComponentSpec(yaml)).toThrow(
+      "required prop 'missing' must reference a declared property"
+    );
+  });
+
+  it('should reject unsafe slot, variant, and layout declarations', () => {
+    const yaml = `
+apiVersion: amaryllis/v1alpha1
+kind: ComponentSpec
+metadata:
+  name: unsafe-ui
+  version: 1.0.0
+target:
+  framework: react
+  runtime: web
+props:
+  type: object
+  properties:
+    title:
+      type: string
+ui:
+  layout: "<script>alert('x')</script>"
+  slots:
+    - footer-text
+  variants:
+    compact-card:
+      layout: "<div>{title}</div>"
+ai:
+  mode: scaffold
+  execution: build
+`;
+
+    expect(() => parseComponentSpec(yaml)).toThrow(
+      'component layout must not contain imports, exports, scripts, eval, require, or Function constructors'
     );
   });
 });

--- a/packages/amaryllis-components/src/generator/react.ts
+++ b/packages/amaryllis-components/src/generator/react.ts
@@ -28,7 +28,9 @@ export class ReactGenerator {
       ui?.slots,
       ui?.designTokens
     );
-    const layout = this.safeLayout(ui?.layout || this.getDefaultLayout(target.runtime));
+    const layout = this.safeLayout(
+      ui?.layout || this.getDefaultLayout(target.runtime)
+    );
 
     const imports = this.generateImports(target.runtime);
 
@@ -159,9 +161,7 @@ ${tokenLines.join('\n')}
 
   private jsonSchemaToTsType(schema: JsonSchemaValue): string {
     if (schema.enum && schema.enum.length > 0) {
-      return schema.enum
-        .map((value) => JSON.stringify(value))
-        .join(' | ');
+      return schema.enum.map((value) => JSON.stringify(value)).join(' | ');
     }
 
     switch (schema.type) {
@@ -226,8 +226,14 @@ ${properties.join('\n')}
   }
 
   private safeLayout(layout: string): string {
-    if (/(<script\b|\bimport\s+|\bexport\s+|\brequire\s*\(|\beval\s*\(|new\s+Function\s*\()/i.test(layout)) {
-      throw new Error('Unsafe layout contains executable code or import/export syntax.');
+    if (
+      /(<script\b|\bimport\s+|\bexport\s+|\brequire\s*\(|\beval\s*\(|new\s+Function\s*\()/i.test(
+        layout
+      )
+    ) {
+      throw new Error(
+        'Unsafe layout contains executable code or import/export syntax.'
+      );
     }
     return layout;
   }

--- a/packages/amaryllis-components/src/generator/react.ts
+++ b/packages/amaryllis-components/src/generator/react.ts
@@ -7,6 +7,7 @@ export interface ReactGeneratorOptions {
   promptVersion?: string;
   validationSummary?: string;
   generatedAt?: Date;
+  generatorVersion?: string;
 }
 
 type ComponentVariants = NonNullable<ValidatedComponentSpec['ui']>['variants'];
@@ -27,7 +28,7 @@ export class ReactGenerator {
       ui?.slots,
       ui?.designTokens
     );
-    const layout = ui?.layout || this.getDefaultLayout(target.runtime);
+    const layout = this.safeLayout(ui?.layout || this.getDefaultLayout(target.runtime));
 
     const imports = this.generateImports(target.runtime);
 
@@ -68,7 +69,7 @@ export const ${componentName}: React.FC<${componentName}Props> = ({
     }
 
     const cases = Object.entries(variants).map(([name, config]) => {
-      const layout = config.layout || defaultLayout;
+      const layout = this.safeLayout(config.layout || defaultLayout);
       return `    case '${name}':\n      return (\n        ${this.wrapWithLayout(layout)}\n      );`;
     });
 
@@ -157,20 +158,45 @@ ${tokenLines.join('\n')}
   }
 
   private jsonSchemaToTsType(schema: JsonSchemaValue): string {
+    if (schema.enum && schema.enum.length > 0) {
+      return schema.enum
+        .map((value) => JSON.stringify(value))
+        .join(' | ');
+    }
+
     switch (schema.type) {
       case 'string':
         return 'string';
       case 'number':
+      case 'integer':
         return 'number';
       case 'boolean':
         return 'boolean';
       case 'array':
-        return 'unknown[]';
+        return `${this.jsonSchemaToTsType(schema.items ?? {})}[]`;
       case 'object':
-        return 'Record<string, unknown>';
+        return this.objectSchemaToTsType(schema);
+      case 'null':
+        return 'null';
       default:
         return 'unknown';
     }
+  }
+
+  private objectSchemaToTsType(schema: JsonSchemaValue): string {
+    if (!schema.properties || Object.keys(schema.properties).length === 0) {
+      return 'Record<string, unknown>';
+    }
+
+    const required = new Set(schema.required ?? []);
+    const properties = Object.entries(schema.properties).map(([key, value]) => {
+      const optional = required.has(key) ? '' : '?';
+      return `    ${key}${optional}: ${this.jsonSchemaToTsType(value)};`;
+    });
+
+    return `{
+${properties.join('\n')}
+  }`;
   }
 
   private generateImports(runtime: string): string {
@@ -199,6 +225,13 @@ ${tokenLines.join('\n')}
     return result;
   }
 
+  private safeLayout(layout: string): string {
+    if (/(<script\b|\bimport\s+|\bexport\s+|\brequire\s*\(|\beval\s*\(|new\s+Function\s*\()/i.test(layout)) {
+      throw new Error('Unsafe layout contains executable code or import/export syntax.');
+    }
+    return layout;
+  }
+
   private generateProvenance(
     specVersion: string,
     options: ReactGeneratorOptions
@@ -206,10 +239,11 @@ ${tokenLines.join('\n')}
     return [
       ` * Spec Version: ${specVersion}`,
       ` * Spec Hash: ${options.specHash ?? 'unavailable'}`,
+      ` * Generator Version: ${options.generatorVersion ?? '0.1.0'}`,
       ` * Model: ${options.modelId ?? 'deterministic-generator'}`,
       ` * Prompt Version: ${options.promptVersion ?? 'none'}`,
       ` * Validation: ${options.validationSummary ?? 'policy-passed'}`,
-      ` * Generated At: ${(options.generatedAt ?? new Date()).toISOString()}`,
+      ` * Generated At: ${options.generatedAt?.toISOString() ?? 'unavailable'}`,
       ' * Previous Diff: available through the customize command',
     ].join('\n');
   }

--- a/packages/amaryllis-components/src/generator/react.ts
+++ b/packages/amaryllis-components/src/generator/react.ts
@@ -15,6 +15,8 @@ type ComponentDesignTokens = NonNullable<
   ValidatedComponentSpec['ui']
 >['designTokens'];
 
+const TS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
 export class ReactGenerator {
   generate(
     spec: ValidatedComponentSpec,
@@ -101,12 +103,12 @@ ${cases.join('\n')}
     const lines = Object.entries(props.properties).map(([key, schema]) => {
       const isRequired = props.required?.includes(key);
       const type = this.jsonSchemaToTsType(schema);
-      return `  ${key}${isRequired ? '' : '?'}: ${type};`;
+      return `  ${this.formatPropertyKey(key)}${isRequired ? '' : '?'}: ${type};`;
     });
 
     if (slots) {
       slots.forEach((slot) => {
-        lines.push(`  ${slot}?: React.ReactNode;`);
+        lines.push(`  ${this.formatPropertyKey(slot)}?: React.ReactNode;`);
       });
     }
 
@@ -152,7 +154,9 @@ ${groups.join('\n')}
       return null;
     }
 
-    const tokenLines = tokens.map((token) => `      ${token}?: string;`);
+    const tokenLines = tokens.map(
+      (token) => `      ${this.formatPropertyKey(token)}?: string;`
+    );
 
     return `    ${groupName}?: {
 ${tokenLines.join('\n')}
@@ -191,12 +195,19 @@ ${tokenLines.join('\n')}
     const required = new Set(schema.required ?? []);
     const properties = Object.entries(schema.properties).map(([key, value]) => {
       const optional = required.has(key) ? '' : '?';
-      return `    ${key}${optional}: ${this.jsonSchemaToTsType(value)};`;
+      return `    ${this.formatPropertyKey(key)}${optional}: ${this.jsonSchemaToTsType(value)};`;
     });
 
     return `{
 ${properties.join('\n')}
   }`;
+  }
+
+  private formatPropertyKey(key: string): string {
+    return TS_IDENTIFIER.test(key) &&
+      !['__proto__', 'constructor', 'prototype'].includes(key)
+      ? key
+      : JSON.stringify(key);
   }
 
   private generateImports(runtime: string): string {

--- a/packages/amaryllis-components/src/generator/schema.ts
+++ b/packages/amaryllis-components/src/generator/schema.ts
@@ -86,7 +86,9 @@ export class JSONSchemaGenerator {
       ...(value.enum && { enum: value.enum }),
       ...(value.default !== undefined && { default: value.default }),
       ...(value.items && { items: this.mapProperty(value.items) }),
-      ...(value.properties && { properties: this.mapProperties(value.properties) }),
+      ...(value.properties && {
+        properties: this.mapProperties(value.properties),
+      }),
       ...(value.required && { required: value.required }),
       ...(value.additionalProperties !== undefined && {
         additionalProperties:

--- a/packages/amaryllis-components/src/generator/schema.ts
+++ b/packages/amaryllis-components/src/generator/schema.ts
@@ -73,15 +73,28 @@ export class JSONSchemaGenerator {
     const mapped: Record<string, JsonSchemaValue> = {};
 
     for (const [key, value] of Object.entries(properties)) {
-      mapped[key] = {
-        type: value.type,
-        ...(value.description && { description: value.description }),
-        ...(value.enum && { enum: value.enum }),
-        ...(value.default !== undefined && { default: value.default }),
-      };
+      mapped[key] = this.mapProperty(value);
     }
 
     return mapped;
+  }
+
+  private mapProperty(value: JsonSchemaValue): JsonSchemaValue {
+    return {
+      ...(value.type && { type: value.type }),
+      ...(value.description && { description: value.description }),
+      ...(value.enum && { enum: value.enum }),
+      ...(value.default !== undefined && { default: value.default }),
+      ...(value.items && { items: this.mapProperty(value.items) }),
+      ...(value.properties && { properties: this.mapProperties(value.properties) }),
+      ...(value.required && { required: value.required }),
+      ...(value.additionalProperties !== undefined && {
+        additionalProperties:
+          typeof value.additionalProperties === 'boolean'
+            ? value.additionalProperties
+            : this.mapProperty(value.additionalProperties),
+      }),
+    };
   }
 
   private mapDesignTokens(

--- a/packages/amaryllis-components/src/policy/engine.ts
+++ b/packages/amaryllis-components/src/policy/engine.ts
@@ -1,8 +1,24 @@
 import type { ValidatedComponentSpec } from '../schema/spec.schema';
 
+export type PolicyErrorCode =
+  | 'operation_conflict'
+  | 'import_conflict'
+  | 'device_contract_required'
+  | 'device_structured_output_required'
+  | 'device_executable_output_forbidden'
+  | 'device_runtime_operation_forbidden'
+  | 'device_runtime_policy_required'
+  | 'executable_output_review_required';
+
+export interface PolicyError {
+  code: PolicyErrorCode;
+  message: string;
+}
+
 export interface PolicyResult {
   valid: boolean;
   errors: string[];
+  issues: PolicyError[];
 }
 
 const EXECUTABLE_OUTPUTS = new Set(['tsx']);
@@ -17,28 +33,37 @@ const FORBIDDEN_RUNTIME_OPERATIONS = new Set([
   'rawMarkup',
   'networkAccess',
   'nativeModuleAccess',
+  'domAccess',
+  'unrestrictedNetworkAccess',
 ]);
 
 export class PolicyEngine {
   validateSpec(spec: ValidatedComponentSpec): PolicyResult {
-    const errors: string[] = [];
+    const issues: PolicyError[] = [];
+    const addIssue = (code: PolicyErrorCode, message: string): void => {
+      issues.push({ code, message });
+    };
 
-    // 1. Check forbidden operations
     if (spec.ai.forbiddenOperations && spec.ai.allowedOperations) {
       for (const op of spec.ai.allowedOperations) {
         if (spec.ai.forbiddenOperations.includes(op)) {
-          errors.push(`Operation '${op}' is both allowed and forbidden.`);
+          addIssue(
+            'operation_conflict',
+            `Operation '${op}' is both allowed and forbidden.`
+          );
         }
       }
     }
 
-    // 2. Import policy
     if (spec.policy?.imports) {
       const { allow, deny } = spec.policy.imports;
       if (allow && deny) {
         for (const item of allow) {
           if (deny.includes(item)) {
-            errors.push(`Import '${item}' is both allowed and denied.`);
+            addIssue(
+              'import_conflict',
+              `Import '${item}' is both allowed and denied.`
+            );
           }
         }
       }
@@ -48,41 +73,68 @@ export class PolicyEngine {
 
     if (spec.ai.execution === 'device') {
       if (!spec.ai.generationContract) {
-        errors.push('Device execution requires a generation contract.');
+        addIssue(
+          'device_contract_required',
+          'Device execution requires a generation contract.'
+        );
       } else if (!STRUCTURED_DEVICE_OUTPUTS.has(output ?? '')) {
-        errors.push('Device execution must output structured data only.');
+        addIssue(
+          'device_structured_output_required',
+          'Device execution must output structured data only.'
+        );
       }
 
       if (output && EXECUTABLE_OUTPUTS.has(output)) {
-        errors.push('Device execution cannot output TSX or executable code.');
+        addIssue(
+          'device_executable_output_forbidden',
+          'Device execution cannot output TSX or executable code.'
+        );
       }
 
       for (const op of spec.ai.allowedOperations ?? []) {
         if (FORBIDDEN_RUNTIME_OPERATIONS.has(op)) {
-          errors.push(`Runtime operation '${op}' is forbidden on device.`);
+          addIssue(
+            'device_runtime_operation_forbidden',
+            `Runtime operation '${op}' is forbidden on device.`
+          );
         }
       }
 
       if (!spec.policy?.runtime?.networkAccess) {
-        errors.push(
+        addIssue(
+          'device_runtime_policy_required',
           'Device execution must declare runtime.networkAccess as restricted or none.'
+        );
+      }
+
+      if (!spec.policy?.runtime?.domAccess) {
+        addIssue(
+          'device_runtime_policy_required',
+          'Device execution must declare runtime.domAccess as restricted or none.'
         );
       }
     }
 
     if (output && EXECUTABLE_OUTPUTS.has(output)) {
       if (spec.ai.execution === 'device') {
-        errors.push('Executable generated output is limited to build or CI.');
+        addIssue(
+          'device_executable_output_forbidden',
+          'Executable generated output is limited to build or CI.'
+        );
       }
 
       if (spec.policy?.review?.requireHumanApproval !== true) {
-        errors.push('Executable generated output requires human approval.');
+        addIssue(
+          'executable_output_review_required',
+          'Executable generated output requires human approval.'
+        );
       }
     }
 
     return {
-      valid: errors.length === 0,
-      errors,
+      valid: issues.length === 0,
+      errors: issues.map((issue) => issue.message),
+      issues,
     };
   }
 }

--- a/packages/amaryllis-components/src/runtime/PersonalizedComponent.tsx
+++ b/packages/amaryllis-components/src/runtime/PersonalizedComponent.tsx
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { PersonalizationEngine } from './engine';
+import {
+  PersonalizationEngine,
+  type PersonalizationDiagnostics,
+} from './engine';
 import { resolveUiPrimitives, type UiPrimitives } from './primitives';
 import { useRegistry } from './registryContext';
+
+export interface PersonalizedComponentValidationEvent {
+  name: string;
+  valid: boolean;
+  errors?: string[];
+  diagnostics?: PersonalizationDiagnostics;
+}
 
 export interface PersonalizedComponentProps {
   /** Name of the registered component to render */
@@ -16,6 +26,10 @@ export interface PersonalizedComponentProps {
   fallback?: React.ReactNode;
   /** Optional UI primitive overrides for React Native or custom renderers */
   primitives?: Partial<UiPrimitives>;
+  /** Optional validation callback for telemetry or diagnostics */
+  onValidation?: (event: PersonalizedComponentValidationEvent) => void;
+  /** Enable console warnings for validation failures. Defaults to false. */
+  warnOnValidationFailure?: boolean;
 }
 
 /**
@@ -29,6 +43,8 @@ export const PersonalizedComponent: React.FC<PersonalizedComponentProps> = ({
   loading,
   fallback,
   primitives,
+  onValidation,
+  warnOnValidationFailure = false,
 }) => {
   const registry = useRegistry();
   const registered = registry.get(name);
@@ -46,22 +62,40 @@ export const PersonalizedComponent: React.FC<PersonalizedComponentProps> = ({
 
     if (personalizationData) {
       const result = engine.validate(registered.contract, personalizationData);
+      onValidation?.({
+        name,
+        valid: result.valid,
+        errors: result.errors,
+        diagnostics: result.diagnostics,
+      });
+
       if (result.valid) {
         setFinalProps(engine.apply(baseProps, result.data ?? {}));
         setError(null);
       } else {
-        console.warn(
-          `Personalization validation failed for ${name}:`,
-          result.errors
-        );
+        if (warnOnValidationFailure) {
+          console.warn(
+            `Personalization validation failed for ${name}:`,
+            result.errors
+          );
+        }
         setError('Invalid personalization data');
         // Revert to base props on failure
         setFinalProps(baseProps);
       }
     } else {
       setFinalProps(baseProps);
+      setError(null);
     }
-  }, [name, personalizationData, baseProps, registered, engine]);
+  }, [
+    name,
+    personalizationData,
+    baseProps,
+    registered,
+    engine,
+    onValidation,
+    warnOnValidationFailure,
+  ]);
 
   if (!registered) {
     return <>{fallback || null}</>;

--- a/packages/amaryllis-components/src/runtime/engine.ts
+++ b/packages/amaryllis-components/src/runtime/engine.ts
@@ -15,10 +15,19 @@ export interface PersonalizationResult {
   valid: boolean;
   data?: PersonalizationData;
   errors?: string[];
+  diagnostics?: PersonalizationDiagnostics;
+}
+
+export interface PersonalizationDiagnostics {
+  accepted: boolean;
+  errorCount: number;
+  usedPatchOverlay: boolean;
+  sanitizedKeys: string[];
 }
 
 export class PersonalizationEngine {
   private ajv: Ajv;
+  private sanitizedKeys: string[] = [];
 
   constructor() {
     this.ajv = new Ajv({ allErrors: true, useDefaults: true });
@@ -28,15 +37,28 @@ export class PersonalizationEngine {
     contract: PersonalizationContract,
     aiOutput: unknown
   ): PersonalizationResult {
+    this.sanitizedKeys = [];
     const validate = this.ajv.compile(contract);
     const valid = validate(aiOutput);
 
     if (!valid) {
+      const errors = this.formatErrors(validate.errors);
       return {
         valid: false,
-        errors: validate.errors?.map(
-          (err: ErrorObject) =>
-            `${err.instancePath || err.schemaPath} ${err.message}`
+        errors,
+        diagnostics: this.createDiagnostics(false, errors.length, false),
+      };
+    }
+
+    const unsafeValueErrors = this.validateSafeValues(aiOutput);
+    if (unsafeValueErrors.length > 0) {
+      return {
+        valid: false,
+        errors: unsafeValueErrors,
+        diagnostics: this.createDiagnostics(
+          false,
+          unsafeValueErrors.length,
+          false
         ),
       };
     }
@@ -49,6 +71,11 @@ export class PersonalizationEngine {
     return {
       valid: true,
       data: patchResult.data,
+      diagnostics: this.createDiagnostics(
+        true,
+        0,
+        Boolean((aiOutput as PersonalizationData).patches?.length)
+      ),
     };
   }
 
@@ -59,6 +86,7 @@ export class PersonalizationEngine {
     baseProps: Record<string, unknown>,
     personalization: PersonalizationData
   ): Record<string, unknown> {
+    this.sanitizedKeys = [];
     const result = this.safeMerge({}, baseProps);
 
     if (personalization.props) {
@@ -70,11 +98,11 @@ export class PersonalizationEngine {
     }
 
     if (personalization.slots) {
-      Object.assign(result, personalization.slots);
+      this.safeMerge(result, personalization.slots);
     }
 
     if (personalization.designTokens) {
-      result.designTokens = personalization.designTokens;
+      result.designTokens = this.safeMerge({}, personalization.designTokens);
     }
 
     return result;
@@ -86,6 +114,7 @@ export class PersonalizationEngine {
   ): Record<string, unknown> {
     Object.entries(source).forEach(([key, value]) => {
       if (this.isUnsafeObjectKey(key)) {
+        this.sanitizedKeys.push(key);
         return;
       }
 
@@ -115,6 +144,7 @@ export class PersonalizationEngine {
       return {
         valid: true,
         data: personalization,
+        diagnostics: this.createDiagnostics(true, 0, false),
       };
     }
 
@@ -126,6 +156,20 @@ export class PersonalizationEngine {
       return {
         valid: false,
         errors: pathErrors,
+        diagnostics: this.createDiagnostics(false, pathErrors.length, true),
+      };
+    }
+
+    const unsafePatchErrors = this.validatePatchValues(personalization.patches);
+    if (unsafePatchErrors.length > 0) {
+      return {
+        valid: false,
+        errors: unsafePatchErrors,
+        diagnostics: this.createDiagnostics(
+          false,
+          unsafePatchErrors.length,
+          true
+        ),
       };
     }
 
@@ -144,12 +188,18 @@ export class PersonalizationEngine {
         return {
           valid: false,
           errors: validationErrors,
+          diagnostics: this.createDiagnostics(
+            false,
+            validationErrors.length,
+            true
+          ),
         };
       }
 
       return {
         valid: true,
         data: patchedData,
+        diagnostics: this.createDiagnostics(true, 0, true),
       };
     } catch (err: unknown) {
       return {
@@ -159,6 +209,7 @@ export class PersonalizationEngine {
             ? `Invalid personalization patch: ${err.message}`
             : 'Invalid personalization patch',
         ],
+        diagnostics: this.createDiagnostics(false, 1, true),
       };
     }
   }
@@ -190,6 +241,33 @@ export class PersonalizationEngine {
     return errors;
   }
 
+  private validatePatchValues(patches: jsonpatch.Operation[]): string[] {
+    const errors: string[] = [];
+
+    patches.forEach((patch, index) => {
+      if ('value' in patch && this.containsUnsafeObjectKey(patch.value)) {
+        errors.push(`/patches/${index}/value contains an unsafe object key`);
+      }
+    });
+
+    return errors;
+  }
+
+  private containsUnsafeObjectKey(value: unknown): boolean {
+    if (Array.isArray(value)) {
+      return value.some((item) => this.containsUnsafeObjectKey(item));
+    }
+
+    if (!this.isRecord(value)) {
+      return false;
+    }
+
+    return Object.entries(value).some(
+      ([key, nested]) =>
+        this.isUnsafeObjectKey(key) || this.containsUnsafeObjectKey(nested)
+    );
+  }
+
   private isAllowedPatchPath(
     contract: PersonalizationContract,
     path: string
@@ -210,7 +288,7 @@ export class PersonalizationEngine {
 
     const [section, name] = segments;
 
-    if (!name) {
+    if (!name || this.isUnsafeObjectKey(name)) {
       return false;
     }
 
@@ -320,12 +398,40 @@ export class PersonalizationEngine {
       return [];
     }
 
+    return this.formatErrors(validate.errors, [
+      'Patched personalization data failed validation',
+    ]);
+  }
+
+  private validateSafeValues(value: unknown): string[] {
+    return this.containsUnsafeObjectKey(value)
+      ? ['Personalization data contains an unsafe object key']
+      : [];
+  }
+
+  private formatErrors(
+    errors: ErrorObject[] | null | undefined,
+    fallback: string[] = []
+  ): string[] {
     return (
-      validate.errors?.map(
+      errors?.map(
         (err: ErrorObject) =>
           `${err.instancePath || err.schemaPath} ${err.message}`
-      ) ?? ['Patched personalization data failed validation']
+      ) ?? fallback
     );
+  }
+
+  private createDiagnostics(
+    accepted: boolean,
+    errorCount: number,
+    usedPatchOverlay: boolean
+  ): PersonalizationDiagnostics {
+    return {
+      accepted,
+      errorCount,
+      usedPatchOverlay,
+      sanitizedKeys: [...this.sanitizedKeys],
+    };
   }
 
   private isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/amaryllis-components/src/schema/spec.schema.ts
+++ b/packages/amaryllis-components/src/schema/spec.schema.ts
@@ -1,5 +1,64 @@
 import { z } from 'zod';
 
+const JS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const COMPONENT_NAME = /^[a-z][a-z0-9-]*$/;
+const SEMVERISH = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+const UNSAFE_LAYOUT_PATTERNS = [
+  /<script\b/i,
+  /\bimport\s+/,
+  /\bexport\s+/,
+  /\brequire\s*\(/,
+  /\beval\s*\(/,
+  /new\s+Function\s*\(/,
+];
+
+function addIdentifierIssue(
+  ctx: z.RefinementCtx,
+  path: (string | number)[],
+  message: string
+): void {
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path,
+    message,
+  });
+}
+
+function isSafeIdentifier(value: string): boolean {
+  return JS_IDENTIFIER.test(value) && !['__proto__', 'constructor', 'prototype'].includes(value);
+}
+
+function validateIdentifierList(
+  values: string[] | undefined,
+  ctx: z.RefinementCtx,
+  path: string[],
+  message: string
+): void {
+  values?.forEach((value, index) => {
+    if (!isSafeIdentifier(value)) {
+      addIdentifierIssue(ctx, [...path, index], message);
+    }
+  });
+}
+
+function validateLayout(
+  layout: string | undefined,
+  ctx: z.RefinementCtx,
+  path: string[]
+): void {
+  if (!layout) {
+    return;
+  }
+
+  if (UNSAFE_LAYOUT_PATTERNS.some((pattern) => pattern.test(layout))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: 'component layout must not contain imports, exports, scripts, eval, require, or Function constructors',
+    });
+  }
+}
+
 export const StabilitySchema = z.enum(['experimental', 'stable', 'deprecated']);
 export const JsonSchemaValueSchema: z.ZodType = z.lazy(() =>
   z
@@ -29,11 +88,8 @@ export const JsonSchemaValueSchema: z.ZodType = z.lazy(() =>
 );
 
 export const ComponentMetadataSchema = z.object({
-  name: z
-    .string()
-    .min(1)
-    .regex(/^[a-z][a-z0-9-]*$/),
-  version: z.string().regex(/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/),
+  name: z.string().min(1).regex(COMPONENT_NAME),
+  version: z.string().regex(SEMVERISH),
   owner: z.string().optional(),
   stability: StabilitySchema.optional(),
 });
@@ -51,42 +107,93 @@ export const ComponentPropsSchema = z
     required: z.array(z.string()).optional(),
   })
   .superRefine((props, ctx) => {
+    const declaredProps = new Set(Object.keys(props.properties));
+
     Object.keys(props.properties).forEach((key) => {
-      if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)) {
+      if (!isSafeIdentifier(key)) {
+        addIdentifierIssue(
+          ctx,
+          ['properties', key],
+          'generated component prop names must be valid JavaScript identifiers'
+        );
+      }
+    });
+
+    props.required?.forEach((key, index) => {
+      if (!declaredProps.has(key)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ['properties', key],
-          message:
-            'generated component prop names must be valid JavaScript identifiers',
+          path: ['required', index],
+          message: `required prop '${key}' must reference a declared property`,
         });
       }
     });
   });
 
-export const ComponentUISchema = z.object({
-  layout: z.string().optional(),
-  slots: z.array(z.string()).optional(),
-  variants: z
-    .record(
-      z.object({
-        layout: z.string().optional(),
-        props: z.record(z.unknown()).optional(),
+export const ComponentUISchema = z
+  .object({
+    layout: z.string().optional(),
+    slots: z.array(z.string()).optional(),
+    variants: z
+      .record(
+        z.object({
+          layout: z.string().optional(),
+          props: z.record(z.unknown()).optional(),
+        })
+      )
+      .optional(),
+    designTokens: z
+      .object({
+        spacing: z.array(z.string()).optional(),
+        typography: z.array(z.string()).optional(),
+        colorRoles: z.array(z.string()).optional(),
       })
-    )
-    .optional(),
-  designTokens: z
-    .object({
-      spacing: z.array(z.string()).optional(),
-      typography: z.array(z.string()).optional(),
-      colorRoles: z.array(z.string()).optional(),
-    })
-    .optional(),
-  accessibility: z
-    .object({
-      rules: z.array(z.string()).optional(),
-    })
-    .optional(),
-});
+      .optional(),
+    accessibility: z
+      .object({
+        rules: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .superRefine((ui, ctx) => {
+    validateLayout(ui.layout, ctx, ['layout']);
+    validateIdentifierList(
+      ui.slots,
+      ctx,
+      ['slots'],
+      'slot names must be safe JavaScript identifiers'
+    );
+
+    Object.entries(ui.variants ?? {}).forEach(([name, config]) => {
+      if (!isSafeIdentifier(name)) {
+        addIdentifierIssue(
+          ctx,
+          ['variants', name],
+          'variant names must be safe JavaScript identifiers'
+        );
+      }
+      validateLayout(config.layout, ctx, ['variants', name, 'layout']);
+    });
+
+    validateIdentifierList(
+      ui.designTokens?.spacing,
+      ctx,
+      ['designTokens', 'spacing'],
+      'design token names must be safe JavaScript identifiers'
+    );
+    validateIdentifierList(
+      ui.designTokens?.typography,
+      ctx,
+      ['designTokens', 'typography'],
+      'design token names must be safe JavaScript identifiers'
+    );
+    validateIdentifierList(
+      ui.designTokens?.colorRoles,
+      ctx,
+      ['designTokens', 'colorRoles'],
+      'design token names must be safe JavaScript identifiers'
+    );
+  });
 
 export const ComponentBehaviorSchema = z.object({
   state: z.record(z.unknown()).optional(),

--- a/packages/amaryllis-components/src/schema/spec.schema.ts
+++ b/packages/amaryllis-components/src/schema/spec.schema.ts
@@ -25,7 +25,10 @@ function addIdentifierIssue(
 }
 
 function isSafeIdentifier(value: string): boolean {
-  return JS_IDENTIFIER.test(value) && !['__proto__', 'constructor', 'prototype'].includes(value);
+  return (
+    JS_IDENTIFIER.test(value) &&
+    !['__proto__', 'constructor', 'prototype'].includes(value)
+  );
 }
 
 function validateIdentifierList(
@@ -54,7 +57,8 @@ function validateLayout(
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path,
-      message: 'component layout must not contain imports, exports, scripts, eval, require, or Function constructors',
+      message:
+        'component layout must not contain imports, exports, scripts, eval, require, or Function constructors',
     });
   }
 }


### PR DESCRIPTION
## Summary

Implements the ordered stabilization work from #34 on top of `feature/ai-components`.

This PR treats PR #30 as the reference implementation and adds the hardening pass for the ordered child issues:

- #35 — stabilize `ComponentSpec` schema/DSL
- #36 — harden policy enforcement and threat boundaries
- #37 — make runtime personalization deterministic/observable/renderer-safe
- #38 — harden generated React output/provenance
- #39 — stabilize components workspace CI/package checks
- #40 — add branch-aware stabilization documentation

## Changes

### Contract / schema

- Reject undeclared `props.required` entries.
- Validate prop, slot, variant, and design token names as safe generated-code identifiers.
- Reject unsafe layout constructs such as scripts, imports, exports, `require`, `eval`, and `Function` constructors.

### Policy

- Add stable `PolicyErrorCode` values and structured `issues` while preserving existing `errors` strings.
- Keep device execution fail-closed for executable output, missing structured contract, forbidden runtime operations, and missing runtime network/DOM policy.
- Keep executable TSX output review-gated.

### Runtime personalization

- Add validation diagnostics suitable for aggregate telemetry without logging raw AI inputs.
- Reject unsafe object keys in personalization data and JSON Patch values.
- Keep patch paths constrained to declared personalization paths.
- Expose `onValidation` and opt-in console warnings in `PersonalizedComponent`.

### Generation

- Make generated provenance deterministic by default: no wall-clock timestamp unless `generatedAt` is supplied.
- Add generator version provenance.
- Improve TypeScript generation for enums, integer, arrays, and nested objects.
- Add generator-side unsafe layout rejection.

### CI / package

- Add explicit components workspace `typecheck` script.
- Run components typecheck in test-publish and publish workflows.

### Docs/tests

- Add stabilization notes mapping #35–#40 to implementation boundaries.
- Add regression coverage for schema, policy, generator, and runtime personalization hardening.

## Verification

Not run locally in this environment. Expected checks:

```sh
yarn workspace @micrantha/amaryllis-components typecheck
yarn workspace @micrantha/amaryllis-components test --runInBand
yarn workspace @micrantha/amaryllis-components build
```

## Notes

This PR targets `feature/ai-components` rather than `main` so it remains a focused stabilization layer over PR #30 instead of duplicating the full feature branch diff.