### PR TITLE
chore: sync main into AI components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       XCODE_VERSION: 16.4
       TURBO_CACHE_DIR: .turbo/ios
@@ -144,7 +144,7 @@ jobs:
 
       - name: Use appropriate Xcode version
         if: env.turbo_cache_hit != 1
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,59 @@
+name: SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+      - feature/*
+    paths:
+      - package.json
+      - yarn.lock
+      - .yarnrc.yml
+      - example/package.json
+      - scripts/validate-sbom.sh
+      - .github/workflows/sbom.yml
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+
+      - name: Prepare artifact directory
+        run: mkdir -p artifacts
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: artifacts/sbom.cdx.json
+          syft-version: v1.42.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Validate SBOM contract
+        run: bash scripts/validate-sbom.sh artifacts/sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: amaryllis-sbom-cyclonedx
+          path: artifacts/sbom.cdx.json
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/ai-components-stabilization-completion.md
+++ b/docs/ai-components-stabilization-completion.md
@@ -1,0 +1,57 @@
+# AI components stabilization progress ledger
+
+Issue #34 defines the ordered stabilization plan for the AI-enabled components work introduced by PR #30. PR #41 implemented schema, policy, runtime-personalization, and generator hardening on `feature/ai-components`, plus part of the CI and documentation work. Those changes are not yet present on `main` because PR #30 remains open.
+
+This ledger records feature-branch progress without closing issues before their implementation reaches the default branch.
+
+## Progress status
+
+| Issue | Area | Status |
+| --- | --- | --- |
+| #35 | `ComponentSpec` schema and DSL contract | Implemented on `feature/ai-components` by PR #41; pending integration through PR #30. |
+| #36 | Policy enforcement and threat boundaries | Implemented on `feature/ai-components` by PR #41; pending integration through PR #30. |
+| #37 | Runtime personalization safety | Implemented on `feature/ai-components` by PR #41; pending integration through PR #30. |
+| #38 | React generation and provenance | Implemented on `feature/ai-components` by PR #41; pending integration through PR #30. |
+| #39 | Components workspace CI/package checks | Partially implemented on `feature/ai-components`. Explicit components `typecheck` coverage was added, but independent lint/test/build/pack validation, package metadata checks, permission documentation, release artifact validation, `dist` policy documentation, and PR #33 review remain open. |
+| #40 | Branch-aware documentation and examples | Partially implemented on `feature/ai-components`. Stabilization and security documentation was added, but runnable YAML/CLI/runtime examples with success and failure paths and CI or manual verification remain open. |
+
+## Parent issue status
+
+Issue #34 remains open because:
+
+- PR #30 has not merged `feature/ai-components` into `main`;
+- #35 through #38 should remain open until their implementation reaches the default branch;
+- #39 still requires the remaining CI, packaging, release, and dependency-review acceptance criteria;
+- #40 still requires runnable end-to-end examples and verification instructions.
+
+Issue #34 should close only after PR #30 is integrated and #39 and #40 are completed or explicitly deferred with rationale.
+
+## Remaining work
+
+### Integration
+
+- merge or otherwise integrate PR #30 into `main`;
+- close #35 through #38 only after the implementation is present on the default branch.
+
+### Issue #39
+
+- run components lint, test, build, typecheck, and pack checks independently in CI;
+- exercise `npm pack --dry-run` for both packages;
+- verify package names, versions, and build outputs before publish;
+- document and constrain workflow permissions;
+- validate or document GitHub Release artifact uploads;
+- document intentional `dist` ignore behavior;
+- review dependency PR #33 after the CI shape is stable.
+
+### Issue #40
+
+- add a realistic `ComponentSpec` YAML fixture;
+- document CLI flows for `generate`, `contract`, and `customize`;
+- add a registered-component runtime personalization example;
+- show valid and invalid personalization behavior;
+- provide CI validation or reproducible manual verification commands;
+- link the runnable examples from the branch-aware documentation.
+
+## Scope boundary
+
+This progress record does not declare `@micrantha/amaryllis-components` generally stable. The package and `amaryllis/v1alpha1` contract remain experimental while PR #30, #39, and #40 are open.

--- a/scripts/validate-sbom.sh
+++ b/scripts/validate-sbom.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sbom_file="${1:-artifacts/sbom.cdx.json}"
+
+node - "$sbom_file" <<'NODE'
+const fs = require('node:fs');
+
+const path = process.argv[2];
+const sbom = JSON.parse(fs.readFileSync(path, 'utf8'));
+
+if (sbom.bomFormat !== 'CycloneDX') {
+  throw new Error(`unexpected SBOM format: ${sbom.bomFormat ?? '<missing>'}`);
+}
+
+if (sbom.specVersion !== '1.6') {
+  throw new Error(`unexpected CycloneDX version: ${sbom.specVersion ?? '<missing>'}`);
+}
+
+if (!Array.isArray(sbom.components) || sbom.components.length === 0) {
+  throw new Error('SBOM contains no components');
+}
+
+const root = sbom.metadata?.component;
+if (root) {
+  if (typeof root.name !== 'string' || root.name.length === 0) {
+    throw new Error('SBOM root metadata component has no name');
+  }
+
+  if (typeof root.type !== 'string' || root.type.length === 0) {
+    throw new Error('SBOM root metadata component has no type');
+  }
+}
+
+if (!Array.isArray(sbom.dependencies) || sbom.dependencies.length === 0) {
+  throw new Error('SBOM contains no dependency graph');
+}
+
+const purls = sbom.components
+  .map((component) => component.purl)
+  .filter(Boolean);
+
+for (const expected of [
+  'pkg:npm/%40micrantha/react-native-amaryllis@',
+  'pkg:npm/react-native-amaryllis-example@',
+]) {
+  if (!purls.some((purl) => purl.startsWith(expected))) {
+    throw new Error(`SBOM is missing expected component: ${expected}`);
+  }
+}
+
+console.log(
+  `Validated ${path}: CycloneDX ${sbom.specVersion}, ${sbom.components.length} components, ${sbom.dependencies.length} dependency nodes`
+);
+NODE


### PR DESCRIPTION
Merge the latest `main` changes, including the SBOM workflow and macOS runner updates, into `feature/ai-components` so stacked work is validated against current main.