### PR TITLE
docs: complete AI component end-to-end guide

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,28 @@
+# AI component examples
+
+> **Experimental:** `@micrantha/amaryllis-components` and the `amaryllis/v1alpha1` contract are not yet stable public APIs.
+
+These examples exercise the provider-free, governed component path on the `feature/ai-components` branch.
+
+## Start here
+
+- [End-to-end AI component walkthrough](./ai-component-end-to-end.md)
+- [Runtime validation flow](./runtime-validation-flow.md)
+
+## Fixtures
+
+- [`summary-card.component.yaml`](./summary-card.component.yaml): valid React Native `ComponentSpec`
+- [`summary-card.customization.patch.json`](./summary-card.customization.patch.json): bounded customization patch
+- [`summary-card.personalization.valid.json`](./summary-card.personalization.valid.json): valid structured personalization output
+- [`summary-card.personalization.invalid.json`](./summary-card.personalization.invalid.json): invalid output used to verify deterministic fallback
+- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): readable personalization contract example
+
+## Verify
+
+From the repository root:
+
+```sh
+yarn verify:component-examples
+```
+
+The verification builds the companion package and exercises schema and policy validation, CLI generation, contract generation, customization, registry identity, valid personalization, invalid personalization, and fail-closed fallback behavior.

--- a/docs/examples/ai-component-end-to-end.md
+++ b/docs/examples/ai-component-end-to-end.md
@@ -2,27 +2,42 @@
 
 > **Experimental:** `amaryllis/v1alpha1` and `@micrantha/amaryllis-components` are branch-level experimental APIs. They are not stable public contracts and may change before release.
 
-This example exercises the governed path from a reviewed component spec to generated artifacts and structured runtime personalization. It is offline-first and does not require a model provider.
+This example exercises the governed path from a reviewed component spec to generated artifacts and structured runtime personalization. It is offline-first and does not require a live model provider.
+
+```text
+ComponentSpec YAML
+  -> schema validation
+  -> policy validation
+  -> contract generation
+  -> React Native component generation or bounded customization
+  -> registry binding
+  -> structured runtime personalization
+  -> deterministic fallback for invalid output
+```
 
 ## Package boundary
 
-- `@micrantha/react-native-amaryllis` is the React Native inference substrate. It owns native model execution and the application-facing inference APIs.
+- `@micrantha/react-native-amaryllis` is the React Native inference substrate. It owns native model execution, streaming, model inputs, and the application-facing inference APIs.
 - `@micrantha/amaryllis-components` is the experimental companion package. It owns `ComponentSpec`, schema and policy validation, build-time React generation, registry identity, personalization contracts, and structured overlay validation.
 
 The companion package does not execute a model and does not replace the base runtime. Applications may obtain structured output from the base runtime, a remote service, a test fixture, or another provider-neutral inference function, then pass that untrusted data through the companion package validators.
 
+The model never becomes the direct source of executable runtime UI.
+
 ## Files
 
-- [`summary-card.component.yaml`](./summary-card.component.yaml): authoritative component spec
+- [`summary-card.component.yaml`](./summary-card.component.yaml): authoritative React Native component spec
 - [`summary-card.customization.patch.json`](./summary-card.customization.patch.json): reviewed build-time JSON Patch
 - [`summary-card.personalization.valid.json`](./summary-card.personalization.valid.json): valid structured runtime output
 - [`summary-card.personalization.invalid.json`](./summary-card.personalization.invalid.json): invalid runtime output that must fall back
+- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): readable example of the personalization contract
 
 ## Build-time CLI flow
 
 Build the companion package before running its CLI:
 
 ```sh
+yarn install --immutable
 yarn workspace @micrantha/amaryllis-components build
 ```
 
@@ -33,6 +48,8 @@ node packages/amaryllis-components/dist/cli/index.js generate \
   --spec docs/examples/summary-card.component.yaml \
   --output /tmp/SummaryCard.tsx
 ```
+
+The CLI performs schema and policy validation before writing output. The canonical spec name is `summary-card`; the generator converts it to the React component identifier `SummaryCard`.
 
 Generate the structured runtime contract:
 
@@ -51,36 +68,54 @@ node packages/amaryllis-components/dist/cli/index.js customize \
   --output /tmp/SummaryCard.customized.tsx
 ```
 
-Generated TSX is a build/CI artifact, not runtime model output. Treat it like source code: inspect the diff, run lint/typecheck/tests, enforce allowed imports, and require human review before promotion.
+Generated TSX is a build or CI artifact, not runtime model output. Treat it like source code: inspect the diff, run lint, type checking, and tests, enforce allowed imports, and require human review before promotion.
 
 ## Runtime personalization flow
 
