### PR TITLE
fix: preserve bounded AI component personalization contracts

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,0 +1,28 @@
+# AI component examples
+
+> **Experimental:** `@micrantha/amaryllis-components` and the `amaryllis/v1alpha1` contract are not yet stable public APIs.
+
+These examples exercise the provider-free, governed component path included in the repository.
+
+## Start here
+
+- [End-to-end AI component walkthrough](./ai-component-end-to-end.md)
+- [Runtime validation flow](./runtime-validation-flow.md)
+
+## Fixtures
+
+- [`summary-card.component.yaml`](./summary-card.component.yaml): valid React Native `ComponentSpec`
+- [`summary-card.customization.patch.json`](./summary-card.customization.patch.json): bounded customization patch
+- [`summary-card.personalization.valid.json`](./summary-card.personalization.valid.json): valid structured personalization output
+- [`summary-card.personalization.invalid.json`](./summary-card.personalization.invalid.json): invalid output used to verify deterministic fallback
+- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): readable personalization contract example
+
+## Verify
+
+From the repository root:
+
+```sh
+yarn verify:component-examples
+```
+
+The verification builds the companion package and exercises schema and policy validation, CLI generation, contract generation, customization, registry identity, valid personalization, invalid personalization, and fail-closed fallback behavior.

--- a/docs/examples/ai-component-end-to-end.md
+++ b/docs/examples/ai-component-end-to-end.md
@@ -1,28 +1,43 @@
 # End-to-end AI component example
 
-> **Experimental:** `amaryllis/v1alpha1` and `@micrantha/amaryllis-components` are branch-level experimental APIs. They are not stable public contracts and may change before release.
+> **Experimental:** `amaryllis/v1alpha1` and `@micrantha/amaryllis-components` are experimental APIs. They are not stable public contracts and may change before release.
 
-This example exercises the governed path from a reviewed component spec to generated artifacts and structured runtime personalization. It is offline-first and does not require a model provider.
+This example exercises the governed path from a reviewed component spec to generated artifacts and structured runtime personalization. It is offline-first and does not require a live model provider.
+
+```text
+ComponentSpec YAML
+  -> schema validation
+  -> policy validation
+  -> contract generation
+  -> React Native component generation or bounded customization
+  -> registry binding
+  -> structured runtime personalization
+  -> deterministic fallback for invalid output
+```
 
 ## Package boundary
 
-- `@micrantha/react-native-amaryllis` is the React Native inference substrate. It owns native model execution and the application-facing inference APIs.
+- `@micrantha/react-native-amaryllis` is the React Native inference substrate. It owns native model execution, streaming, model inputs, and the application-facing inference APIs.
 - `@micrantha/amaryllis-components` is the experimental companion package. It owns `ComponentSpec`, schema and policy validation, build-time React generation, registry identity, personalization contracts, and structured overlay validation.
 
 The companion package does not execute a model and does not replace the base runtime. Applications may obtain structured output from the base runtime, a remote service, a test fixture, or another provider-neutral inference function, then pass that untrusted data through the companion package validators.
 
+The model never becomes the direct source of executable runtime UI.
+
 ## Files
 
-- [`summary-card.component.yaml`](./summary-card.component.yaml): authoritative component spec
+- [`summary-card.component.yaml`](./summary-card.component.yaml): authoritative React Native component spec
 - [`summary-card.customization.patch.json`](./summary-card.customization.patch.json): reviewed build-time JSON Patch
 - [`summary-card.personalization.valid.json`](./summary-card.personalization.valid.json): valid structured runtime output
 - [`summary-card.personalization.invalid.json`](./summary-card.personalization.invalid.json): invalid runtime output that must fall back
+- [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json): generated personalization contract for this spec
 
 ## Build-time CLI flow
 
 Build the companion package before running its CLI:
 
 ```sh
+yarn install --immutable
 yarn workspace @micrantha/amaryllis-components build
 ```
 
@@ -34,6 +49,8 @@ node packages/amaryllis-components/dist/cli/index.js generate \
   --output /tmp/SummaryCard.tsx
 ```
 
+The CLI performs schema and policy validation before writing output. The canonical spec name is `summary-card`; the generator converts it to the React component identifier `SummaryCard`.
+
 Generate the structured runtime contract:
 
 ```sh
@@ -41,6 +58,8 @@ node packages/amaryllis-components/dist/cli/index.js contract \
   --spec docs/examples/summary-card.component.yaml \
   > /tmp/SummaryCard.contract.json
 ```
+
+The checked-in [`summary-card.personalization.schema.json`](./summary-card.personalization.schema.json) is the readable generated form of this contract and must remain aligned with the CLI output.
 
 Apply a reviewed customization patch and regenerate:
 
@@ -51,47 +70,109 @@ node packages/amaryllis-components/dist/cli/index.js customize \
   --output /tmp/SummaryCard.customized.tsx
 ```
 
