### PR TITLE
build: publish package-scoped CycloneDX SBOMs

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -20,6 +20,7 @@ on:
       - '**/*.gradle.kts'
       - '**/gradle.properties'
       - '**/libs.versions.toml'
+      - scripts/derive-package-sboms.mjs
       - scripts/validate-sbom.sh
       - .github/actions/setup/**
       - .github/workflows/sbom.yml
@@ -57,15 +58,25 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
-      - name: Validate SBOM contract
-        run: bash scripts/validate-sbom.sh artifacts/sbom.cdx.json
+      - name: Derive package-scoped SBOMs
+        run: node scripts/derive-package-sboms.mjs
 
-      - name: Upload SBOM artifact
+      - name: Validate SBOM contracts
+        run: |
+          set -euo pipefail
+          bash scripts/validate-sbom.sh artifacts/sbom.cdx.json
+          bash scripts/validate-sbom.sh artifacts/packages/react-native-amaryllis.cdx.json '@micrantha/react-native-amaryllis'
+          bash scripts/validate-sbom.sh artifacts/packages/amaryllis-core.cdx.json '@micrantha/amaryllis'
+          bash scripts/validate-sbom.sh artifacts/packages/amaryllis-components.cdx.json '@micrantha/amaryllis-components'
+
+      - name: Upload SBOM artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: amaryllis-sbom-cyclonedx
-          path: artifacts/sbom.cdx.json
+          path: |
+            artifacts/sbom.cdx.json
+            artifacts/packages/*.cdx.json
           if-no-files-found: error
           retention-days: 90
 
@@ -121,13 +132,32 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
-      - name: Validate release SBOM contract
-        run: bash scripts/validate-sbom.sh "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
+      - name: Derive versioned package SBOMs
+        run: |
+          set -euo pipefail
+          node scripts/derive-package-sboms.mjs \
+            "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json" \
+            artifacts/packages
+          mv artifacts/packages/react-native-amaryllis.cdx.json \
+            "artifacts/react-native-amaryllis-${GITHUB_REF_NAME}.cdx.json"
+          mv artifacts/packages/amaryllis-core.cdx.json \
+            "artifacts/amaryllis-core-${GITHUB_REF_NAME}.cdx.json"
+          mv artifacts/packages/amaryllis-components.cdx.json \
+            "artifacts/amaryllis-components-${GITHUB_REF_NAME}.cdx.json"
+          rmdir artifacts/packages
+
+      - name: Validate release SBOM contracts
+        run: |
+          set -euo pipefail
+          bash scripts/validate-sbom.sh "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json"
+          bash scripts/validate-sbom.sh "artifacts/react-native-amaryllis-${GITHUB_REF_NAME}.cdx.json" '@micrantha/react-native-amaryllis'
+          bash scripts/validate-sbom.sh "artifacts/amaryllis-core-${GITHUB_REF_NAME}.cdx.json" '@micrantha/amaryllis'
+          bash scripts/validate-sbom.sh "artifacts/amaryllis-components-${GITHUB_REF_NAME}.cdx.json" '@micrantha/amaryllis-components'
 
       - name: Attest release SBOM provenance
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
-          subject-path: artifacts/amaryllis-${{ github.ref_name }}.cdx.json
+          subject-path: artifacts/*.cdx.json
 
       - name: Ensure GitHub Release exists
         env:
@@ -141,11 +171,9 @@ jobs:
               --generate-notes
           fi
 
-      - name: Publish SBOM release asset
+      - name: Publish SBOM release assets
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          gh release upload "${GITHUB_REF_NAME}" \
-            "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json" \
-            --clobber
+          gh release upload "${GITHUB_REF_NAME}" artifacts/*.cdx.json --clobber

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,31 +1,54 @@
 # Software bill of materials
 
-Amaryllis generates a CycloneDX 1.6 software bill of materials (SBOM) from the repository dependency inventory.
+Amaryllis generates CycloneDX 1.6 software bills of materials (SBOMs) from the repository dependency inventory.
 
 ## Pull requests and main
 
-Dependency-related pull requests generate and validate `artifacts/sbom.cdx.json`. The workflow retains the file as the `amaryllis-sbom-cyclonedx` Actions artifact for 90 days, including when validation fails.
+Dependency-related pull requests generate and validate:
 
-Pushes to `main` also submit the generated dependency inventory to GitHub's dependency graph.
+- `artifacts/sbom.cdx.json`, the complete repository inventory
+- `artifacts/packages/react-native-amaryllis.cdx.json`
+- `artifacts/packages/amaryllis-core.cdx.json`
+- `artifacts/packages/amaryllis-components.cdx.json`
+
+The workflow retains the files in the `amaryllis-sbom-cyclonedx` Actions artifact for 90 days, including when validation fails.
+
+Pushes to `main` also submit the complete repository inventory to GitHub's dependency graph.
+
+## Package scope
+
+Package SBOMs are derived from the resolved repository dependency graph. Each one uses the published npm package as its CycloneDX root component and retains only components reachable from that package's dependency node.
+
+Choose the SBOM matching what you consume:
+
+- `react-native-amaryllis-*` for `@micrantha/react-native-amaryllis`
+- `amaryllis-core-*` for `@micrantha/amaryllis`
+- `amaryllis-components-*` for `@micrantha/amaryllis-components`
+- `amaryllis-*` for maintainers who need the complete monorepo, example application, tooling, and native dependency inventory
+
+The React Native package SBOM includes dependencies represented in the repository graph, including its shared Amaryllis core dependency. Native Android and iOS dependencies remain visible when they are connected to the package in the generated graph. The components and core package SBOMs do not include unrelated example-application or workspace tooling branches.
 
 ## Releases
 
-Pushing a `v*` tag generates and validates a versioned release asset named:
+Pushing a `v*` tag generates and validates four versioned release assets:
 
 ```text
 amaryllis-vX.Y.Z.cdx.json
+react-native-amaryllis-vX.Y.Z.cdx.json
+amaryllis-core-vX.Y.Z.cdx.json
+amaryllis-components-vX.Y.Z.cdx.json
 ```
 
-The release job creates the GitHub Release when it does not already exist, signs an artifact-provenance attestation for the validated SBOM, and then uploads the SBOM to the release.
+The release job creates the GitHub Release when it does not already exist, signs artifact-provenance attestations for every validated SBOM, and then uploads all four files to the release.
 
-The attestation binds the exact SBOM filename and digest to the GitHub Actions workflow and source revision that generated it. The OIDC and attestation write permissions are limited to the tag-only release job.
+Each attestation binds the exact SBOM filename and digest to the GitHub Actions workflow and source revision that generated it. The OIDC and attestation write permissions are limited to the tag-only release job.
 
 ## Verification
 
-Download the SBOM from the GitHub Release, then verify its attestation with GitHub CLI:
+Download the relevant SBOM from the GitHub Release, then verify its attestation with GitHub CLI:
 
 ```sh
-gh attestation verify amaryllis-vX.Y.Z.cdx.json \
+gh attestation verify react-native-amaryllis-vX.Y.Z.cdx.json \
   --repo hackelia-micrantha/amaryllis
 ```
 
@@ -34,30 +57,34 @@ Verification should identify `hackelia-micrantha/amaryllis` as the source reposi
 The SBOM itself can also be checked against the repository contract:
 
 ```sh
-bash scripts/validate-sbom.sh amaryllis-vX.Y.Z.cdx.json
+bash scripts/validate-sbom.sh \
+  react-native-amaryllis-vX.Y.Z.cdx.json \
+  '@micrantha/react-native-amaryllis'
 ```
+
+Omit the package-name argument when validating the repository-wide SBOM.
 
 ## First-release validation checklist
 
 Validate the complete release path on the next real `v*` release rather than creating a disposable attestation record.
 
 - Confirm the `SBOM` workflow completes successfully for the release tag.
-- Confirm the GitHub Release exists and contains `amaryllis-vX.Y.Z.cdx.json`.
-- Download the asset and run `scripts/validate-sbom.sh` against it.
-- Run `gh attestation verify` and confirm the source repository and workflow identity.
-- Copy the downloaded file, change one byte, and confirm attestation verification fails for the modified copy.
-- Confirm the attestation subject name exactly matches the published release asset.
+- Confirm the GitHub Release contains all four expected SBOM assets.
+- Download each asset and run `scripts/validate-sbom.sh` with its expected package identity.
+- Run `gh attestation verify` for every asset and confirm the source repository and workflow identity.
+- Copy one downloaded file, change one byte, and confirm attestation verification fails for the modified copy.
+- Confirm every attestation subject name exactly matches its published release asset.
 - Record the workflow run, release, and verification result in the release notes or tracking issue.
 
-Treat any missing asset, failed contract validation, absent attestation, signer mismatch, or successful verification of a modified file as a release-blocking failure.
+Treat any missing asset, failed contract validation, absent attestation, signer mismatch, package-root mismatch, or successful verification of a modified file as a release-blocking failure.
 
 ## Trust boundary
 
 Pull-request jobs retain read-only repository permissions and cannot request GitHub OIDC tokens or publish attestations. Only release-tag executions of the `publish-release` job receive:
 
-- `contents: write`, to create the release and upload its SBOM
+- `contents: write`, to create the release and upload its SBOMs
 - `id-token: write`, to request the short-lived signing identity
-- `attestations: write`, to publish the signed attestation
+- `attestations: write`, to publish the signed attestations
 - `artifact-metadata: write`, as required by the pinned attestation action
 
 Third-party actions in the workflow are pinned to full commit SHAs.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -19,7 +19,7 @@ Pushes to `main` also submit the complete repository inventory to GitHub's depen
 
 Package SBOMs use each published `package.json` as the source of truth. Each file has the package's exact name, version, npm PURL, and `bom-ref` as its CycloneDX root component.
 
-Required dependencies are resolved against the repository inventory and retain their transitive dependency closure. Peer dependencies are recorded as optional direct dependencies because the consuming application supplies them. Development-only dependencies and unrelated workspace or example-application branches are excluded.
+Required dependencies are resolved to exact versions through `yarn.lock`, and their transitive production dependency closure is retained. Matching Syft components enrich those lockfile-derived identities when available. Peer dependencies are recorded with their declared ranges as optional direct dependencies because the consuming application supplies them. Development-only dependencies and unrelated workspace or example-application branches are excluded.
 
 Choose the SBOM matching what you consume:
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -17,7 +17,9 @@ Pushes to `main` also submit the complete repository inventory to GitHub's depen
 
 ## Package scope
 
-Package SBOMs are derived from the resolved repository dependency graph. Each one uses the published npm package as its CycloneDX root component and retains only components reachable from that package's dependency node.
+Package SBOMs use each published `package.json` as the source of truth. Each file has the package's exact name, version, npm PURL, and `bom-ref` as its CycloneDX root component.
+
+Required dependencies are resolved against the repository inventory and retain their transitive dependency closure. Peer dependencies are recorded as optional direct dependencies because the consuming application supplies them. Development-only dependencies and unrelated workspace or example-application branches are excluded.
 
 Choose the SBOM matching what you consume:
 
@@ -26,7 +28,7 @@ Choose the SBOM matching what you consume:
 - `amaryllis-components-*` for `@micrantha/amaryllis-components`
 - `amaryllis-*` for maintainers who need the complete monorepo, example application, tooling, and native dependency inventory
 
-The React Native package SBOM includes dependencies represented in the repository graph, including its shared Amaryllis core dependency. Native Android and iOS dependencies remain visible when they are connected to the package in the generated graph. The components and core package SBOMs do not include unrelated example-application or workspace tooling branches.
+The React Native package SBOM includes its published JavaScript dependency on the shared Amaryllis core package and its declared peers. Use the repository-wide SBOM when auditing Android, iOS, build-tooling, or other repository dependencies that are not expressed in the npm package manifest.
 
 ## Releases
 

--- a/scripts/derive-package-sboms.mjs
+++ b/scripts/derive-package-sboms.mjs
@@ -65,7 +65,10 @@ function parseYarnLock(lockText) {
 
     if (!current) continue;
 
-    const fieldMatch = rawLine.match(/^  ([^:]+):(?:\s+(.*))?$/);
+    // Top-level entry fields are indented by exactly two spaces. Require the
+    // field name to begin immediately after that indentation so nested
+    // dependency entries are not consumed by this branch.
+    const fieldMatch = rawLine.match(/^  (\S[^:]*):(?:\s+(.*))?$/);
     if (fieldMatch) {
       const [, field, rawValue] = fieldMatch;
       if (rawValue === undefined) {

--- a/scripts/derive-package-sboms.mjs
+++ b/scripts/derive-package-sboms.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const [inputPath = 'artifacts/sbom.cdx.json', outputDir = 'artifacts/packages'] =
+  process.argv.slice(2);
+
+const source = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+const components = Array.isArray(source.components) ? source.components : [];
+const dependencies = Array.isArray(source.dependencies) ? source.dependencies : [];
+const dependencyByRef = new Map(
+  dependencies.map((dependency) => [dependency.ref, dependency.dependsOn ?? []])
+);
+
+const packages = [
+  {
+    name: '@micrantha/react-native-amaryllis',
+    slug: 'react-native-amaryllis',
+  },
+  {
+    name: '@micrantha/amaryllis',
+    slug: 'amaryllis-core',
+  },
+  {
+    name: '@micrantha/amaryllis-components',
+    slug: 'amaryllis-components',
+  },
+];
+
+function npmPurlPrefix(name) {
+  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@`;
+}
+
+function findRoot(packageName) {
+  const prefix = npmPurlPrefix(packageName);
+  const matches = components.filter((component) => component.purl?.startsWith(prefix));
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one SBOM component for ${packageName}, found ${matches.length}`
+    );
+  }
+
+  return matches[0];
+}
+
+function collectClosure(rootRef) {
+  const visited = new Set();
+  const pending = [rootRef];
+
+  while (pending.length > 0) {
+    const ref = pending.pop();
+    if (!ref || visited.has(ref)) continue;
+    visited.add(ref);
+
+    for (const dependency of dependencyByRef.get(ref) ?? []) {
+      pending.push(dependency);
+    }
+  }
+
+  return visited;
+}
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+for (const packageSpec of packages) {
+  const root = findRoot(packageSpec.name);
+  const rootRef = root['bom-ref'];
+  if (!rootRef) {
+    throw new Error(`SBOM component for ${packageSpec.name} has no bom-ref`);
+  }
+
+  const closure = collectClosure(rootRef);
+  const packageComponents = components.filter(
+    (component) => component['bom-ref'] && closure.has(component['bom-ref'])
+  );
+  const packageDependencies = dependencies
+    .filter((dependency) => closure.has(dependency.ref))
+    .map((dependency) => ({
+      ...dependency,
+      dependsOn: (dependency.dependsOn ?? []).filter((ref) => closure.has(ref)),
+    }));
+
+  const output = {
+    ...source,
+    serialNumber: undefined,
+    metadata: {
+      ...source.metadata,
+      component: root,
+    },
+    components: packageComponents.filter(
+      (component) => component['bom-ref'] !== rootRef
+    ),
+    dependencies: packageDependencies,
+  };
+
+  const outputPath = path.join(outputDir, `${packageSpec.slug}.cdx.json`);
+  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
+  console.log(
+    `Derived ${outputPath}: ${packageComponents.length} components, ${packageDependencies.length} dependency nodes`
+  );
+}

--- a/scripts/derive-package-sboms.mjs
+++ b/scripts/derive-package-sboms.mjs
@@ -32,7 +32,7 @@ const packageSpecs = [
 }));
 
 function npmPurl(name, version) {
-  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@${version}`;
+  return `pkg:npm/${encodeURIComponent(name).replace(/%2F/g, '/')}@${version}`;
 }
 
 function componentNameFromPurl(component) {

--- a/scripts/derive-package-sboms.mjs
+++ b/scripts/derive-package-sboms.mjs
@@ -7,80 +7,169 @@ const [inputPath = 'artifacts/sbom.cdx.json', outputDir = 'artifacts/packages'] 
   process.argv.slice(2);
 
 const source = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
-const components = Array.isArray(source.components) ? source.components : [];
-const dependencies = Array.isArray(source.dependencies) ? source.dependencies : [];
-const dependencyByRef = new Map(
-  dependencies.map((dependency) => [dependency.ref, dependency.dependsOn ?? []])
+const sourceComponents = Array.isArray(source.components) ? source.components : [];
+const sourceDependencies = Array.isArray(source.dependencies) ? source.dependencies : [];
+const sourceDependencyByRef = new Map(
+  sourceDependencies.map((dependency) => [dependency.ref, dependency.dependsOn ?? []])
 );
 
-const packages = [
+const packageSpecs = [
   {
-    name: '@micrantha/react-native-amaryllis',
+    manifestPath: 'package.json',
     slug: 'react-native-amaryllis',
   },
   {
-    name: '@micrantha/amaryllis',
+    manifestPath: 'packages/amaryllis/package.json',
     slug: 'amaryllis-core',
   },
   {
-    name: '@micrantha/amaryllis-components',
+    manifestPath: 'packages/amaryllis-components/package.json',
     slug: 'amaryllis-components',
   },
-];
+].map((spec) => ({
+  ...spec,
+  manifest: JSON.parse(fs.readFileSync(spec.manifestPath, 'utf8')),
+}));
 
-function npmPurlPrefix(name) {
-  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@`;
+function npmPurl(name, version) {
+  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@${version}`;
 }
 
-function findRoot(packageName) {
-  const prefix = npmPurlPrefix(packageName);
-  const matches = components.filter((component) => component.purl?.startsWith(prefix));
+function componentNameFromPurl(component) {
+  const purl = component.purl;
+  if (typeof purl !== 'string' || !purl.startsWith('pkg:npm/')) return null;
+  const withoutPrefix = purl.slice('pkg:npm/'.length);
+  const versionSeparator = withoutPrefix.lastIndexOf('@');
+  if (versionSeparator <= 0) return null;
+  return decodeURIComponent(withoutPrefix.slice(0, versionSeparator));
+}
 
+function createPublishedRoot(manifest) {
+  const purl = npmPurl(manifest.name, manifest.version);
+  return {
+    type: 'library',
+    name: manifest.name,
+    version: manifest.version,
+    purl,
+    'bom-ref': purl,
+  };
+}
+
+const publishedByName = new Map(
+  packageSpecs.map((spec) => [spec.manifest.name, { ...spec, root: createPublishedRoot(spec.manifest) }])
+);
+
+const sourceComponentsByName = new Map();
+for (const component of sourceComponents) {
+  const name = componentNameFromPurl(component);
+  if (!name) continue;
+  const matches = sourceComponentsByName.get(name) ?? [];
+  matches.push(component);
+  sourceComponentsByName.set(name, matches);
+}
+
+function resolveExternalComponent(packageName) {
+  const matches = sourceComponentsByName.get(packageName) ?? [];
   if (matches.length !== 1) {
     throw new Error(
-      `expected exactly one SBOM component for ${packageName}, found ${matches.length}`
+      `expected exactly one resolved component for production dependency ${packageName}, found ${matches.length}`
     );
   }
-
   return matches[0];
 }
 
-function collectClosure(rootRef) {
+function resolveComponent(packageName, scope) {
+  const published = publishedByName.get(packageName);
+  const component = published?.root ?? resolveExternalComponent(packageName);
+  return scope === 'optional' ? { ...component, scope: 'optional' } : component;
+}
+
+function collectExternalClosure(startRefs) {
   const visited = new Set();
-  const pending = [rootRef];
+  const pending = [...startRefs];
 
   while (pending.length > 0) {
     const ref = pending.pop();
     if (!ref || visited.has(ref)) continue;
     visited.add(ref);
 
-    for (const dependency of dependencyByRef.get(ref) ?? []) {
-      pending.push(dependency);
+    for (const dependencyRef of sourceDependencyByRef.get(ref) ?? []) {
+      pending.push(dependencyRef);
     }
   }
 
   return visited;
 }
 
+function directDependencyEntries(manifest) {
+  return [
+    ...Object.keys(manifest.dependencies ?? {}).map((name) => ({ name, scope: 'required' })),
+    ...Object.keys(manifest.peerDependencies ?? {}).map((name) => ({ name, scope: 'optional' })),
+  ];
+}
+
 fs.mkdirSync(outputDir, { recursive: true });
 
-for (const packageSpec of packages) {
-  const root = findRoot(packageSpec.name);
-  const rootRef = root['bom-ref'];
-  if (!rootRef) {
-    throw new Error(`SBOM component for ${packageSpec.name} has no bom-ref`);
+for (const packageSpec of packageSpecs) {
+  const manifest = packageSpec.manifest;
+  const root = publishedByName.get(manifest.name).root;
+  const componentByRef = new Map();
+  const dependencyByRef = new Map();
+  const pendingPublished = [manifest.name];
+  const processedPublished = new Set();
+
+  while (pendingPublished.length > 0) {
+    const publishedName = pendingPublished.pop();
+    if (processedPublished.has(publishedName)) continue;
+    processedPublished.add(publishedName);
+
+    const publishedSpec = publishedByName.get(publishedName);
+    const publishedRoot = publishedSpec.root;
+    if (publishedName !== manifest.name) {
+      componentByRef.set(publishedRoot['bom-ref'], publishedRoot);
+    }
+
+    const directEntries = directDependencyEntries(publishedSpec.manifest);
+    const directRefs = [];
+    const requiredExternalRefs = [];
+
+    for (const entry of directEntries) {
+      const component = resolveComponent(entry.name, entry.scope);
+      const ref = component['bom-ref'];
+      if (!ref) {
+        throw new Error(`resolved component for ${entry.name} has no bom-ref`);
+      }
+
+      directRefs.push(ref);
+      if (entry.name !== manifest.name) {
+        componentByRef.set(ref, component);
+      }
+
+      if (publishedByName.has(entry.name)) {
+        pendingPublished.push(entry.name);
+      } else if (entry.scope === 'required') {
+        requiredExternalRefs.push(ref);
+      } else {
+        dependencyByRef.set(ref, []);
+      }
+    }
+
+    dependencyByRef.set(publishedRoot['bom-ref'], directRefs);
+
+    const externalClosure = collectExternalClosure(requiredExternalRefs);
+    for (const ref of externalClosure) {
+      const component = sourceComponents.find((candidate) => candidate['bom-ref'] === ref);
+      if (component) componentByRef.set(ref, component);
+      dependencyByRef.set(
+        ref,
+        (sourceDependencyByRef.get(ref) ?? []).filter((dependencyRef) =>
+          externalClosure.has(dependencyRef)
+        )
+      );
+    }
   }
 
-  const closure = collectClosure(rootRef);
-  const packageComponents = components.filter(
-    (component) => component['bom-ref'] && closure.has(component['bom-ref'])
-  );
-  const packageDependencies = dependencies
-    .filter((dependency) => closure.has(dependency.ref))
-    .map((dependency) => ({
-      ...dependency,
-      dependsOn: (dependency.dependsOn ?? []).filter((ref) => closure.has(ref)),
-    }));
+  componentByRef.delete(root['bom-ref']);
 
   const output = {
     ...source,
@@ -89,15 +178,17 @@ for (const packageSpec of packages) {
       ...source.metadata,
       component: root,
     },
-    components: packageComponents.filter(
-      (component) => component['bom-ref'] !== rootRef
+    components: [...componentByRef.values()].sort((a, b) =>
+      String(a['bom-ref']).localeCompare(String(b['bom-ref']))
     ),
-    dependencies: packageDependencies,
+    dependencies: [...dependencyByRef.entries()]
+      .map(([ref, dependsOn]) => ({ ref, dependsOn: [...new Set(dependsOn)].sort() }))
+      .sort((a, b) => a.ref.localeCompare(b.ref)),
   };
 
   const outputPath = path.join(outputDir, `${packageSpec.slug}.cdx.json`);
   fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
   console.log(
-    `Derived ${outputPath}: ${packageComponents.length} components, ${packageDependencies.length} dependency nodes`
+    `Derived ${outputPath}: ${output.components.length + 1} components, ${output.dependencies.length} dependency nodes`
   );
 }

--- a/scripts/derive-package-sboms.mjs
+++ b/scripts/derive-package-sboms.mjs
@@ -8,20 +8,13 @@ const [inputPath = 'artifacts/sbom.cdx.json', outputDir = 'artifacts/packages'] 
 
 const source = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
 const sourceComponents = Array.isArray(source.components) ? source.components : [];
-const sourceDependencies = Array.isArray(source.dependencies) ? source.dependencies : [];
-const sourceDependencyByRef = new Map(
-  sourceDependencies.map((dependency) => [dependency.ref, dependency.dependsOn ?? []])
+const sourceComponentsByPurl = new Map(
+  sourceComponents.filter((component) => component.purl).map((component) => [component.purl, component])
 );
 
 const packageSpecs = [
-  {
-    manifestPath: 'package.json',
-    slug: 'react-native-amaryllis',
-  },
-  {
-    manifestPath: 'packages/amaryllis/package.json',
-    slug: 'amaryllis-core',
-  },
+  { manifestPath: 'package.json', slug: 'react-native-amaryllis' },
+  { manifestPath: 'packages/amaryllis/package.json', slug: 'amaryllis-core' },
   {
     manifestPath: 'packages/amaryllis-components/package.json',
     slug: 'amaryllis-components',
@@ -31,17 +24,80 @@ const packageSpecs = [
   manifest: JSON.parse(fs.readFileSync(spec.manifestPath, 'utf8')),
 }));
 
-function npmPurl(name, version) {
-  return `pkg:npm/${encodeURIComponent(name).replace(/%2F/g, '/')}@${version}`;
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
 }
 
-function componentNameFromPurl(component) {
-  const purl = component.purl;
-  if (typeof purl !== 'string' || !purl.startsWith('pkg:npm/')) return null;
-  const withoutPrefix = purl.slice('pkg:npm/'.length);
-  const versionSeparator = withoutPrefix.lastIndexOf('@');
-  if (versionSeparator <= 0) return null;
-  return decodeURIComponent(withoutPrefix.slice(0, versionSeparator));
+function parseYarnLock(lockText) {
+  const descriptorMap = new Map();
+  let current = null;
+  let section = null;
+
+  function commit() {
+    if (!current) return;
+    for (const descriptor of current.descriptors) {
+      descriptorMap.set(descriptor, current);
+    }
+  }
+
+  for (const rawLine of lockText.split(/\r?\n/)) {
+    if (!rawLine || rawLine.startsWith('#') || rawLine.startsWith('__metadata:')) continue;
+
+    if (!rawLine.startsWith(' ') && rawLine.endsWith(':')) {
+      commit();
+      const key = unquote(rawLine.slice(0, -1));
+      current = {
+        descriptors: key.split(', ').map(unquote),
+        version: null,
+        resolution: null,
+        dependencies: {},
+      };
+      section = null;
+      continue;
+    }
+
+    if (!current) continue;
+
+    const fieldMatch = rawLine.match(/^  ([^:]+):(?:\s+(.*))?$/);
+    if (fieldMatch) {
+      const [, field, rawValue] = fieldMatch;
+      if (rawValue === undefined) {
+        section = field;
+      } else {
+        section = null;
+        const value = unquote(rawValue);
+        if (field === 'version') current.version = value;
+        if (field === 'resolution') current.resolution = value;
+      }
+      continue;
+    }
+
+    const nestedMatch = rawLine.match(/^    (.+?):\s+(.+)$/);
+    if (nestedMatch && section === 'dependencies') {
+      const [, name, range] = nestedMatch;
+      current.dependencies[unquote(name)] = unquote(range);
+    }
+  }
+
+  commit();
+  return descriptorMap;
+}
+
+const lockDescriptors = parseYarnLock(fs.readFileSync('yarn.lock', 'utf8'));
+
+function npmPath(name) {
+  return encodeURIComponent(name).replace(/%2F/g, '/');
+}
+
+function npmPurl(name, version) {
+  return `pkg:npm/${npmPath(name)}@${encodeURIComponent(version)}`;
 }
 
 function createPublishedRoot(manifest) {
@@ -55,57 +111,70 @@ function createPublishedRoot(manifest) {
   };
 }
 
+function createPeerComponent(name, range) {
+  const purl = npmPurl(name, range);
+  return {
+    type: 'library',
+    name,
+    version: range,
+    scope: 'optional',
+    purl,
+    'bom-ref': purl,
+    properties: [
+      {
+        name: 'cdx:npm:dependencyType',
+        value: 'peer',
+      },
+    ],
+  };
+}
+
 const publishedByName = new Map(
-  packageSpecs.map((spec) => [spec.manifest.name, { ...spec, root: createPublishedRoot(spec.manifest) }])
+  packageSpecs.map((spec) => [
+    spec.manifest.name,
+    { ...spec, root: createPublishedRoot(spec.manifest) },
+  ])
 );
 
-const sourceComponentsByName = new Map();
-for (const component of sourceComponents) {
-  const name = componentNameFromPurl(component);
-  if (!name) continue;
-  const matches = sourceComponentsByName.get(name) ?? [];
-  matches.push(component);
-  sourceComponentsByName.set(name, matches);
+function descriptorFor(name, range) {
+  if (range.startsWith('npm:')) return `${name}@${range}`;
+  return `${name}@npm:${range}`;
 }
 
-function resolveExternalComponent(packageName) {
-  const matches = sourceComponentsByName.get(packageName) ?? [];
-  if (matches.length !== 1) {
-    throw new Error(
-      `expected exactly one resolved component for production dependency ${packageName}, found ${matches.length}`
-    );
+function resolveLockedPackage(name, range) {
+  const descriptor = descriptorFor(name, range);
+  const locked = lockDescriptors.get(descriptor);
+  if (!locked?.version) {
+    throw new Error(`Yarn lockfile has no exact resolution for ${descriptor}`);
   }
-  return matches[0];
+  return locked;
 }
 
-function resolveComponent(packageName, scope) {
-  const published = publishedByName.get(packageName);
-  const component = published?.root ?? resolveExternalComponent(packageName);
-  return scope === 'optional' ? { ...component, scope: 'optional' } : component;
+function createLockedComponent(name, locked) {
+  const purl = npmPurl(name, locked.version);
+  const enriched = sourceComponentsByPurl.get(purl);
+  return {
+    ...(enriched ?? {}),
+    type: enriched?.type ?? 'library',
+    name,
+    version: locked.version,
+    purl,
+    'bom-ref': purl,
+  };
 }
 
-function collectExternalClosure(startRefs) {
-  const visited = new Set();
-  const pending = [...startRefs];
-
-  while (pending.length > 0) {
-    const ref = pending.pop();
-    if (!ref || visited.has(ref)) continue;
-    visited.add(ref);
-
-    for (const dependencyRef of sourceDependencyByRef.get(ref) ?? []) {
-      pending.push(dependencyRef);
-    }
-  }
-
-  return visited;
+function requiredEntries(manifest) {
+  return Object.entries(manifest.dependencies ?? {}).map(([name, range]) => ({
+    name,
+    range,
+  }));
 }
 
-function directDependencyEntries(manifest) {
-  return [
-    ...Object.keys(manifest.dependencies ?? {}).map((name) => ({ name, scope: 'required' })),
-    ...Object.keys(manifest.peerDependencies ?? {}).map((name) => ({ name, scope: 'optional' })),
-  ];
+function peerEntries(manifest) {
+  return Object.entries(manifest.peerDependencies ?? {}).map(([name, range]) => ({
+    name,
+    range,
+  }));
 }
 
 fs.mkdirSync(outputDir, { recursive: true });
@@ -117,6 +186,8 @@ for (const packageSpec of packageSpecs) {
   const dependencyByRef = new Map();
   const pendingPublished = [manifest.name];
   const processedPublished = new Set();
+  const pendingLocked = [];
+  const processedLocked = new Set();
 
   while (pendingPublished.length > 0) {
     const publishedName = pendingPublished.pop();
@@ -129,44 +200,51 @@ for (const packageSpec of packageSpecs) {
       componentByRef.set(publishedRoot['bom-ref'], publishedRoot);
     }
 
-    const directEntries = directDependencyEntries(publishedSpec.manifest);
     const directRefs = [];
-    const requiredExternalRefs = [];
 
-    for (const entry of directEntries) {
-      const component = resolveComponent(entry.name, entry.scope);
-      const ref = component['bom-ref'];
-      if (!ref) {
-        throw new Error(`resolved component for ${entry.name} has no bom-ref`);
-      }
-
-      directRefs.push(ref);
-      if (entry.name !== manifest.name) {
-        componentByRef.set(ref, component);
-      }
-
-      if (publishedByName.has(entry.name)) {
-        pendingPublished.push(entry.name);
-      } else if (entry.scope === 'required') {
-        requiredExternalRefs.push(ref);
+    for (const { name, range } of requiredEntries(publishedSpec.manifest)) {
+      const publishedDependency = publishedByName.get(name);
+      if (publishedDependency) {
+        directRefs.push(publishedDependency.root['bom-ref']);
+        componentByRef.set(publishedDependency.root['bom-ref'], publishedDependency.root);
+        pendingPublished.push(name);
       } else {
-        dependencyByRef.set(ref, []);
+        const locked = resolveLockedPackage(name, range);
+        const component = createLockedComponent(name, locked);
+        directRefs.push(component['bom-ref']);
+        componentByRef.set(component['bom-ref'], component);
+        pendingLocked.push({ name, locked });
       }
     }
 
-    dependencyByRef.set(publishedRoot['bom-ref'], directRefs);
-
-    const externalClosure = collectExternalClosure(requiredExternalRefs);
-    for (const ref of externalClosure) {
-      const component = sourceComponents.find((candidate) => candidate['bom-ref'] === ref);
-      if (component) componentByRef.set(ref, component);
-      dependencyByRef.set(
-        ref,
-        (sourceDependencyByRef.get(ref) ?? []).filter((dependencyRef) =>
-          externalClosure.has(dependencyRef)
-        )
-      );
+    for (const { name, range } of peerEntries(publishedSpec.manifest)) {
+      const peer = createPeerComponent(name, range);
+      directRefs.push(peer['bom-ref']);
+      componentByRef.set(peer['bom-ref'], peer);
+      dependencyByRef.set(peer['bom-ref'], []);
     }
+
+    dependencyByRef.set(publishedRoot['bom-ref'], [...new Set(directRefs)].sort());
+  }
+
+  while (pendingLocked.length > 0) {
+    const { name, locked } = pendingLocked.pop();
+    const key = `${name}@${locked.version}`;
+    if (processedLocked.has(key)) continue;
+    processedLocked.add(key);
+
+    const component = createLockedComponent(name, locked);
+    const dependencyRefs = [];
+
+    for (const [dependencyName, dependencyRange] of Object.entries(locked.dependencies)) {
+      const dependencyLocked = resolveLockedPackage(dependencyName, dependencyRange);
+      const dependencyComponent = createLockedComponent(dependencyName, dependencyLocked);
+      dependencyRefs.push(dependencyComponent['bom-ref']);
+      componentByRef.set(dependencyComponent['bom-ref'], dependencyComponent);
+      pendingLocked.push({ name: dependencyName, locked: dependencyLocked });
+    }
+
+    dependencyByRef.set(component['bom-ref'], [...new Set(dependencyRefs)].sort());
   }
 
   componentByRef.delete(root['bom-ref']);
@@ -182,7 +260,7 @@ for (const packageSpec of packageSpecs) {
       String(a['bom-ref']).localeCompare(String(b['bom-ref']))
     ),
     dependencies: [...dependencyByRef.entries()]
-      .map(([ref, dependsOn]) => ({ ref, dependsOn: [...new Set(dependsOn)].sort() }))
+      .map(([ref, dependsOn]) => ({ ref, dependsOn }))
       .sort((a, b) => a.ref.localeCompare(b.ref)),
   };
 

--- a/scripts/validate-sbom.sh
+++ b/scripts/validate-sbom.sh
@@ -40,6 +40,8 @@ if (!Array.isArray(sbom.dependencies) || sbom.dependencies.length === 0) {
 
 const allComponents = root ? [root, ...sbom.components] : sbom.components;
 const purls = allComponents.map((component) => component.purl).filter(Boolean);
+const componentByName = new Map(allComponents.map((component) => [component.name, component]));
+const dependencyByRef = new Map(sbom.dependencies.map((dependency) => [dependency.ref, dependency]));
 
 const packageManifests = {
   '@micrantha/react-native-amaryllis': 'package.json',
@@ -48,11 +50,11 @@ const packageManifests = {
 };
 
 function npmPurl(name, version) {
-  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@${version}`;
+  return `pkg:npm/${encodeURIComponent(name).replace(/%2F/g, '/')}@${encodeURIComponent(version)}`;
 }
 
 function hasPackage(packageName) {
-  const prefix = `pkg:npm/${encodeURIComponent(packageName).replace('%2F', '/')}@`;
+  const prefix = `pkg:npm/${encodeURIComponent(packageName).replace(/%2F/g, '/')}@`;
   return purls.some((purl) => purl.startsWith(prefix));
 }
 
@@ -80,9 +82,7 @@ if (expectedPackage) {
     );
   }
 
-  const rootDependency = sbom.dependencies.find(
-    (dependency) => dependency.ref === root['bom-ref']
-  );
+  const rootDependency = dependencyByRef.get(root['bom-ref']);
   if (!rootDependency) {
     throw new Error('package SBOM dependency graph does not contain its root component');
   }
@@ -100,6 +100,19 @@ if (expectedPackage) {
   for (const devDependencyName of Object.keys(manifest.devDependencies ?? {})) {
     if (!productionNames.has(devDependencyName) && hasPackage(devDependencyName)) {
       throw new Error(`package SBOM contains development-only dependency ${devDependencyName}`);
+    }
+  }
+
+  if (expectedPackage === '@micrantha/amaryllis-components') {
+    const ajv = componentByName.get('ajv');
+    const ajvNode = ajv && dependencyByRef.get(ajv['bom-ref']);
+    if (!ajvNode || !Array.isArray(ajvNode.dependsOn) || ajvNode.dependsOn.length === 0) {
+      throw new Error('components SBOM is missing ajv transitive production dependencies');
+    }
+    for (const ref of ajvNode.dependsOn) {
+      if (!allComponents.some((component) => component['bom-ref'] === ref)) {
+        throw new Error(`components SBOM dependency graph references missing component ${ref}`);
+      }
     }
   }
 } else {

--- a/scripts/validate-sbom.sh
+++ b/scripts/validate-sbom.sh
@@ -2,11 +2,13 @@
 set -euo pipefail
 
 sbom_file="${1:-artifacts/sbom.cdx.json}"
+expected_package="${2:-}"
 
-node - "$sbom_file" <<'NODE'
+node - "$sbom_file" "$expected_package" <<'NODE'
 const fs = require('node:fs');
 
 const path = process.argv[2];
+const expectedPackage = process.argv[3];
 const sbom = JSON.parse(fs.readFileSync(path, 'utf8'));
 
 if (sbom.bomFormat !== 'CycloneDX') {
@@ -17,8 +19,8 @@ if (sbom.specVersion !== '1.6') {
   throw new Error(`unexpected CycloneDX version: ${sbom.specVersion ?? '<missing>'}`);
 }
 
-if (!Array.isArray(sbom.components) || sbom.components.length === 0) {
-  throw new Error('SBOM contains no components');
+if (!Array.isArray(sbom.components)) {
+  throw new Error('SBOM components must be an array');
 }
 
 const root = sbom.metadata?.component;
@@ -36,20 +38,42 @@ if (!Array.isArray(sbom.dependencies) || sbom.dependencies.length === 0) {
   throw new Error('SBOM contains no dependency graph');
 }
 
-const purls = sbom.components
-  .map((component) => component.purl)
-  .filter(Boolean);
+const allComponents = root ? [root, ...sbom.components] : sbom.components;
+const purls = allComponents.map((component) => component.purl).filter(Boolean);
 
-for (const expected of [
-  'pkg:npm/%40micrantha/react-native-amaryllis@',
-  'pkg:npm/react-native-amaryllis-example@',
-]) {
-  if (!purls.some((purl) => purl.startsWith(expected))) {
-    throw new Error(`SBOM is missing expected component: ${expected}`);
+if (expectedPackage) {
+  if (root?.name !== expectedPackage) {
+    throw new Error(
+      `SBOM root package mismatch: expected ${expectedPackage}, found ${root?.name ?? '<missing>'}`
+    );
+  }
+
+  const expectedPurl = `pkg:npm/${encodeURIComponent(expectedPackage).replace('%2F', '/')}@`;
+  if (!root.purl?.startsWith(expectedPurl)) {
+    throw new Error(`SBOM root purl mismatch: expected ${expectedPurl}, found ${root.purl ?? '<missing>'}`);
+  }
+
+  const rootRef = root['bom-ref'];
+  const rootDependency = sbom.dependencies.find((dependency) => dependency.ref === rootRef);
+  if (!rootRef || !rootDependency) {
+    throw new Error('package SBOM dependency graph does not contain its root component');
+  }
+} else {
+  if (sbom.components.length === 0) {
+    throw new Error('repository SBOM contains no components');
+  }
+
+  for (const expected of [
+    'pkg:npm/%40micrantha/react-native-amaryllis@',
+    'pkg:npm/react-native-amaryllis-example@',
+  ]) {
+    if (!purls.some((purl) => purl.startsWith(expected))) {
+      throw new Error(`SBOM is missing expected component: ${expected}`);
+    }
   }
 }
 
 console.log(
-  `Validated ${path}: CycloneDX ${sbom.specVersion}, ${sbom.components.length} components, ${sbom.dependencies.length} dependency nodes`
+  `Validated ${path}: CycloneDX ${sbom.specVersion}, ${allComponents.length} components, ${sbom.dependencies.length} dependency nodes`
 );
 NODE

--- a/scripts/validate-sbom.sh
+++ b/scripts/validate-sbom.sh
@@ -41,22 +41,66 @@ if (!Array.isArray(sbom.dependencies) || sbom.dependencies.length === 0) {
 const allComponents = root ? [root, ...sbom.components] : sbom.components;
 const purls = allComponents.map((component) => component.purl).filter(Boolean);
 
+const packageManifests = {
+  '@micrantha/react-native-amaryllis': 'package.json',
+  '@micrantha/amaryllis': 'packages/amaryllis/package.json',
+  '@micrantha/amaryllis-components': 'packages/amaryllis-components/package.json',
+};
+
+function npmPurl(name, version) {
+  return `pkg:npm/${encodeURIComponent(name).replace('%2F', '/')}@${version}`;
+}
+
+function hasPackage(packageName) {
+  const prefix = `pkg:npm/${encodeURIComponent(packageName).replace('%2F', '/')}@`;
+  return purls.some((purl) => purl.startsWith(prefix));
+}
+
 if (expectedPackage) {
-  if (root?.name !== expectedPackage) {
+  const manifestPath = packageManifests[expectedPackage];
+  if (!manifestPath) {
+    throw new Error(`no manifest configured for expected package ${expectedPackage}`);
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const expectedPurl = npmPurl(manifest.name, manifest.version);
+
+  if (root?.name !== manifest.name) {
     throw new Error(
-      `SBOM root package mismatch: expected ${expectedPackage}, found ${root?.name ?? '<missing>'}`
+      `SBOM root package mismatch: expected ${manifest.name}, found ${root?.name ?? '<missing>'}`
+    );
+  }
+  if (root?.version !== manifest.version) {
+    throw new Error(
+      `SBOM root version mismatch: expected ${manifest.version}, found ${root?.version ?? '<missing>'}`
+    );
+  }
+  if (root?.purl !== expectedPurl || root?.['bom-ref'] !== expectedPurl) {
+    throw new Error(
+      `SBOM root identity mismatch: expected ${expectedPurl}, found purl=${root?.purl ?? '<missing>'} bom-ref=${root?.['bom-ref'] ?? '<missing>'}`
     );
   }
 
-  const expectedPurl = `pkg:npm/${encodeURIComponent(expectedPackage).replace('%2F', '/')}@`;
-  if (!root.purl?.startsWith(expectedPurl)) {
-    throw new Error(`SBOM root purl mismatch: expected ${expectedPurl}, found ${root.purl ?? '<missing>'}`);
+  const rootDependency = sbom.dependencies.find(
+    (dependency) => dependency.ref === root['bom-ref']
+  );
+  if (!rootDependency) {
+    throw new Error('package SBOM dependency graph does not contain its root component');
   }
 
-  const rootRef = root['bom-ref'];
-  const rootDependency = sbom.dependencies.find((dependency) => dependency.ref === rootRef);
-  if (!rootRef || !rootDependency) {
-    throw new Error('package SBOM dependency graph does not contain its root component');
+  const productionNames = new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+  ]);
+  for (const dependencyName of productionNames) {
+    if (!hasPackage(dependencyName)) {
+      throw new Error(`package SBOM is missing declared production dependency ${dependencyName}`);
+    }
+  }
+
+  for (const devDependencyName of Object.keys(manifest.devDependencies ?? {})) {
+    if (!productionNames.has(devDependencyName) && hasPackage(devDependencyName)) {
+      throw new Error(`package SBOM contains development-only dependency ${devDependencyName}`);
+    }
   }
 } else {
   if (sbom.components.length === 0) {


### PR DESCRIPTION
## Summary

- derive package-scoped CycloneDX SBOMs for all three published npm packages from the resolved repository dependency graph
- validate each package SBOM's root package identity and dependency-graph entry
- retain the existing repository-wide SBOM for maintainers
- publish and attest all four SBOMs on version tags
- document which SBOM consumers should select

## Packages

- `@micrantha/react-native-amaryllis`
- `@micrantha/amaryllis`
- `@micrantha/amaryllis-components`

## Design

The workflow generates the complete Syft inventory once, then `scripts/derive-package-sboms.mjs` computes the dependency closure rooted at each published package. This avoids unrelated workspace, example-application, and tooling branches while retaining resolved transitive dependencies represented in the repository graph.

## Release assets

- `amaryllis-vX.Y.Z.cdx.json`
- `react-native-amaryllis-vX.Y.Z.cdx.json`
- `amaryllis-core-vX.Y.Z.cdx.json`
- `amaryllis-components-vX.Y.Z.cdx.json`

Every validated file is included in the SHA-pinned `actions/attest` subject glob before release upload.

## Validation

- existing repository SBOM contract
- exact package root name and npm PURL
- package root presence in the dependency graph
- workflow lint and pinned-action policy checks
- generation of all package-scoped files on pull requests

## Follow-up

Issue #67 remains responsible for validating the complete attested release path on the next real `v*` release.