-Register an approved component implementation with its validated spec and generated contract. The model-facing boundary accepts only structured data:
+Register an approved implementation with its validated spec and generated contract. The registry identity must exactly match `spec.metadata.name`:
 
-```tsx
+```ts
+import fs from 'node:fs';
+import {
+  ComponentRegistry,
+  JSONSchemaGenerator,
+  PersonalizationEngine,
+  parseComponentSpec,
+} from '@micrantha/amaryllis-components';
+
+const spec = parseComponentSpec(
+  fs.readFileSync('docs/examples/summary-card.component.yaml', 'utf8')
+);
+const contract = JSON.parse(new JSONSchemaGenerator().generate(spec));
+
 const registry = new ComponentRegistry();
+const SummaryCard = () => null;
 
-registry.register('SummaryCard', {
+registry.register('summary-card', {
   component: SummaryCard,
   spec,
   contract,
   implementationIdentity: 'app/components/SummaryCard',
 });
 
-<RegistryProvider registry={registry}>
-  <PersonalizedComponent
-    name="SummaryCard"
-    baseProps={{
-      title: 'Base title',
-      summary: 'Base summary',
-      variant: 'expanded',
-    }}
-    personalizationData={structuredOutput}
-    onValidation={({ valid, errors }) => {
-      telemetry.record({ valid, errorCount: errors?.length ?? 0 });
-    }}
-  />
-</RegistryProvider>;
+const baseProps = {
+  title: 'Base title',
+  summary: 'Base summary',
+  variant: 'expanded',
+};
+
+const structuredOutput = JSON.parse(
+  fs.readFileSync(
+    'docs/examples/summary-card.personalization.valid.json',
+    'utf8'
+  )
+);
+
+const engine = new PersonalizationEngine();
+const result = engine.validate(contract, structuredOutput);
+const personalizedProps = result.valid
+  ? engine.apply(baseProps, result.data ?? {})
+  : baseProps;
 ```
 
 ```text
@@ -91,7 +126,27 @@ untrusted structured output
   -> approved registered component
 ```
 
-Valid output is merged over base props. Invalid output is rejected and the component deterministically renders its original base props. Runtime JSX, TSX, JavaScript, imports, and native operations are outside this contract.
+Valid output is merged over base props only after validation. Runtime JSX, TSX, JavaScript, imports, event handlers, and native operations are outside this contract.
+
+## Invalid-output fallback
+
+Use the invalid fixture to prove the fail-closed behavior:
+
+```ts
+const invalidOutput = JSON.parse(
+  fs.readFileSync(
+    'docs/examples/summary-card.personalization.invalid.json',
+    'utf8'
+  )
+);
+
+const invalidResult = engine.validate(contract, invalidOutput);
+const fallbackProps = invalidResult.valid
+  ? engine.apply(baseProps, invalidResult.data ?? {})
+  : baseProps;
+```
+
+`fallbackProps` remains exactly equal to `baseProps`. Invalid output is rejected as a whole and does not partially mutate component state.
 
 ## Automated verification
 
@@ -101,9 +156,14 @@ Run the provider-free verification from the repository root:
 yarn verify:component-examples
 ```
 
-The root command builds `@micrantha/amaryllis-components` before running the verifier. CI performs the same operations as separate explicit steps: test, lint, typecheck, build, then example verification.
+Or run the workspace verifier after building:
 
-The verifier uses the package's actual parser, generators, registry, and personalization engine. It executes all three CLI commands, validates the valid fixture, rejects the invalid fixture, and asserts fallback to base props.
+```sh
+yarn workspace @micrantha/amaryllis-components build
+yarn workspace @micrantha/amaryllis-components verify:examples
+```
+
+The verifier uses the package's actual parser, policy path, generators, registry, and personalization engine. It executes all three CLI commands, validates the valid fixture, rejects the invalid fixture, and asserts fallback to base props. CI performs the same operations after component tests, lint, type checking, and build.
 
 ## Security notes
 
@@ -119,6 +179,23 @@ Executable TSX generation is limited to build or CI workflows and must be review
 
 Runtime personalization is structured-data-only. Reject data that does not match the generated contract, references undeclared variants or paths, includes unsafe object keys, or attempts to carry executable values. Validation failure must not partially apply output.
 
+### Registry authority
+
+The registry binds a canonical spec identity and version to a reviewed implementation and runtime contract. Model output must not select arbitrary modules, rename registry identities, or bypass implementation binding.
+
 ### Telemetry and input minimization
 
-Collect validation outcomes and coarse diagnostics rather than raw prompts, user content, or full model output by default. Minimize inference inputs before they reach any provider, redact secrets and personal data, and define retention and access controls before enabling diagnostic capture.
+Collect validation outcomes, contract or spec identifiers, bounded operation types, and coarse diagnostics rather than raw prompts, user content, images, secrets, or full model output by default. Define retention and access controls before enabling diagnostic capture.
+
+### Fail closed
+
+On parse, schema, policy, registry, or contract-validation failure:
+
+- reject the personalization output
+- preserve the last trusted or base props
+- surface a bounded diagnostic
+- never fall back to executing raw output
+
+## Current limitations
+
+This example proves the contract, generation, registry, and fallback path. It does not establish production readiness. The experimental package still requires versioning discipline, compatibility guarantees, release hardening, and broader consumer validation before its API can be considered stable.

--- a/docs/examples/ai-component-end-to-end.md
+++ b/docs/examples/ai-component-end-to-end.md
@@ -30,7 +30,7 @@ The model never becomes the direct source of executable runtime UI.
 - [`summary-card.customization.patch.json`](./summary-card.customization.patch.json): reviewed build-time JSON Patch
 - [`summary-card.personalization.valid.json`](./summary-card.personalization.valid.json): valid structured runtime output
 - [`summary-card.personalization.invalid.json`](./summary-card.personalization.invalid.json): invalid runtime output that must fall back
-- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): readable example of the personalization contract
+- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): generated personalization contract for this spec
 
 ## Build-time CLI flow
 
