### PR TITLE
fix: replace retired dependency audit endpoint

### DIFF
--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -10,115 +10,16 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Run npm audit and capture output
-        id: npm_audit
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          yarn npm audit --all --severity high > audit-output.txt 2>&1
-
-      - name: Build issue body if audit failed
-        if: steps.npm_audit.outcome == 'failure'
-        run: |
-          {
-            echo "# Dependency audit failed"
-            echo
-            echo "- Workflow: $GITHUB_WORKFLOW"
-            echo "- Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "- Commit: ${GITHUB_SHA}"
-            echo
-            echo "## Audit output"
-            echo
-            echo '```text'
-            sed -n '1,400p' audit-output.txt
-            echo '```'
-          } > audit-issue.md
-
-      - name: Ensure audit labels exist
-        if: steps.npm_audit.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const labels = [
-              {
-                name: 'security',
-                color: 'd73a4a',
-                description: 'Security-related issues and findings',
-              },
-              {
-                name: 'dependencies',
-                color: '0366d6',
-                description: 'Dependency maintenance and audit findings',
-              },
-            ];
-
-            for (const label of labels) {
-              try {
-                await github.rest.issues.getLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                });
-
-                await github.rest.issues.updateLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label.name,
-                  color: label.color,
-                  description: label.description,
-                });
-              } catch (error) {
-                if (error.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name: label.name,
-                    color: label.color,
-                    description: label.description,
-                  });
-                  continue;
-                }
-
-                throw error;
-              }
-            }
-
-      - name: Create issue when audit fails
-        if: steps.npm_audit.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('./audit-issue.md', 'utf8');
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Dependency audit failure (${context.runId})`,
-              body,
-              labels: ['security', 'dependencies'],
-            });
-
-      - name: Print audit output when audit fails
-        if: steps.npm_audit.outcome == 'failure'
-        run: |
-          echo "Dependency audit failed. Captured output:"
-          echo
-          sed -n '1,400p' audit-output.txt
-
-      - name: Fail job if audit failed
-        if: steps.npm_audit.outcome == 'failure'
-        run: exit 1
+    name: OSV dependency scan
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    with:
+      scan-args: |-
+        --recursive
+        ./
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary

- replace `yarn npm audit`, which calls npm's retired quick-audit endpoint, with the official OSV-Scanner reusable workflow
- scan all supported lockfiles recursively, including `yarn.lock` and `Gemfile.lock`
- publish findings through GitHub code scanning instead of creating a new issue for every failed scheduled run
- remove unnecessary `issues: write` permission

## Security and maintenance impact

- restores scheduled and main-branch dependency vulnerability scanning
- uses a scanner that natively supports Yarn lockfiles
- centralizes findings in GitHub code scanning for deduplication and lifecycle management
- limits workflow permissions to read-only repository access plus `security-events: write` for SARIF upload

Closes #44