### PR TITLE
fix: enforce explicit AI component patch contracts

### DIFF
--- a/docs/examples/summary-card.personalization.schema.json
+++ b/docs/examples/summary-card.personalization.schema.json
@@ -67,37 +67,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "patches": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "op": {
-            "type": "string",
-            "enum": [
-              "add",
-              "remove",
-              "replace",
-              "move",
-              "copy",
-              "test"
-            ]
-          },
-          "path": {
-            "type": "string"
-          },
-          "from": {
-            "type": "string"
-          },
-          "value": {}
-        },
-        "required": [
-          "op",
-          "path"
-        ],
-        "additionalProperties": false
-      }
     }
   },
   "additionalProperties": false

--- a/packages/amaryllis-components/src/__tests__/Personalization.test.ts
+++ b/packages/amaryllis-components/src/__tests__/Personalization.test.ts
@@ -31,7 +31,7 @@ describe('Personalization', () => {
       mode: 'personalize',
       execution: 'device',
       generationContract: {
-        output: 'props-json',
+        output: 'json-patch',
       },
     },
     policy: {
@@ -66,7 +66,7 @@ describe('Personalization', () => {
 
   test('should fail validation for incorrect data types', () => {
     const aiOutput = {
-      props: { title: 123 }, // Should be string
+      props: { title: 123 },
     };
 
     const result = engine.validate(contract, aiOutput);
@@ -77,7 +77,7 @@ describe('Personalization', () => {
 
   test('should fail validation for missing required props', () => {
     const aiOutput = {
-      props: { count: 1 }, // Missing title
+      props: { count: 1 },
     };
 
     const result = engine.validate(contract, aiOutput);

--- a/packages/amaryllis-components/src/__tests__/SchemaGenerator.security.test.ts
+++ b/packages/amaryllis-components/src/__tests__/SchemaGenerator.security.test.ts
@@ -1,0 +1,76 @@
+import { JSONSchemaGenerator } from '../generator/schema';
+import { PersonalizationEngine } from '../runtime/engine';
+import type { ValidatedComponentSpec } from '../schema/spec.schema';
+
+describe('JSONSchemaGenerator security boundaries', () => {
+  const generator = new JSONSchemaGenerator();
+  const engine = new PersonalizationEngine();
+
+  const propsJsonSpec: ValidatedComponentSpec = {
+    apiVersion: 'amaryllis/v1alpha1',
+    kind: 'ComponentSpec',
+    metadata: { name: 'summary-card', version: '0.1.0' },
+    target: { framework: 'react', runtime: 'rn' },
+    props: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        summary: { type: 'string', maxLength: 240 },
+      },
+      required: ['title'],
+    },
+    ui: {
+      slots: ['summary'],
+    },
+    ai: {
+      mode: 'personalize',
+      execution: 'device',
+      allowedOperations: ['setSlotText'],
+      generationContract: { output: 'props-json' },
+    },
+  };
+
+  test('propagates summary length constraints to props and matching slots', () => {
+    const contract = JSON.parse(generator.generate(propsJsonSpec));
+
+    expect(contract.properties.props.properties.summary.maxLength).toBe(240);
+    expect(contract.properties.slots.properties.summary.maxLength).toBe(240);
+
+    const overlongSummary = 'x'.repeat(241);
+    expect(
+      engine.validate(contract, {
+        props: { title: 'Title', summary: overlongSummary },
+      }).valid
+    ).toBe(false);
+    expect(
+      engine.validate(contract, {
+        props: { title: 'Title' },
+        slots: { summary: overlongSummary },
+      }).valid
+    ).toBe(false);
+  });
+
+  test('omits patches unless the generation contract explicitly selects json-patch', () => {
+    const propsContract = JSON.parse(generator.generate(propsJsonSpec));
+
+    expect(propsContract.properties.patches).toBeUndefined();
+    expect(
+      engine.validate(propsContract, {
+        props: { title: 'Title' },
+        patches: [{ op: 'replace', path: '/props/title', value: 'Changed' }],
+      }).valid
+    ).toBe(false);
+
+    const patchSpec: ValidatedComponentSpec = {
+      ...propsJsonSpec,
+      metadata: { name: 'patch-card', version: '0.1.0' },
+      ai: {
+        ...propsJsonSpec.ai,
+        generationContract: { output: 'json-patch' },
+      },
+    };
+    const patchContract = JSON.parse(generator.generate(patchSpec));
+
+    expect(patchContract.properties.patches).toBeDefined();
+  });
+});

--- a/packages/amaryllis-components/src/generator/schema.ts
+++ b/packages/amaryllis-components/src/generator/schema.ts
@@ -3,7 +3,8 @@ import type { JsonSchemaValue } from '../types/spec';
 
 export class JSONSchemaGenerator {
   generate(spec: ValidatedComponentSpec): string {
-    const { metadata, props, ui } = spec;
+    const { metadata, props, ui, ai } = spec;
+    const allowsJsonPatch = ai.generationContract?.output === 'json-patch';
 
     const schema = {
       $schema: 'http://json-schema.org/draft-07/schema#',
@@ -45,23 +46,25 @@ export class JSONSchemaGenerator {
               additionalProperties: false,
             }
           : undefined,
-        patches: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              op: {
-                type: 'string',
-                enum: ['add', 'remove', 'replace', 'move', 'copy', 'test'],
+        patches: allowsJsonPatch
+          ? {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  op: {
+                    type: 'string',
+                    enum: ['add', 'remove', 'replace', 'move', 'copy', 'test'],
+                  },
+                  path: { type: 'string' },
+                  from: { type: 'string' },
+                  value: {},
+                },
+                required: ['op', 'path'],
+                additionalProperties: false,
               },
-              path: { type: 'string' },
-              from: { type: 'string' },
-              value: {},
-            },
-            required: ['op', 'path'],
-            additionalProperties: false,
-          },
-        },
+            }
+          : undefined,
       },
       additionalProperties: false,
     };
@@ -87,6 +90,7 @@ export class JSONSchemaGenerator {
       ...(value.description && { description: value.description }),
       ...(value.enum && { enum: value.enum }),
       ...(value.default !== undefined && { default: value.default }),
+      ...(value.minLength !== undefined && { minLength: value.minLength }),
       ...(value.maxLength !== undefined && { maxLength: value.maxLength }),
       ...(value.items && { items: this.mapProperty(value.items) }),
       ...(value.properties && {

--- a/packages/amaryllis-components/src/types/spec.ts
+++ b/packages/amaryllis-components/src/types/spec.ts
@@ -27,6 +27,7 @@ export interface JsonSchemaValue {
   description?: string;
   enum?: unknown[];
   default?: unknown;
+  minLength?: number;
   maxLength?: number;
   items?: JsonSchemaValue;
   properties?: Record<string, JsonSchemaValue>;


### PR DESCRIPTION
## Summary

- refresh the branch onto current `main` after PR #60 landed the documentation and bounded-schema work
- emit JSON Patch contracts only when `generationContract.output` explicitly selects `json-patch`
- keep existing patch behavior tests on an explicit `json-patch` fixture
- add regression coverage proving `props-json` rejects patch payloads
- preserve generated string length constraints, including matching slot schemas
- regenerate the summary-card `props-json` contract without a `patches` surface

## Scope

This branch is based directly on current `main` (`30db2cff6a8a6dfbc88c0fdf08a799e0a3b0d520`) and contains only the stricter contract-authorization delta not already merged through PR #60.

## Validation

- branch is current with `main`
- diff is limited to five schema, test, and fixture files
- prior review findings remain addressed
- fresh CI is required for the reconciled head