@@ -59,6 +59,8 @@ node packages/amaryllis-components/dist/cli/index.js contract \
   > /tmp/SummaryCard.contract.json
 ```
 
+The checked-in [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json) is the readable generated form of this contract and must remain aligned with the CLI output.
+
 Apply a reviewed customization patch and regenerate:
 
 ```sh
@@ -72,21 +74,35 @@ Generated TSX is a build or CI artifact, not runtime model output. Treat it like
 
 ## Runtime personalization flow
 
-Register an approved implementation with its validated spec and generated contract. The registry identity must exactly match `spec.metadata.name`:
+For provider-free Node or CI verification, import only the built modules exercised by the example. Importing the package barrel also loads React Native runtime primitives and is intended for React Native application code, not plain Node execution.
 
-```ts
+```js
 import fs from 'node:fs';
-import {
-  ComponentRegistry,
-  JSONSchemaGenerator,
-  PersonalizationEngine,
-  parseComponentSpec,
-} from '@micrantha/amaryllis-components';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const distRoot = path.resolve('packages/amaryllis-components/dist');
+
+const { ComponentRegistry } = require(
+  path.join(distRoot, 'runtime/registry.js')
+);
+const { PersonalizationEngine } = require(
+  path.join(distRoot, 'runtime/engine.js')
+);
+const { JSONSchemaGenerator } = require(
+  path.join(distRoot, 'generator/schema.js')
+);
+const { parseComponentSpec } = require(
+  path.join(distRoot, 'parser/yaml.js')
+);
 
 const spec = parseComponentSpec(
   fs.readFileSync('docs/examples/summary-card.component.yaml', 'utf8')
 );
-const contract = JSON.parse(new JSONSchemaGenerator().generate(spec));
+const generatedContract = JSON.parse(
+  new JSONSchemaGenerator().generate(spec)
+);
 
 const registry = new ComponentRegistry();
 const SummaryCard = () => null;
@@ -94,9 +110,14 @@ const SummaryCard = () => null;
 registry.register('summary-card', {
   component: SummaryCard,
   spec,
-  contract,
+  contract: generatedContract,
   implementationIdentity: 'app/components/SummaryCard',
 });
