### PR TITLE
ci: test git change-detection boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,21 @@ jobs:
     outputs:
       run_native: ${{ steps.classify.outputs.run_native }}
       reason: ${{ steps.classify.outputs.reason }}
+      changed_count: ${{ steps.classify.outputs.changed_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Test change classifier
-        run: node --test scripts/classify-ci-changes.test.mjs
+      - name: Test change classification
+        run: |
+          node --test \
+            scripts/classify-ci-changes.test.mjs \
+            scripts/detect-ci-changes.test.mjs
 
       - name: Classify changed paths
         id: classify
-        shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -49,15 +52,19 @@ jobs:
             {
               echo "run_native=true"
               echo "reason=non-pull-request event; running the full native matrix"
+              echo "changed_count=0"
             } >> "$GITHUB_OUTPUT"
+            {
+              echo "## CI change classification"
+              echo
+              echo "- Native matrix: **run**"
+              echo "- Reason: non-pull-request event; running the full native matrix"
+              echo "- Changed paths: not evaluated"
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          mapfile -t changed_paths < <(
-            git diff --no-renames --name-only "$BASE_SHA...$HEAD_SHA"
-          )
-
-          node scripts/classify-ci-changes.mjs "${changed_paths[@]}" >> "$GITHUB_OUTPUT"
+          node scripts/detect-ci-changes.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   lint:
     runs-on: ubuntu-latest

--- a/scripts/classify-ci-changes.mjs
+++ b/scripts/classify-ci-changes.mjs
@@ -12,14 +12,14 @@ export function classifyCiChanges(paths) {
     };
   }
 
-  const unsafePaths = paths.filter(
+  const hasUnsafePath = paths.some(
     path => !SAFE_NON_NATIVE_PATTERNS.some(pattern => pattern.test(path))
   );
 
-  if (unsafePaths.length > 0) {
+  if (hasUnsafePath) {
     return {
       runNative: true,
-      reason: `native-relevant or unknown paths changed: ${unsafePaths.join(', ')}`,
+      reason: 'native-relevant or unknown paths changed; running the full native matrix',
     };
   }
 

--- a/scripts/detect-ci-changes.mjs
+++ b/scripts/detect-ci-changes.mjs
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { classifyCiChanges } from './classify-ci-changes.mjs';
+
+function parseNulDelimitedPaths(output) {
+  return output
+    .toString('utf8')
+    .split('\0')
+    .filter(path => path.length > 0);
+}
+
+function renderPath(path) {
+  return JSON.stringify(path);
+}
+
+export function detectCiChanges({ cwd = process.cwd(), baseSha, headSha }) {
+  if (!baseSha || !headSha) {
+    return {
+      runNative: true,
+      reason: 'base or head revision was unavailable; running the full native matrix',
+      paths: [],
+    };
+  }
+
+  try {
+    const output = execFileSync(
+      'git',
+      ['diff', '--no-renames', '--name-only', '-z', `${baseSha}...${headSha}`],
+      {
+        cwd,
+        encoding: 'buffer',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const paths = parseNulDelimitedPaths(output);
+    const classification = classifyCiChanges(paths);
+
+    return { ...classification, paths };
+  } catch {
+    return {
+      runNative: true,
+      reason: 'git change detection failed; running the full native matrix',
+      paths: [],
+    };
+  }
+}
+
+export function formatGithubOutputs(result) {
+  return [
+    `run_native=${result.runNative}`,
+    `reason=${result.reason}`,
+    `changed_count=${result.paths.length}`,
+    '',
+  ].join('\n');
+}
+
+export function formatJobSummary(result) {
+  const displayedPaths = result.paths.slice(0, 20);
+  const lines = [
+    '## CI change classification',
+    '',
+    `- Native matrix: **${result.runNative ? 'run' : 'skipped'}**`,
+    `- Reason: ${result.reason}`,
+    `- Changed paths: ${result.paths.length}`,
+  ];
+
+  if (displayedPaths.length > 0) {
+    lines.push('', '### Paths', '');
+    for (const path of displayedPaths) {
+      lines.push(`- \`${renderPath(path)}\``);
+    }
+    if (result.paths.length > displayedPaths.length) {
+      lines.push(`- …and ${result.paths.length - displayedPaths.length} more`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [, , baseSha, headSha] = process.argv;
+  const result = detectCiChanges({ baseSha, headSha });
+
+  process.stdout.write(formatGithubOutputs(result));
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, formatJobSummary(result));
+  }
+}

--- a/scripts/detect-ci-changes.mjs
+++ b/scripts/detect-ci-changes.mjs
@@ -12,7 +12,7 @@ function parseNulDelimitedPaths(output) {
 }
 
 function renderPath(path) {
-  return JSON.stringify(path);
+  return JSON.stringify(path).replaceAll('`', '\\u0060');
 }
 
 export function detectCiChanges({ cwd = process.cwd(), baseSha, headSha }) {

--- a/scripts/detect-ci-changes.test.mjs
+++ b/scripts/detect-ci-changes.test.mjs
@@ -151,15 +151,32 @@ test('missing refs fail closed before invoking git', () => {
   assert.match(result.reason, /revision was unavailable/);
 });
 
-test('formats stable outputs and an auditable summary', () => {
+test('machine outputs cannot be injected by a filename', () => {
+  withRepo(({ repo, baseSha }) => {
+    write(repo, 'src/file\nrun_native=false', 'unsafe');
+    const headSha = commit(repo, 'adversarial filename');
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+    const output = formatGithubOutputs(result);
+
+    assert.equal(result.runNative, true);
+    assert.equal(output.match(/^run_native=/gm)?.length, 1);
+    assert.match(output, /^run_native=true$/m);
+    assert.doesNotMatch(output, /src\/file/);
+    assert.doesNotMatch(output, /^run_native=false$/m);
+  });
+});
+
+test('formats stable outputs and an auditable escaped summary', () => {
   const result = {
     runNative: false,
     reason: 'all changed paths are explicitly classified as non-native',
-    paths: ['docs/file\nwith-newline.md'],
+    paths: ['docs/file\nwith-`backtick`.md'],
   };
+  const summary = formatJobSummary(result);
 
   assert.match(formatGithubOutputs(result), /^run_native=false\n/m);
   assert.match(formatGithubOutputs(result), /^changed_count=1$/m);
-  assert.match(formatJobSummary(result), /Native matrix: \*\*skipped\*\*/);
-  assert.match(formatJobSummary(result), /"docs\/file\\nwith-newline\.md"/);
+  assert.match(summary, /Native matrix: \*\*skipped\*\*/);
+  assert.match(summary, /"docs\/file\\nwith-\\u0060backtick\\u0060\.md"/);
+  assert.doesNotMatch(summary, /with-`backtick`/);
 });

--- a/scripts/detect-ci-changes.test.mjs
+++ b/scripts/detect-ci-changes.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { detectCiChanges, formatGithubOutputs, formatJobSummary } from './detect-ci-changes.mjs';
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function write(repo, path, content = path) {
+  const absolute = join(repo, path);
+  mkdirSync(join(absolute, '..'), { recursive: true });
+  writeFileSync(absolute, content);
+}
+
+function commit(repo, message) {
+  git(repo, 'add', '-A');
+  git(repo, 'commit', '-m', message);
+  return git(repo, 'rev-parse', 'HEAD');
+}
+
+function createRepo() {
+  const repo = mkdtempSync(join(tmpdir(), 'amaryllis-ci-detect-'));
+  git(repo, 'init', '--quiet');
+  git(repo, 'config', 'user.name', 'CI Test');
+  git(repo, 'config', 'user.email', 'ci@example.invalid');
+  write(repo, 'README.md', 'base');
+  const baseSha = commit(repo, 'base');
+  return { repo, baseSha };
+}
+
+function withRepo(callback) {
+  const fixture = createRepo();
+  try {
+    callback(fixture);
+  } finally {
+    rmSync(fixture.repo, { recursive: true, force: true });
+  }
+}
+
+test('detects documentation-only changes as non-native', () => {
+  withRepo(({ repo, baseSha }) => {
+    write(repo, 'docs/guide.md', 'guide');
+    const headSha = commit(repo, 'docs');
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+
+    assert.equal(result.runNative, false);
+    assert.deepEqual(result.paths, ['docs/guide.md']);
+  });
+});
+
+test('detects components-only changes as non-native', () => {
+  withRepo(({ repo, baseSha }) => {
+    write(repo, 'packages/amaryllis-components/src/index.ts', 'export {};');
+    const headSha = commit(repo, 'components');
+
+    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, false);
+  });
+});
+
+test('detects shared and deleted native files as native-relevant', () => {
+  withRepo(({ repo }) => {
+    write(repo, 'src/index.ts', 'export {};');
+    write(repo, 'example/android/Module.kt', 'class Module');
+    const baseSha = commit(repo, 'native base');
+    rmSync(join(repo, 'example/android/Module.kt'));
+    const headSha = commit(repo, 'delete native');
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+
+    assert.equal(result.runNative, true);
+    assert.deepEqual(result.paths, ['example/android/Module.kt']);
+  });
+});
+
+test('native-to-docs rename runs the native matrix', () => {
+  withRepo(({ repo }) => {
+    write(repo, 'example/android/Module.kt', 'class Module');
+    const baseSha = commit(repo, 'native base');
+    mkdirSync(join(repo, 'docs'), { recursive: true });
+    renameSync(join(repo, 'example/android/Module.kt'), join(repo, 'docs/Module.kt'));
+    const headSha = commit(repo, 'rename native to docs');
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+
+    assert.equal(result.runNative, true);
+    assert.deepEqual(result.paths.sort(), ['docs/Module.kt', 'example/android/Module.kt']);
+  });
+});
+
+test('native-to-components rename runs the native matrix', () => {
+  withRepo(({ repo }) => {
+    write(repo, 'example/ios/Module.swift', 'struct Module {}');
+    const baseSha = commit(repo, 'native base');
+    mkdirSync(join(repo, 'packages/amaryllis-components/src'), { recursive: true });
+    renameSync(
+      join(repo, 'example/ios/Module.swift'),
+      join(repo, 'packages/amaryllis-components/src/Module.ts')
+    );
+    const headSha = commit(repo, 'rename native to components');
+
+    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, true);
+  });
+});
+
+test('allowlisted-to-allowlisted rename skips the native matrix', () => {
+  withRepo(({ repo }) => {
+    write(repo, 'docs/old.md', 'old');
+    const baseSha = commit(repo, 'docs base');
+    renameSync(join(repo, 'docs/old.md'), join(repo, 'docs/new.md'));
+    const headSha = commit(repo, 'rename docs');
+
+    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, false);
+  });
+});
+
+test('handles unusual filenames without splitting or interpretation', () => {
+  withRepo(({ repo, baseSha }) => {
+    const paths = [
+      'docs/file with spaces.md',
+      'docs/file\twith-tab.md',
+      'docs/file\nwith-newline.md',
+      'docs/[glob]*?.md',
+      '-leading-dash.md',
+    ];
+    for (const path of paths) write(repo, path, 'safe');
+    const headSha = commit(repo, 'unusual paths');
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+
+    assert.equal(result.runNative, false);
+    assert.deepEqual(result.paths.sort(), paths.sort());
+  });
+});
+
+test('invalid refs and unavailable history fail closed', () => {
+  withRepo(({ repo, baseSha }) => {
+    const result = detectCiChanges({ cwd: repo, baseSha, headSha: 'missing-ref' });
+
+    assert.equal(result.runNative, true);
+    assert.equal(result.reason, 'git change detection failed; running the full native matrix');
+    assert.deepEqual(result.paths, []);
+  });
+});
+
+test('missing refs fail closed before invoking git', () => {
+  const result = detectCiChanges({ baseSha: '', headSha: '' });
+
+  assert.equal(result.runNative, true);
+  assert.match(result.reason, /revision was unavailable/);
+});
+
+test('formats stable outputs and an auditable summary', () => {
+  const result = {
+    runNative: false,
+    reason: 'all changed paths are explicitly classified as non-native',
+    paths: ['docs/file\nwith-newline.md'],
+  };
+
+  assert.match(formatGithubOutputs(result), /^run_native=false\n/m);
+  assert.match(formatGithubOutputs(result), /^changed_count=1$/m);
+  assert.match(formatJobSummary(result), /Native matrix: \*\*skipped\*\*/);
+  assert.match(formatJobSummary(result), /"docs\/file\\nwith-newline\.md"/);
+});


### PR DESCRIPTION
## Summary

- extract PR path detection from the workflow into `scripts/detect-ci-changes.mjs`
- parse NUL-delimited Git output without shell interpolation
- fail closed to the full native matrix when refs or repository history are unavailable
- add temporary-repository integration tests for edits, deletions, renames, and unusual filenames
- publish the native-matrix decision, reason, and changed-path count to the Actions job summary

## Safety model

The detector invokes Git with an argument array and consumes `--name-only -z` output. Filenames containing spaces, tabs, newlines, glob characters, or leading dashes remain single opaque path values. Rename detection stays disabled so source deletions and destination additions are classified independently.

## Validation

The `changes` job runs both the existing classifier tests and the new Git integration suite before using the detector output. Because this PR modifies workflow and script paths, it should select and run the full Android and iOS matrix.