### PR TITLE
ci: harden SBOM publishing and dependency coverage

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -121,10 +121,23 @@ jobs:
       - name: Validate release SBOM contract
         run: bash scripts/validate-sbom.sh "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
 
+      - name: Ensure GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi
+
       - name: Publish SBOM release asset
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release upload "${GITHUB_REF_NAME}"
-          "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
-          --clobber
+        run: |
+          set -euo pipefail
+          gh release upload "${GITHUB_REF_NAME}" \
+            "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json" \
+            --clobber

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,7 +10,18 @@ on:
       - yarn.lock
       - .yarnrc.yml
       - example/package.json
+      - packages/*/package.json
+      - android/**
+      - ios/**
+      - '*.podspec'
+      - '**/Podfile.lock'
+      - '**/Package.resolved'
+      - '**/*.gradle'
+      - '**/*.gradle.kts'
+      - '**/gradle.properties'
+      - '**/libs.versions.toml'
       - scripts/validate-sbom.sh
+      - .github/actions/setup/**
       - .github/workflows/sbom.yml
   push:
     branches:
@@ -57,3 +68,63 @@ jobs:
           path: artifacts/sbom.cdx.json
           if-no-files-found: error
           retention-days: 90
+
+  dependency-snapshot:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+
+      - name: Submit dependency snapshot
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        with:
+          path: .
+          format: cyclonedx-json
+          syft-version: v1.42.0
+          dependency-snapshot: true
+          upload-artifact: false
+          upload-release-assets: false
+
+  publish-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup dependencies
+        uses: ./.github/actions/setup
+
+      - name: Prepare artifact directory
+        run: mkdir -p artifacts
+
+      - name: Generate release CycloneDX SBOM
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: artifacts/amaryllis-${{ github.ref_name }}.cdx.json
+          syft-version: v1.42.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Validate release SBOM contract
+        run: bash scripts/validate-sbom.sh "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
+
+      - name: Publish SBOM release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "${GITHUB_REF_NAME}"
+          "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
+          --clobber


### PR DESCRIPTION
## Summary

- broaden SBOM workflow triggers to cover workspace package manifests and native Android/iOS dependency files
- submit the generated dependency inventory to GitHub's dependency graph on pushes to `main`
- generate, validate, and attach a versioned CycloneDX SBOM to `v*` GitHub releases
- keep pull-request generation read-only while granting write permissions only to the narrowly scoped dependency-submission and release jobs

## Why

The existing SBOM workflow generated and validated a reproducible CycloneDX artifact, but some package and native dependency changes did not trigger it. Tagged builds also retained the SBOM only as a 90-day workflow artifact, and GitHub's dependency graph did not receive the generated inventory.

## Security

- existing third-party actions remain pinned to full commit SHAs
- release publication occurs only for pushed `v*` tags
- the release asset is validated before upload
- write permissions are isolated to jobs that require them
- pull-request execution remains `contents: read`

## Validation

- workflow syntax and repository action-policy checks through CI
- SBOM contract validation through `scripts/validate-sbom.sh`
- dependency submission exercised after merge on the next `main` push
- release asset publication exercised on the next `v*` tag

## Follow-up

A signed artifact attestation should be added in a separate slice once the repository selects and pins a reviewed `actions/attest` release SHA. This PR does not introduce an unpinned action tag.