+
+const registered = registry.get('summary-card');
+if (!registered) {
+  throw new Error('summary-card was not registered');
+}
 
 const baseProps = {
   title: 'Base title',
@@ -112,27 +133,30 @@ const structuredOutput = JSON.parse(
 );
 
 const engine = new PersonalizationEngine();
-const result = engine.validate(contract, structuredOutput);
+const result = engine.validate(registered.contract, structuredOutput);
 const personalizedProps = result.valid
   ? engine.apply(baseProps, result.data ?? {})
   : baseProps;
+
+const ApprovedSummaryCard = registered.component;
 ```
+
+The demonstrated authority path is now explicit:
 
 ```text
 untrusted structured output
-  -> JSON Schema validation
-  -> unsafe-value and patch validation
+  -> registered contract validation
   -> bounded props overlay
-  -> approved registered component
+  -> registry-approved component implementation
 ```
 
-Valid output is merged over base props only after validation. Runtime JSX, TSX, JavaScript, imports, event handlers, and native operations are outside this contract.
+`ApprovedSummaryCard`, `registered.spec`, and `registered.contract` all come from the same registry entry. Valid output is merged over base props only after validation against the bound contract. Runtime JSX, TSX, JavaScript, imports, event handlers, and native operations are outside this contract.
 
 ## Invalid-output fallback
 
-Use the invalid fixture to prove the fail-closed behavior:
+Use the invalid fixture to prove the fail-closed behavior through the same registered contract:
 
-```ts
+```js
 const invalidOutput = JSON.parse(
   fs.readFileSync(
     'docs/examples/summary-card.personalization.invalid.json',
@@ -140,13 +164,15 @@ const invalidOutput = JSON.parse(
   )
 );
 
-const invalidResult = engine.validate(contract, invalidOutput);
+const invalidResult = engine.validate(registered.contract, invalidOutput);
 const fallbackProps = invalidResult.valid
   ? engine.apply(baseProps, invalidResult.data ?? {})
   : baseProps;
 ```
 
 `fallbackProps` remains exactly equal to `baseProps`. Invalid output is rejected as a whole and does not partially mutate component state.
+
+In React Native application code, consumers may use the package barrel and registry-backed rendering primitives because the React Native runtime is present. The provider-free Node example above intentionally mirrors the CI verifier and avoids loading platform primitives.
 
 ## Automated verification
 
@@ -163,7 +189,7 @@ yarn workspace @micrantha/amaryllis-components build
 yarn workspace @micrantha/amaryllis-components verify:examples
 ```
 
-The verifier uses the package's actual parser, policy path, generators, registry, and personalization engine. It executes all three CLI commands, validates the valid fixture, rejects the invalid fixture, and asserts fallback to base props. CI performs the same operations after component tests, lint, type checking, and build.
+The verifier uses the package's actual parser, policy path, generators, registry, and personalization engine. It executes all three CLI commands, compares the generated contract to the runtime contract, validates the valid fixture through the registered entry, rejects the invalid fixture, and asserts fallback to base props. CI performs the same operations after component tests, lint, type checking, and build.
 
 ## Security notes
 

--- a/docs/examples/summary-card.personalization.schema.json
+++ b/docs/examples/summary-card.personalization.schema.json
@@ -1,17 +1,102 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://micrantha.com/amaryllis/examples/summary-card.personalization.schema.json",
-  "title": "SummaryCardPersonalization",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "summary-card Personalization Contract",
+  "description": "Schema for on-device personalization of summary-card v0.1.0",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
-    "summary": {
-      "type": "string",
-      "maxLength": 240
+    "props": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "compact",
+            "expanded"
+          ]
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false
     },
     "variant": {
       "type": "string",
-      "enum": ["compact", "expanded"]
+      "enum": [
+        "compact",
+        "expanded"
+      ]
+    },
+    "slots": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "designTokens": {
+      "type": "object",
+      "properties": {
+        "spacingSm": {
+          "type": "string"
+        },
+        "spacingMd": {
+          "type": "string"
+        },
+        "bodySm": {
+          "type": "string"
+        },
+        "bodyMd": {
+          "type": "string"
+        },
+        "surfacePrimary": {
+          "type": "string"
+        },
+        "textPrimary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "patches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
+            "enum": [
+              "add",
+              "remove",
+              "replace",
+              "move",
+              "copy",
+              "test"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "value": {}
+        },
+        "required": [
+          "op",
+          "path"
+        ],
+        "additionalProperties": false
+      }
     }
-  }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

- complete the provider-free end-to-end walkthrough for `@micrantha/amaryllis-components`
- document the package boundary with `@micrantha/react-native-amaryllis`
- show CLI generation, contract generation, and bounded customization
- show registry binding, valid personalization, invalid-output fallback, and fail-closed behavior
- document experimental status, prompt-injection boundaries, generated-code review, registry authority, and telemetry minimization
- add an examples index linked by the existing root README examples entry

## Why

Issue #40 requires a runnable, branch-aware walkthrough that proves the stabilized schema, policy, runtime, generator, and CI work without overstating production readiness.

## Validation

- documentation commands and imports were checked against the current package scripts and public exports
- canonical registry identity now matches `spec.metadata.name` (`summary-card`)
- the documented verification command is the same provider-free example verifier used in CI

Closes #40