### PR TITLE
feat: complete React generation hardening

### DIFF
--- a/docs/generated-component-provenance.md
+++ b/docs/generated-component-provenance.md
@@ -1,0 +1,54 @@
+# Generated Component Provenance
+
+Amaryllis Components records provenance for generated React artifacts, but the meaning of that provenance depends on the generation path.
+
+## Deterministic generator provenance
+
+The built-in `ReactGenerator` is deterministic when callers provide the same validated `ComponentSpec` and the same generation options.
+
+A deterministic generation record should include:
+
+- the component spec version;
+- a content-derived spec hash;
+- the generator version;
+- the validation or policy summary;
+- a normalized `generatedAt` value when timestamps are embedded in source.
+
+`generatedAt` is metadata, not an input to component semantics. Callers that require byte-identical source must supply a fixed timestamp or store timestamps outside the generated source artifact.
+
+The default model identifier, `deterministic-generator`, means that the checked-in generator emitted the source directly. It does not imply that an AI model reproduced or verified the artifact.
+
+## AI-assisted generation provenance
+
+When an AI system contributes implementation or customization output, provenance must additionally identify:
+
+- the model and model version or immutable deployment identifier;
+- the prompt or instruction-template version;
+- the structured generation contract used;
+- validation results applied after model output;
+- the reviewed diff or approval record.
+
+These fields provide traceability. They do not prove that another model invocation will reproduce identical output. AI-assisted generation is bounded-nondeterministic unless the provider, sampling configuration, model artifact, prompt, and execution environment are all reproducibly pinned.
+
+## Validation boundary
+
+Provenance never substitutes for validation. The required pipeline is:
+
+```text
+validated ComponentSpec
+  -> policy checks
+  -> deterministic or AI-assisted generation
+  -> generated-source typecheck and security checks
+  -> human review when executable output is produced
+  -> publication
+```
+
+The React generator treats layout strings as untrusted source inputs. Generated layouts are limited to target-appropriate allowlisted elements and expressions referencing only `children` or declared slots. Imports, event handlers, spread props, executable expressions, raw HTML sinks, and unapproved elements are rejected.
+
+## Current schema-generation contract
+
+- Component and slot names must be safe JavaScript identifiers before generation.
+- JSON Schema object property names are emitted as quoted TypeScript keys when necessary.
+- Arrays, nested objects, enums, primitives, and defaults are accepted by the schema.
+- Defaults currently describe the component contract but do not emit runtime default initialization.
+- Generated source for `web`, `nextjs`, and `rn` is typechecked in tests using compiler options compatible with the package TypeScript configuration.