-Generated TSX is a build/CI artifact, not runtime model output. Treat it like source code: inspect the diff, run lint/typecheck/tests, enforce allowed imports, and require human review before promotion.
+Generated TSX is a build or CI artifact, not runtime model output. Treat it like source code: inspect the diff, run lint, type checking, and tests, enforce allowed imports, and require human review before promotion.
 
 ## Runtime personalization flow
 
-Register an approved component implementation with its validated spec and generated contract. The model-facing boundary accepts only structured data:
+For provider-free Node or CI verification, import only the built modules exercised by the example. Importing the package barrel also loads React Native runtime primitives and is intended for React Native application code, not plain Node execution.
 
-```tsx
+```js
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const distRoot = path.resolve('packages/amaryllis-components/dist');
+
+const { ComponentRegistry } = require(
+  path.join(distRoot, 'runtime/registry.js')
+);
+const { PersonalizationEngine } = require(
+  path.join(distRoot, 'runtime/engine.js')
+);
+const { JSONSchemaGenerator } = require(
+  path.join(distRoot, 'generator/schema.js')
+);
+const { parseComponentSpec } = require(
+  path.join(distRoot, 'parser/yaml.js')
+);
+
+const spec = parseComponentSpec(
+  fs.readFileSync('docs/examples/summary-card.component.yaml', 'utf8')
+);
+const generatedContract = JSON.parse(
+  new JSONSchemaGenerator().generate(spec)
+);
+
 const registry = new ComponentRegistry();
+const SummaryCard = () => null;
 
