### PR TITLE
ci: attest release SBOM provenance

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -97,6 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Checkout
@@ -120,6 +123,11 @@ jobs:
 
       - name: Validate release SBOM contract
         run: bash scripts/validate-sbom.sh "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
+
+      - name: Attest release SBOM provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: artifacts/amaryllis-${{ github.ref_name }}.cdx.json
 
       - name: Ensure GitHub Release exists
         env:

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,49 @@
+# Software bill of materials
+
+Amaryllis generates a CycloneDX 1.6 software bill of materials (SBOM) from the repository dependency inventory.
+
+## Pull requests and main
+
+Dependency-related pull requests generate and validate `artifacts/sbom.cdx.json`. The workflow retains the file as the `amaryllis-sbom-cyclonedx` Actions artifact for 90 days, including when validation fails.
+
+Pushes to `main` also submit the generated dependency inventory to GitHub's dependency graph.
+
+## Releases
+
+Pushing a `v*` tag generates and validates a versioned release asset named:
+
+```text
+amaryllis-vX.Y.Z.cdx.json
+```
+
+The release job creates the GitHub Release when it does not already exist, signs an artifact-provenance attestation for the validated SBOM, and then uploads the SBOM to the release.
+
+The attestation binds the exact SBOM filename and digest to the GitHub Actions workflow and source revision that generated it. The OIDC and attestation write permissions are limited to the tag-only release job.
+
+## Verification
+
+Download the SBOM from the GitHub Release, then verify its attestation with GitHub CLI:
+
+```sh
+gh attestation verify amaryllis-vX.Y.Z.cdx.json \
+  --repo hackelia-micrantha/amaryllis
+```
+
+Verification should identify `hackelia-micrantha/amaryllis` as the source repository and the release workflow as the signer workflow. A changed or substituted SBOM will fail digest verification.
+
+The SBOM itself can also be checked against the repository contract:
+
+```sh
+bash scripts/validate-sbom.sh amaryllis-vX.Y.Z.cdx.json
+```
+
+## Trust boundary
+
+Pull-request jobs retain read-only repository permissions and cannot request GitHub OIDC tokens or publish attestations. Only release-tag executions of the `publish-release` job receive:
+
+- `contents: write`, to create the release and upload its SBOM
+- `id-token: write`, to request the short-lived signing identity
+- `attestations: write`, to publish the signed attestation
+- `artifact-metadata: write`, as required by the pinned attestation action
+
+Third-party actions in the workflow are pinned to full commit SHAs.


### PR DESCRIPTION
## Summary

- attest each validated release CycloneDX SBOM before publishing it
- pin the official `actions/attest` v4 action to a full commit SHA
- restrict OIDC, attestation, and artifact-metadata write permissions to the tag-only release job
- document release SBOM download, verification, and trust boundaries

## Why

Release SBOMs are currently generated, validated, and attached to GitHub Releases, but consumers cannot cryptographically verify which workflow and source revision produced the downloaded file. This adds a GitHub artifact-provenance attestation bound to the exact SBOM filename and digest.

## Security

- `actions/attest` is pinned to `f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6`
- repository-level permissions remain `contents: read`
- only `publish-release` receives `id-token: write`, `attestations: write`, and `artifact-metadata: write`
- the attestation step runs only for pushed `v*` tags and only after SBOM contract validation succeeds
- release upload occurs only after attestation succeeds

## Verification

Release consumers can verify a downloaded SBOM with:

```sh
gh attestation verify amaryllis-vX.Y.Z.cdx.json \
  --repo hackelia-micrantha/amaryllis
```

## Validation

- workflow lint and pinned-action policy checks
- existing SBOM generation and contract validation on the pull request
- full attestation execution on the next `v*` release tag

## Notes

The current official `actions/attest` v4 action requires `artifact-metadata: write` in addition to OIDC and attestation permissions. Artifact attestations are supported for this public repository.