--- a/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
@@ -61,9 +61,9 @@ function typecheckGeneratedSource(source: string): readonly ts.Diagnostic[] {
   writeFileSync(
     declarationsPath,
     `declare namespace React {
-  type ReactNode = unknown;
+  type ReactNode = any;
   interface FC<P = Record<string, never>> {
-    (props: P): ReactNode;
+    (props: P): any;
   }
 }
 declare module 'react' { export = React; }
@@ -72,20 +72,20 @@ declare module 'react-native' {
   export const Text: React.FC<Record<string, unknown>>;
 }
 declare module 'react/jsx-runtime' {
-  export const jsx: unknown;
-  export const jsxs: unknown;
-  export const Fragment: unknown;
-}
-declare namespace JSX {
-  interface IntrinsicElements {
-    article: Record<string, unknown>;
-    aside: Record<string, unknown>;
-    div: Record<string, unknown>;
-    footer: Record<string, unknown>;
-    header: Record<string, unknown>;
-    main: Record<string, unknown>;
-    section: Record<string, unknown>;
-    span: Record<string, unknown>;
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+  namespace JSX {
+    interface IntrinsicElements {
+      article: Record<string, unknown>;
+      aside: Record<string, unknown>;
+      div: Record<string, unknown>;
+      footer: Record<string, unknown>;
+      header: Record<string, unknown>;
+      main: Record<string, unknown>;
+      section: Record<string, unknown>;
+      span: Record<string, unknown>;
+    }
   }
 }
 `,

--- a/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
@@ -93,19 +93,16 @@ declare module 'react/jsx-runtime' {
   );
 
   try {
-    const program = ts.createProgram(
-      [sourcePath, declarationsPath],
-      {
-        target: ts.ScriptTarget.ESNext,
-        module: ts.ModuleKind.CommonJS,
-        moduleResolution: ts.ModuleResolutionKind.Node10,
-        strict: true,
-        esModuleInterop: true,
-        skipLibCheck: true,
-        jsx: ts.JsxEmit.ReactJSX,
-        noEmit: true,
-      }
-    );
+    const program = ts.createProgram([sourcePath, declarationsPath], {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      jsx: ts.JsxEmit.ReactJSX,
+      noEmit: true,
+    });
 
     return ts.getPreEmitDiagnostics(program);
   } finally {

--- a/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
@@ -1,0 +1,160 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import ts from 'typescript';
+
+import { ReactGenerator } from '../generator/react';
+import type { ValidatedComponentSpec } from '../schema/spec.schema';
+
+const GENERATED_AT = new Date('2026-01-01T00:00:00.000Z');
+const RUNTIMES = ['web', 'nextjs', 'rn'] as const;
+
+type Runtime = (typeof RUNTIMES)[number];
+
+function createSpec(runtime: Runtime): ValidatedComponentSpec {
+  return {
+    apiVersion: 'amaryllis/v1alpha1',
+    kind: 'ComponentSpec',
+    metadata: { name: `compiled-${runtime}-card`, version: '1.0.0' },
+    props: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        tags: { type: 'array', items: { type: 'string' } },
+        settings: {
+          type: 'object',
+          properties: {
+            tone: { type: 'string', enum: ['info', 'warning'] },
+          },
+          required: ['tone'],
+        },
+      },
+      required: ['title'],
+    },
+    ui: {
+      slots: ['header'],
+      layout:
+        runtime === 'rn'
+          ? '<View>{slots.header}{children}</View>'
+          : '<section>{slots.header}{children}</section>',
+    },
+    target: { framework: 'react', runtime },
+    ai: { mode: 'scaffold', execution: 'build' },
+  };
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {
+  return diagnostics
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    )
+    .join('\n');
+}
+
+function typecheckGeneratedSource(source: string): readonly ts.Diagnostic[] {
+  const directory = mkdtempSync(join(tmpdir(), 'amaryllis-generated-'));
+  const sourcePath = join(directory, 'generated.tsx');
+  const declarationsPath = join(directory, 'generated-types.d.ts');
+
+  writeFileSync(sourcePath, source, 'utf8');
+  writeFileSync(
+    declarationsPath,
+    `declare namespace React {
+  type ReactNode = unknown;
+  interface FC<P = Record<string, never>> {
+    (props: P): ReactNode;
+  }
+}
+declare module 'react' { export = React; }
+declare module 'react-native' {
+  export const View: React.FC<Record<string, unknown>>;
+  export const Text: React.FC<Record<string, unknown>>;
+}
+declare module 'react/jsx-runtime' {
+  export const jsx: unknown;
+  export const jsxs: unknown;
+  export const Fragment: unknown;
+}
+declare namespace JSX {
+  interface IntrinsicElements {
+    article: Record<string, unknown>;
+    aside: Record<string, unknown>;
+    div: Record<string, unknown>;
+    footer: Record<string, unknown>;
+    header: Record<string, unknown>;
+    main: Record<string, unknown>;
+    section: Record<string, unknown>;
+    span: Record<string, unknown>;
+  }
+}
+`,
+    'utf8'
+  );
+
+  try {
+    const program = ts.createProgram(
+      [sourcePath, declarationsPath],
+      {
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.Node10,
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        jsx: ts.JsxEmit.ReactJSX,
+        noEmit: true,
+      }
+    );
+
+    return ts.getPreEmitDiagnostics(program);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe('ReactGenerator source hardening', () => {
+  const generator = new ReactGenerator();
+
+  it.each<Runtime>(RUNTIMES)(
+    'emits %s source that typechecks under package-compatible options',
+    (runtime) => {
+      const source = generator.generate(createSpec(runtime), {
+        generatedAt: GENERATED_AT,
+      });
+      const diagnostics = typecheckGeneratedSource(source);
+
+      expect(formatDiagnostics(diagnostics)).toBe('');
+    }
+  );
+
+  it('normalizes declared slot references', () => {
+    const source = generator.generate(createSpec('web'), {
+      generatedAt: GENERATED_AT,
+    });
+
+    expect(source).toContain('<section>{header}{children}</section>');
+    expect(source).not.toContain('{slots.header}');
+  });
+
+  it.each([
+    ['undeclared expressions', '<div>{dangerous()}</div>'],
+    ['event handlers', '<div onClick={children}>{children}</div>'],
+    ['spread props', '<div {...children}>{children}</div>'],
+    ['unapproved web elements', '<iframe>{children}</iframe>'],
+  ])('rejects %s in web layouts', (_name, layout) => {
+    const spec = createSpec('web');
+    spec.ui = { ...spec.ui, layout };
+
+    expect(() => generator.generate(spec)).toThrow();
+  });
+
+  it('rejects web elements in React Native layouts', () => {
+    const spec = createSpec('rn');
+    spec.ui = { ...spec.ui, layout: '<div>{children}</div>' };
+
+    expect(() => generator.generate(spec)).toThrow(
+      "component layout element 'div' is not allowed for rn"
+    );
+  });
+});

--- a/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
@@ -150,6 +150,8 @@ describe('ReactGenerator source hardening', () => {
     ['non-JSX source', 'plainIdentifier'],
     ['multiple roots', '<div>{children}</div><div>{children}</div>'],
     ['attributes', '<div className="card">{children}</div>'],
+    ['unmatched closing brace', '<div>}</div>'],
+    ['unmatched closing brace after text', '<div>text }</div>'],
   ])('rejects %s in web layouts', (_name, layout) => {
     const spec = createSpec('web');
     spec.ui = { ...spec.ui, layout };

--- a/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Generator.hardening.test.ts
@@ -142,6 +142,14 @@ describe('ReactGenerator source hardening', () => {
     ['event handlers', '<div onClick={children}>{children}</div>'],
     ['spread props', '<div {...children}>{children}</div>'],
     ['unapproved web elements', '<iframe>{children}</iframe>'],
+    [
+      'statement breakout',
+      '<div>{children}</div>); arbitraryCall(); return (<div>{children}</div>',
+    ],
+    ['unbalanced elements', '<div><span>{children}</div>'],
+    ['non-JSX source', 'plainIdentifier'],
+    ['multiple roots', '<div>{children}</div><div>{children}</div>'],
+    ['attributes', '<div className="card">{children}</div>'],
   ])('rejects %s in web layouts', (_name, layout) => {
     const spec = createSpec('web');
     spec.ui = { ...spec.ui, layout };

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -58,9 +58,7 @@ export function validateAndNormalizeLayout(
         );
       }
 
-      const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(
-        expression
-      );
+      const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(expression);
       const normalizedExpression = slotMatch?.[1] ?? expression;
       if (!allowedExpressions.has(normalizedExpression)) {
         return invalidLayout(
@@ -74,9 +72,7 @@ export function validateAndNormalizeLayout(
     }
 
     if (remaining.startsWith('<')) {
-      const tagMatch = /^<(\/)?([A-Za-z][A-Za-z0-9]*)(\s*\/?)>/.exec(
-        remaining
-      );
+      const tagMatch = /^<(\/)?([A-Za-z][A-Za-z0-9]*)(\s*\/?)>/.exec(remaining);
       const closing = tagMatch?.[1] === '/';
       const tagName = tagMatch?.[2];
       const suffix = tagMatch?.[3];
@@ -121,9 +117,7 @@ export function validateAndNormalizeLayout(
     const nextToken = remaining.search(/[<{}]/);
     const textLength = nextToken === -1 ? remaining.length : nextToken;
     if (textLength === 0) {
-      return invalidLayout(
-        'component layout contains an unmatched JSX brace'
-      );
+      return invalidLayout('component layout contains an unmatched JSX brace');
     }
 
     const text = remaining.slice(0, textLength);
@@ -138,9 +132,7 @@ export function validateAndNormalizeLayout(
   }
 
   if (rootElements !== 1 || elementStack.length !== 0) {
-    return invalidLayout(
-      'component layout contains unbalanced JSX elements'
-    );
+    return invalidLayout('component layout contains unbalanced JSX elements');
   }
 
   return { layout: normalized };

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -24,50 +24,107 @@ export interface LayoutValidationResult {
   error?: string;
 }
 
+function invalidLayout(error: string): LayoutValidationResult {
+  return { error };
+}
+
 export function validateAndNormalizeLayout(
   layout: string,
   runtime: ReactLayoutRuntime,
   slots: readonly string[] = []
 ): LayoutValidationResult {
   if (UNSAFE_LAYOUT_PATTERN.test(layout)) {
-    return {
-      error: 'Unsafe layout contains executable code or import/export syntax.',
-    };
-  }
-
-  const allowedExpressions = new Set(['children', ...slots]);
-  let normalized = layout;
-  const expressions = [...layout.matchAll(/\{([^{}]+)\}/g)];
-
-  for (const match of expressions) {
-    const expression = match[1].trim();
-    const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(expression);
-    const normalizedExpression = slotMatch?.[1] ?? expression;
-
-    if (!allowedExpressions.has(normalizedExpression)) {
-      return {
-        error: `component layout expression '${expression}' must reference children or a declared slot`,
-      };
-    }
-
-    if (slotMatch) {
-      normalized = normalized.replace(match[0], `{${normalizedExpression}}`);
-    }
-  }
-
-  const withoutAllowedExpressions = normalized.replace(/\{[^{}]+\}/g, '');
-  if (/[{}]/.test(withoutAllowedExpressions)) {
-    return { error: 'component layout contains an invalid JSX expression' };
+    return invalidLayout(
+      'Unsafe layout contains executable code or import/export syntax.'
+    );
   }
 
   const allowedElements = runtime === 'rn' ? NATIVE_ELEMENTS : WEB_ELEMENTS;
-  const tags = [...normalized.matchAll(/<\/?([A-Za-z][A-Za-z0-9]*)\b/g)];
-  for (const tag of tags) {
-    if (!allowedElements.has(tag[1])) {
-      return {
-        error: `component layout element '${tag[1]}' is not allowed for ${runtime}`,
-      };
+  const allowedExpressions = new Set(['children', ...slots]);
+  const elementStack: string[] = [];
+  let normalized = '';
+  let position = 0;
+  let rootElements = 0;
+
+  while (position < layout.length) {
+    const remaining = layout.slice(position);
+
+    if (remaining.startsWith('{')) {
+      const expressionMatch = /^\{([^{}]+)\}/.exec(remaining);
+      const expression = expressionMatch?.[1]?.trim();
+      if (!expressionMatch || !expression || elementStack.length === 0) {
+        return invalidLayout('component layout contains an invalid JSX expression');
+      }
+
+      const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(expression);
+      const normalizedExpression = slotMatch?.[1] ?? expression;
+      if (!allowedExpressions.has(normalizedExpression)) {
+        return invalidLayout(
+          `component layout expression '${expression}' must reference children or a declared slot`
+        );
+      }
+
+      normalized += `{${normalizedExpression}}`;
+      position += expressionMatch[0].length;
+      continue;
     }
+
+    if (remaining.startsWith('<')) {
+      const tagMatch = /^<(\/)?([A-Za-z][A-Za-z0-9]*)(\s*\/?)>/.exec(remaining);
+      const closing = tagMatch?.[1] === '/';
+      const tagName = tagMatch?.[2];
+      const suffix = tagMatch?.[3];
+      if (!tagMatch || !tagName || suffix === undefined) {
+        return invalidLayout(
+          'component layout must use attribute-free, balanced JSX elements'
+        );
+      }
+
+      if (!allowedElements.has(tagName)) {
+        return invalidLayout(
+          `component layout element '${tagName}' is not allowed for ${runtime}`
+        );
+      }
+
+      const selfClosing = !closing && suffix.trim() === '/';
+      if (closing) {
+        if (suffix.trim() !== '' || elementStack.pop() !== tagName) {
+          return invalidLayout('component layout contains unbalanced JSX elements');
+        }
+      } else {
+        if (elementStack.length === 0) {
+          rootElements += 1;
+          if (rootElements > 1) {
+            return invalidLayout(
+              'component layout must contain exactly one root JSX element'
+            );
+          }
+        }
+        if (!selfClosing) {
+          elementStack.push(tagName);
+        }
+      }
+
+      normalized += tagMatch[0];
+      position += tagMatch[0].length;
+      continue;
+    }
+
+    const nextToken = remaining.search(/[<{]/);
+    const textLength = nextToken === -1 ? remaining.length : nextToken;
+    const text = remaining.slice(0, textLength);
+    if (elementStack.length === 0 && text.trim() !== '') {
+      return invalidLayout(
+        'component layout must contain only one complete JSX element'
+      );
+    }
+
+    normalized += text;
+    position += textLength;
+  }
+
+  if (rootElements !== 1 || elementStack.length !== 0) {
+    return invalidLayout('component layout contains unbalanced JSX elements');
   }
 
   return { layout: normalized };

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -1,0 +1,75 @@
+const JS_TRIVIA = String.raw`(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*`;
+
+const UNSAFE_LAYOUT_PATTERN = new RegExp(
+  `(?:<script\\b|\\bimport(?:\\s+|${JS_TRIVIA}\\()|\\bexport\\s+|\\brequire${JS_TRIVIA}\\(|\\beval${JS_TRIVIA}\\(|\\b(?:new${JS_TRIVIA})?Function${JS_TRIVIA}\\(|dangerouslySetInnerHTML|\\bon[A-Z][A-Za-z]*\\s*=|\\{\\s*\\.\\.\\.)`,
+  'i'
+);
+
+const WEB_ELEMENTS = new Set([
+  'article',
+  'aside',
+  'div',
+  'footer',
+  'header',
+  'main',
+  'section',
+  'span',
+]);
+const NATIVE_ELEMENTS = new Set(['Text', 'View']);
+
+export type ReactLayoutRuntime = 'nextjs' | 'web' | 'rn';
+
+export interface LayoutValidationResult {
+  layout?: string;
+  error?: string;
+}
+
+export function validateAndNormalizeLayout(
+  layout: string,
+  runtime: ReactLayoutRuntime,
+  slots: readonly string[] = []
+): LayoutValidationResult {
+  if (UNSAFE_LAYOUT_PATTERN.test(layout)) {
+    return {
+      error:
+        'component layout must not contain executable code, imports, event handlers, spread props, or raw HTML sinks',
+    };
+  }
+
+  const allowedExpressions = new Set(['children', ...slots]);
+  let normalized = layout;
+  const expressions = [...layout.matchAll(/\{([^{}]+)\}/g)];
+
+  for (const match of expressions) {
+    const expression = match[1].trim();
+    const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(expression);
+    const normalizedExpression = slotMatch?.[1] ?? expression;
+
+    if (!allowedExpressions.has(normalizedExpression)) {
+      return {
+        error: `component layout expression '${expression}' must reference children or a declared slot`,
+      };
+    }
+
+    if (slotMatch) {
+      normalized = normalized.replace(match[0], `{${normalizedExpression}}`);
+    }
+  }
+
+  const withoutAllowedExpressions = normalized.replace(/\{[^{}]+\}/g, '');
+  if (/[{}]/.test(withoutAllowedExpressions)) {
+    return { error: 'component layout contains an invalid JSX expression' };
+  }
+
+  const allowedElements = runtime === 'rn' ? NATIVE_ELEMENTS : WEB_ELEMENTS;
+  const tags = [...normalized.matchAll(/<\/?([A-Za-z][A-Za-z0-9]*)\b/g)];
+  for (const tag of tags) {
+    if (!allowedElements.has(tag[1])) {
+      return {
+        error: `component layout element '${tag[1]}' is not allowed for ${runtime}`,
+      };
+    }
+  }
+
+  return { layout: normalized };
+}

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -53,10 +53,14 @@ export function validateAndNormalizeLayout(
       const expressionMatch = /^\{([^{}]+)\}/.exec(remaining);
       const expression = expressionMatch?.[1]?.trim();
       if (!expressionMatch || !expression || elementStack.length === 0) {
-        return invalidLayout('component layout contains an invalid JSX expression');
+        return invalidLayout(
+          'component layout contains an invalid JSX expression'
+        );
       }
 
-      const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(expression);
+      const slotMatch = /^slots\.([A-Za-z_$][A-Za-z0-9_$]*)$/.exec(
+        expression
+      );
       const normalizedExpression = slotMatch?.[1] ?? expression;
       if (!allowedExpressions.has(normalizedExpression)) {
         return invalidLayout(
@@ -70,7 +74,9 @@ export function validateAndNormalizeLayout(
     }
 
     if (remaining.startsWith('<')) {
-      const tagMatch = /^<(\/)?([A-Za-z][A-Za-z0-9]*)(\s*\/?)>/.exec(remaining);
+      const tagMatch = /^<(\/)?([A-Za-z][A-Za-z0-9]*)(\s*\/?)>/.exec(
+        remaining
+      );
       const closing = tagMatch?.[1] === '/';
       const tagName = tagMatch?.[2];
       const suffix = tagMatch?.[3];
@@ -89,7 +95,9 @@ export function validateAndNormalizeLayout(
       const selfClosing = !closing && suffix.trim() === '/';
       if (closing) {
         if (suffix.trim() !== '' || elementStack.pop() !== tagName) {
-          return invalidLayout('component layout contains unbalanced JSX elements');
+          return invalidLayout(
+            'component layout contains unbalanced JSX elements'
+          );
         }
       } else {
         if (elementStack.length === 0) {
@@ -110,8 +118,12 @@ export function validateAndNormalizeLayout(
       continue;
     }
 
-    const nextToken = remaining.search(/[<{]/);
+    const nextToken = remaining.search(/[<{}]/);
     const textLength = nextToken === -1 ? remaining.length : nextToken;
+    if (textLength === 0) {
+      return invalidLayout('component layout contains an unmatched JSX brace');
+    }
+
     const text = remaining.slice(0, textLength);
     if (elementStack.length === 0 && text.trim() !== '') {
       return invalidLayout(

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -31,8 +31,7 @@ export function validateAndNormalizeLayout(
 ): LayoutValidationResult {
   if (UNSAFE_LAYOUT_PATTERN.test(layout)) {
     return {
-      error:
-        'component layout must not contain executable code, imports, event handlers, spread props, or raw HTML sinks',
+      error: 'Unsafe layout contains executable code or import/export syntax.',
     };
   }
 

--- a/packages/amaryllis-components/src/generator/layout.ts
+++ b/packages/amaryllis-components/src/generator/layout.ts
@@ -121,7 +121,9 @@ export function validateAndNormalizeLayout(
     const nextToken = remaining.search(/[<{}]/);
     const textLength = nextToken === -1 ? remaining.length : nextToken;
     if (textLength === 0) {
-      return invalidLayout('component layout contains an unmatched JSX brace');
+      return invalidLayout(
+        'component layout contains an unmatched JSX brace'
+      );
     }
 
     const text = remaining.slice(0, textLength);
@@ -136,7 +138,9 @@ export function validateAndNormalizeLayout(
   }
 
   if (rootElements !== 1 || elementStack.length !== 0) {
-    return invalidLayout('component layout contains unbalanced JSX elements');
+    return invalidLayout(
+      'component layout contains unbalanced JSX elements'
+    );
   }
 
   return { layout: normalized };

--- a/packages/amaryllis-components/src/generator/react.ts
+++ b/packages/amaryllis-components/src/generator/react.ts
@@ -1,9 +1,6 @@
 import type { ValidatedComponentSpec } from '../schema/spec.schema';
 import type { JsonSchemaValue } from '../types/spec';
-import {
-  validateAndNormalizeLayout,
-  type ReactLayoutRuntime,
-} from './layout';
+import { validateAndNormalizeLayout, type ReactLayoutRuntime } from './layout';
 
 export interface ReactGeneratorOptions {
   specHash?: string;
@@ -30,11 +27,7 @@ export class ReactGenerator {
     const componentName = this.toPascalCase(metadata.name);
     const slots = ui?.slots ?? [];
 
-    const propsType = this.generatePropsType(
-      props,
-      slots,
-      ui?.designTokens
-    );
+    const propsType = this.generatePropsType(props, slots, ui?.designTokens);
     const layout = this.safeLayout(
       ui?.layout || this.getDefaultLayout(target.runtime),
       target.runtime,

--- a/packages/amaryllis-components/src/generator/react.ts
+++ b/packages/amaryllis-components/src/generator/react.ts
@@ -1,5 +1,9 @@
 import type { ValidatedComponentSpec } from '../schema/spec.schema';
 import type { JsonSchemaValue } from '../types/spec';
+import {
+  validateAndNormalizeLayout,
+  type ReactLayoutRuntime,
+} from './layout';
 
 export interface ReactGeneratorOptions {
   specHash?: string;
@@ -16,11 +20,6 @@ type ComponentDesignTokens = NonNullable<
 >['designTokens'];
 
 const TS_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-const JS_TRIVIA = String.raw`(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*`;
-const UNSAFE_LAYOUT_PATTERN = new RegExp(
-  `(?:<script\\b|\\bimport(?:\\s+|${JS_TRIVIA}\\()|\\bexport\\s+|\\brequire${JS_TRIVIA}\\(|\\beval${JS_TRIVIA}\\(|\\b(?:new${JS_TRIVIA})?Function${JS_TRIVIA}\\()`,
-  'i'
-);
 
 export class ReactGenerator {
   generate(
@@ -29,27 +28,35 @@ export class ReactGenerator {
   ): string {
     const { metadata, props, ui, target } = spec;
     const componentName = this.toPascalCase(metadata.name);
+    const slots = ui?.slots ?? [];
 
     const propsType = this.generatePropsType(
       props,
-      ui?.slots,
+      slots,
       ui?.designTokens
     );
     const layout = this.safeLayout(
-      ui?.layout || this.getDefaultLayout(target.runtime)
+      ui?.layout || this.getDefaultLayout(target.runtime),
+      target.runtime,
+      slots
     );
 
     const imports = this.generateImports(target.runtime);
 
     const propKeys = [
       ...Object.keys(props.properties),
-      ...(ui?.slots || []),
+      ...slots,
       ...(ui?.designTokens ? ['designTokens'] : []),
       'variant',
       'children',
     ];
 
-    const variantLogic = this.generateVariantLogic(ui?.variants, layout);
+    const variantLogic = this.generateVariantLogic(
+      ui?.variants,
+      layout,
+      target.runtime,
+      slots
+    );
     const provenance = this.generateProvenance(metadata.version, options);
 
     return `
@@ -71,21 +78,29 @@ export const ${componentName}: React.FC<${componentName}Props> = ({
 
   private generateVariantLogic(
     variants: ComponentVariants,
-    defaultLayout: string
+    defaultLayout: string,
+    runtime: ReactLayoutRuntime,
+    slots: readonly string[]
   ): string {
     if (!variants || Object.keys(variants).length === 0) {
-      return `return (\n    ${this.wrapWithLayout(defaultLayout)}\n  );`;
+      return `return (\n    ${defaultLayout}\n  );`;
     }
 
     const cases = Object.entries(variants).map(([name, config]) => {
-      const layout = this.safeLayout(config.layout || defaultLayout);
-      return `    case '${name}':\n      return (\n        ${this.wrapWithLayout(layout)}\n      );`;
+      const layout = this.safeLayout(
+        config.layout || defaultLayout,
+        runtime,
+        slots
+      );
+      return `    case '${name}':\n      return (\n        ${layout}\n      );`;
     });
 
     return `switch (variant) {
 ${cases.join('\n')}
     default:
-      return (\n        ${this.wrapWithLayout(defaultLayout)}\n      );
+      return (
+        ${defaultLayout}
+      );
   }`;
   }
 
@@ -102,7 +117,7 @@ ${cases.join('\n')}
 
   private generatePropsType(
     props: ValidatedComponentSpec['props'],
-    slots?: string[],
+    slots?: readonly string[],
     designTokens?: ComponentDesignTokens
   ): string {
     const lines = Object.entries(props.properties).map(([key, schema]) => {
@@ -228,26 +243,16 @@ ${properties.join('\n')}
       : '<div>{children}</div>';
   }
 
-  private wrapWithLayout(layout: string, slots?: string[]): string {
-    // Basic substitution for slots if they exist in layout as {slotName}
-    let result = layout;
-    if (slots) {
-      slots.forEach((slot) => {
-        // Replace both {slot} and {slots.slot} for flexibility
-        result = result.split(`{${slot}}`).join(`{${slot}}`);
-        result = result.split(`{slots.${slot}}`).join(`{${slot}}`);
-      });
+  private safeLayout(
+    layout: string,
+    runtime: ReactLayoutRuntime,
+    slots: readonly string[]
+  ): string {
+    const result = validateAndNormalizeLayout(layout, runtime, slots);
+    if (!result.layout) {
+      throw new Error(result.error ?? 'Unsafe component layout.');
     }
-    return result;
-  }
-
-  private safeLayout(layout: string): string {
-    if (UNSAFE_LAYOUT_PATTERN.test(layout)) {
-      throw new Error(
-        'Unsafe layout contains executable code or import/export syntax.'
-      );
-    }
-    return layout;
+    return result.layout;
   }
 
   private generateProvenance(


### PR DESCRIPTION
## Summary

Completes the remaining focused work for #38 after deterministic goldens landed in #46.

## Changes

- typecheck generated `web`, `nextjs`, and `rn` TSX with TypeScript compiler diagnostics
- constrain layout templates to target-appropriate allowlisted elements
- allow expressions only for `children` and declared slots
- normalize `{slots.name}` references to generated prop identifiers
- reject event handlers, spread props, executable expressions, raw HTML sinks, and unapproved elements
- document deterministic generator provenance versus AI-assisted provenance
- document current JSON Schema/default generation boundaries

## Scope

- no new runtime rendering behavior
- no provider-specific model dependency
- no expansion of on-device executable output
- defaults remain schema metadata and do not initialize runtime values

## Validation

CI will run lint, typecheck, unit tests, compatibility, coverage, and CodeQL.

Closes #38 when merged.