-registry.register('SummaryCard', {
+registry.register('summary-card', {
   component: SummaryCard,
   spec,
-  contract,
+  contract: generatedContract,
   implementationIdentity: 'app/components/SummaryCard',
 });
 
-<RegistryProvider registry={registry}>
-  <PersonalizedComponent
-    name="SummaryCard"
-    baseProps={{
-      title: 'Base title',
-      summary: 'Base summary',
-      variant: 'expanded',
-    }}
-    personalizationData={structuredOutput}
-    onValidation={({ valid, errors }) => {
-      telemetry.record({ valid, errorCount: errors?.length ?? 0 });
-    }}
-  />
-</RegistryProvider>;
+const registered = registry.get('summary-card');
+if (!registered) {
+  throw new Error('summary-card was not registered');
+}
+
+const baseProps = {
+  title: 'Base title',
+  summary: 'Base summary',
+  variant: 'expanded',
+};
+
+const structuredOutput = JSON.parse(
+  fs.readFileSync(
+    'docs/examples/summary-card.personalization.valid.json',
+    'utf8'
+  )
+);
+
+const engine = new PersonalizationEngine();
+const result = engine.validate(registered.contract, structuredOutput);
+const personalizedProps = result.valid
+  ? engine.apply(baseProps, result.data ?? {})
+  : baseProps;
+
+const ApprovedSummaryCard = registered.component;
 ```
+
+The demonstrated authority path is now explicit:
 
 ```text
 untrusted structured output
-  -> JSON Schema validation
-  -> unsafe-value and patch validation
+  -> registered contract validation
   -> bounded props overlay
-  -> approved registered component
+  -> registry-approved component implementation
 ```
 
-Valid output is merged over base props. Invalid output is rejected and the component deterministically renders its original base props. Runtime JSX, TSX, JavaScript, imports, and native operations are outside this contract.
+`ApprovedSummaryCard`, `registered.spec`, and `registered.contract` all come from the same registry entry. Valid output is merged over base props only after validation against the bound contract. Runtime JSX, TSX, JavaScript, imports, event handlers, and native operations are outside this contract.
+
+## Invalid-output fallback
+
+Use the invalid fixture to prove the fail-closed behavior through the same registered contract:
+
+```js
+const invalidOutput = JSON.parse(
+  fs.readFileSync(
+    'docs/examples/summary-card.personalization.invalid.json',
+    'utf8'
+  )
+);
+
+const invalidResult = engine.validate(registered.contract, invalidOutput);
+const fallbackProps = invalidResult.valid
+  ? engine.apply(baseProps, invalidResult.data ?? {})
+  : baseProps;
+```
+
+`fallbackProps` remains exactly equal to `baseProps`. Invalid output is rejected as a whole and does not partially mutate component state.
+
+In React Native application code, consumers may use the package barrel and registry-backed rendering primitives because the React Native runtime is present. The provider-free Node example above intentionally mirrors the CI verifier and avoids loading platform primitives.
 
 ## Automated verification
 
@@ -101,9 +182,14 @@ Run the provider-free verification from the repository root:
 yarn verify:component-examples
 ```
 
-The root command builds `@micrantha/amaryllis-components` before running the verifier. CI performs the same operations as separate explicit steps: test, lint, typecheck, build, then example verification.
+Or run the workspace verifier after building:
 
-The verifier uses the package's actual parser, generators, registry, and personalization engine. It executes all three CLI commands, validates the valid fixture, rejects the invalid fixture, and asserts fallback to base props.
+```sh
+yarn workspace @micrantha/amaryllis-components build
+yarn workspace @micrantha/amaryllis-components verify:examples
+```
+
+The verifier uses the package's actual parser, policy path, generators, registry, and personalization engine. It executes all three CLI commands, compares the generated contract to the runtime contract, validates the valid fixture through the registered entry, rejects the invalid fixture, and asserts fallback to base props. CI performs the same operations after component tests, lint, type checking, and build.
 
 ## Security notes
 
@@ -119,6 +205,23 @@ Executable TSX generation is limited to build or CI workflows and must be review
 
 Runtime personalization is structured-data-only. Reject data that does not match the generated contract, references undeclared variants or paths, includes unsafe object keys, or attempts to carry executable values. Validation failure must not partially apply output.
 
+### Registry authority
+
+The registry binds a canonical spec identity and version to a reviewed implementation and runtime contract. Model output must not select arbitrary modules, rename registry identities, or bypass implementation binding.
+
 ### Telemetry and input minimization
 
-Collect validation outcomes and coarse diagnostics rather than raw prompts, user content, or full model output by default. Minimize inference inputs before they reach any provider, redact secrets and personal data, and define retention and access controls before enabling diagnostic capture.
+Collect validation outcomes, contract or spec identifiers, bounded operation types, and coarse diagnostics rather than raw prompts, user content, images, secrets, or full model output by default. Define retention and access controls before enabling diagnostic capture.
+
+### Fail closed
+
+On parse, schema, policy, registry, or contract-validation failure:
+
+- reject the personalization output
+- preserve the last trusted or base props
+- surface a bounded diagnostic
+- never fall back to executing raw output
+
+## Current limitations
+
+This example proves the contract, generation, registry, and fallback path. It does not establish production readiness. The experimental package still requires versioning discipline, compatibility guarantees, release hardening, and broader consumer validation before its API can be considered stable.

--- a/docs/examples/summary-card.component.yaml
+++ b/docs/examples/summary-card.component.yaml
@@ -19,6 +19,7 @@ props:
       type: string
     summary:
       type: string
+      maxLength: 240
     variant:
       type: string
       enum:

--- a/docs/examples/summary-card.personalization.schema.json
+++ b/docs/examples/summary-card.personalization.schema.json
@@ -11,7 +11,8 @@
           "type": "string"
         },
         "summary": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 240
         },
         "variant": {
           "type": "string",
@@ -37,7 +38,8 @@
       "type": "object",
       "properties": {
         "summary": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 240
         }
       },
       "additionalProperties": false

