### PR TITLE
docs: add release SBOM validation checklist

### DIFF
--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -37,6 +37,20 @@ The SBOM itself can also be checked against the repository contract:
 bash scripts/validate-sbom.sh amaryllis-vX.Y.Z.cdx.json
 ```
 
+## First-release validation checklist
+
+Validate the complete release path on the next real `v*` release rather than creating a disposable attestation record.
+
+- Confirm the `SBOM` workflow completes successfully for the release tag.
+- Confirm the GitHub Release exists and contains `amaryllis-vX.Y.Z.cdx.json`.
+- Download the asset and run `scripts/validate-sbom.sh` against it.
+- Run `gh attestation verify` and confirm the source repository and workflow identity.
+- Copy the downloaded file, change one byte, and confirm attestation verification fails for the modified copy.
+- Confirm the attestation subject name exactly matches the published release asset.
+- Record the workflow run, release, and verification result in the release notes or tracking issue.
+
+Treat any missing asset, failed contract validation, absent attestation, signer mismatch, or successful verification of a modified file as a release-blocking failure.
+
 ## Trust boundary
 
 Pull-request jobs retain read-only repository permissions and cannot request GitHub OIDC tokens or publish attestations. Only release-tag executions of the `publish-release` job receive:


### PR DESCRIPTION
## Summary

- add a concrete first-release validation checklist for the SBOM provenance path
- define release-blocking failure conditions for missing assets, invalid CycloneDX output, attestation identity mismatches, and tamper verification failures
- link the operational validation to issue #67

## Why

The release SBOM workflow and provenance attestation are implemented, but a disposable smoke release would leave a durable GitHub attestation record even after deleting the temporary tag and release. The safer validation strategy is to exercise the full path on the next real `v*` release and record the evidence.

## Validation

Documentation-only change. Existing workflow behavior is unchanged.

Closes no issue; issue #67 remains open until the next real release is validated.