### PR TITLE
ci: skip native builds for explicitly non-native changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,43 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_native: ${{ steps.classify.outputs.run_native }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test change classifier
+        run: node --test scripts/classify-ci-changes.test.mjs
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            {
+              echo "run_native=true"
+              echo "reason=non-pull-request event; running the full native matrix"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t changed_paths < <(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+
+          node scripts/classify-ci-changes.mjs "${changed_paths[@]}" >> "$GITHUB_OUTPUT"
+
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -118,6 +155,8 @@ jobs:
         run: echo "Main library build and package outputs were validated by components-package"
 
   build-android:
+    needs: changes
+    if: needs.changes.outputs.run_native == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -178,6 +217,8 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
+    needs: changes
+    if: needs.changes.outputs.run_native == 'true'
     runs-on: macos-15
     timeout-minutes: 35
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
             exit 0
           fi
 
-          mapfile -t changed_paths < <(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          mapfile -t changed_paths < <(
+            git diff --no-renames --name-only "$BASE_SHA...$HEAD_SHA"
+          )
 
           node scripts/classify-ci-changes.mjs "${changed_paths[@]}" >> "$GITHUB_OUTPUT"
 

--- a/scripts/classify-ci-changes.mjs
+++ b/scripts/classify-ci-changes.mjs
@@ -1,0 +1,36 @@
+const SAFE_NON_NATIVE_PATTERNS = [
+  /^docs\//,
+  /^packages\/amaryllis-components\//,
+  /^[^/]+\.md$/,
+];
+
+export function classifyCiChanges(paths) {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    return {
+      runNative: true,
+      reason: 'no changed paths were available; running the full native matrix',
+    };
+  }
+
+  const unsafePaths = paths.filter(
+    path => !SAFE_NON_NATIVE_PATTERNS.some(pattern => pattern.test(path))
+  );
+
+  if (unsafePaths.length > 0) {
+    return {
+      runNative: true,
+      reason: `native-relevant or unknown paths changed: ${unsafePaths.join(', ')}`,
+    };
+  }
+
+  return {
+    runNative: false,
+    reason: 'all changed paths are explicitly classified as non-native',
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = classifyCiChanges(process.argv.slice(2));
+  process.stdout.write(`run_native=${result.runNative}\n`);
+  process.stdout.write(`reason=${result.reason}\n`);
+}

--- a/scripts/classify-ci-changes.test.mjs
+++ b/scripts/classify-ci-changes.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyCiChanges } from './classify-ci-changes.mjs';
+
+test('skips native builds for documentation-only changes', () => {
+  assert.deepEqual(classifyCiChanges(['docs/examples/README.md']), {
+    runNative: false,
+    reason: 'all changed paths are explicitly classified as non-native',
+  });
+});
+
+test('skips native builds for components-only changes', () => {
+  assert.equal(
+    classifyCiChanges([
+      'packages/amaryllis-components/src/generator/schema.ts',
+      'packages/amaryllis-components/src/__tests__/SchemaGenerator.test.ts',
+    ]).runNative,
+    false
+  );
+});
+
+test('skips native builds for root markdown changes', () => {
+  assert.equal(classifyCiChanges(['README.md', 'RELEASE.md']).runNative, false);
+});
+
+test('runs native builds for shared runtime changes', () => {
+  assert.equal(classifyCiChanges(['src/index.ts']).runNative, true);
+});
+
+test('runs native builds for lockfile and workflow changes', () => {
+  assert.equal(
+    classifyCiChanges(['yarn.lock', '.github/workflows/ci.yml']).runNative,
+    true
+  );
+});
+
+test('fails closed when no changed paths are available', () => {
+  assert.deepEqual(classifyCiChanges([]), {
+    runNative: true,
+    reason: 'no changed paths were available; running the full native matrix',
+  });
+});
+
+test('fails closed for unknown paths', () => {
+  assert.equal(classifyCiChanges(['tools/new-helper.ts']).runNative, true);
+});

--- a/scripts/classify-ci-changes.test.mjs
+++ b/scripts/classify-ci-changes.test.mjs
@@ -35,6 +35,33 @@ test('runs native builds for lockfile and workflow changes', () => {
   );
 });
 
+test('runs native builds when a native file is renamed into docs', () => {
+  assert.equal(
+    classifyCiChanges([
+      'example/android/app/src/main/java/com/amaryllis/Module.kt',
+      'docs/Module.kt',
+    ]).runNative,
+    true
+  );
+});
+
+test('runs native builds when a native file is renamed into components', () => {
+  assert.equal(
+    classifyCiChanges([
+      'example/ios/Amaryllis/Module.swift',
+      'packages/amaryllis-components/src/Module.ts',
+    ]).runNative,
+    true
+  );
+});
+
+test('skips native builds for renames entirely within allowlisted paths', () => {
+  assert.equal(
+    classifyCiChanges(['docs/old.md', 'docs/new.md']).runNative,
+    false
+  );
+});
+
 test('fails closed when no changed paths are available', () => {
   assert.deepEqual(classifyCiChanges([]), {
     runNative: true,


### PR DESCRIPTION
## Summary

- add a small, tested change classifier for CI
- skip Android and iOS builds only when every changed path is explicitly classified as non-native
- treat documentation, root Markdown, and `packages/amaryllis-components/**` as safe non-native changes
- fail closed for unknown paths, empty diffs, lockfiles, workflows, shared runtime, and root configuration
- always run the full native matrix for pushes and merge-queue events

## Safety model

This first slice intentionally does not attempt fine-grained Android-versus-iOS inference. Any path outside the narrow allowlist runs both native builds. A classifier test or execution failure fails the `changes` job and blocks CI rather than silently skipping native validation.

## Validation

- classifier unit tests run inside the `changes` job before its output is used
- this PR changes workflow and script files, so it should exercise the full Android and iOS matrix
- existing native job names remain unchanged for branch-protection compatibility