--- a/docs/examples/summary-card.personalization.schema.json
+++ b/docs/examples/summary-card.personalization.schema.json
@@ -1,17 +1,102 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://micrantha.com/amaryllis/examples/summary-card.personalization.schema.json",
-  "title": "SummaryCardPersonalization",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "summary-card Personalization Contract",
+  "description": "Schema for on-device personalization of summary-card v0.1.0",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
-    "summary": {
-      "type": "string",
-      "maxLength": 240
+    "props": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "variant": {
+          "type": "string",
+          "enum": [
+            "compact",
+            "expanded"
+          ]
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false
     },
     "variant": {
       "type": "string",
-      "enum": ["compact", "expanded"]
+      "enum": [
+        "compact",
+        "expanded"
+      ]
+    },
+    "slots": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "designTokens": {
+      "type": "object",
+      "properties": {
+        "spacingSm": {
+          "type": "string"
+        },
+        "spacingMd": {
+          "type": "string"
+        },
+        "bodySm": {
+          "type": "string"
+        },
+        "bodyMd": {
+          "type": "string"
+        },
+        "surfacePrimary": {
+          "type": "string"
+        },
+        "textPrimary": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "patches": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "op": {
+            "type": "string",
+            "enum": [
+              "add",
+              "remove",
+              "replace",
+              "move",
+              "copy",
+              "test"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "value": {}
+        },
+        "required": [
+          "op",
+          "path"
+        ],
+        "additionalProperties": false
+      }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/packages/amaryllis-components/src/__tests__/SchemaGenerator.test.ts
+++ b/packages/amaryllis-components/src/__tests__/SchemaGenerator.test.ts
@@ -1,0 +1,38 @@
+import { JSONSchemaGenerator } from '../generator/schema';
+import type { ValidatedComponentSpec } from '../schema/spec.schema';
+
+describe('JSONSchemaGenerator', () => {
+  it('preserves string bounds for props and matching slots', () => {
+    const spec: ValidatedComponentSpec = {
+      apiVersion: 'amaryllis/v1alpha1',
+      kind: 'ComponentSpec',
+      metadata: { name: 'summary-card', version: '0.1.0' },
+      target: { framework: 'react', runtime: 'rn' },
+      props: {
+        type: 'object',
+        properties: {
+          summary: { type: 'string', maxLength: 240 },
+        },
+      },
+      ui: {
+        slots: ['summary'],
+      },
+      ai: {
+        mode: 'personalize',
+        execution: 'device',
+        generationContract: { output: 'props-json' },
+      },
+    };
+
+    const schema = JSON.parse(new JSONSchemaGenerator().generate(spec));
+
+    expect(schema.properties.props.properties.summary).toEqual({
+      type: 'string',
+      maxLength: 240,
+    });
+    expect(schema.properties.slots.properties.summary).toEqual({
+      type: 'string',
+      maxLength: 240,
+    });
+  });
+});

--- a/packages/amaryllis-components/src/generator/schema.ts
+++ b/packages/amaryllis-components/src/generator/schema.ts
@@ -28,7 +28,9 @@ export class JSONSchemaGenerator {
               type: 'object',
               properties: ui.slots.reduce(
                 (acc, slot) => {
-                  acc[slot] = { type: 'string' };
+                  acc[slot] = props.properties[slot]
+                    ? this.mapProperty(props.properties[slot])
+                    : { type: 'string' };
                   return acc;
                 },
                 {} as Record<string, JsonSchemaValue>
@@ -85,6 +87,7 @@ export class JSONSchemaGenerator {
       ...(value.description && { description: value.description }),
       ...(value.enum && { enum: value.enum }),
       ...(value.default !== undefined && { default: value.default }),
+      ...(value.maxLength !== undefined && { maxLength: value.maxLength }),
       ...(value.items && { items: this.mapProperty(value.items) }),
       ...(value.properties && {
         properties: this.mapProperties(value.properties),

--- a/packages/amaryllis-components/src/schema/spec.schema.ts
+++ b/packages/amaryllis-components/src/schema/spec.schema.ts
@@ -83,6 +83,7 @@ export const JsonSchemaValueSchema: z.ZodType = z.lazy(() =>
       description: z.string().optional(),
       enum: z.array(z.unknown()).optional(),
       default: z.unknown().optional(),
+      maxLength: z.number().int().nonnegative().optional(),
       items: JsonSchemaValueSchema.optional(),
       properties: z.record(JsonSchemaValueSchema).optional(),
       required: z.array(z.string()).optional(),

--- a/packages/amaryllis-components/src/types/spec.ts
+++ b/packages/amaryllis-components/src/types/spec.ts
@@ -27,6 +27,7 @@ export interface JsonSchemaValue {
   description?: string;
   enum?: unknown[];
   default?: unknown;
+  maxLength?: number;
   items?: JsonSchemaValue;
   properties?: Record<string, JsonSchemaValue>;
   required?: string[];


### PR DESCRIPTION
## Summary

- sync the final AI component examples index and provider-free end-to-end guide to `main`
- preserve JSON Schema string bounds such as `maxLength` in generated personalization contracts
- make matching slot schemas inherit the authoritative prop schema
- add the 240-character summary bound to the example spec and generated contract
- add regression coverage for bounded `props.summary` and `slots.summary`

## Why

PR #30 was squash-merged before the final documentation refinements from PR #56 landed on `feature/ai-components`. During the focused sync, review found that the generated contract dropped the example's 240-character summary constraint. This PR now fixes the generator rather than weakening fail-closed validation or patching only the checked-in fixture.

## Changed areas

- AI component example documentation and fixtures
- `JsonSchemaValue` typing and validation
- personalization schema generation
- schema-generator regression tests

## Validation

- component package tests, lint, typecheck, build, and example verification
- root CI and package validation
- compatibility matrix
- coverage gate
- CodeQL
- Cloudflare documentation preview