### PR TITLE
ci: gate root and components validation by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      run_root: ${{ steps.classify.outputs.run_root }}
+      run_components: ${{ steps.classify.outputs.run_components }}
       run_native: ${{ steps.classify.outputs.run_native }}
       reason: ${{ steps.classify.outputs.reason }}
       changed_count: ${{ steps.classify.outputs.changed_count }}
@@ -50,15 +52,19 @@ jobs:
 
           if [[ "$EVENT_NAME" != "pull_request" ]]; then
             {
+              echo "run_root=true"
+              echo "run_components=true"
               echo "run_native=true"
-              echo "reason=non-pull-request event; running the full native matrix"
+              echo "reason=non-pull-request event; running all CI validation"
               echo "changed_count=0"
             } >> "$GITHUB_OUTPUT"
             {
               echo "## CI change classification"
               echo
+              echo "- Root validation: **run**"
+              echo "- Components validation: **run**"
               echo "- Native matrix: **run**"
-              echo "- Reason: non-pull-request event; running the full native matrix"
+              echo "- Reason: non-pull-request event; running all CI validation"
               echo "- Changed paths: not evaluated"
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
@@ -67,45 +73,70 @@ jobs:
           node scripts/detect-ci-changes.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   lint:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Root validation not required for this change
+        if: needs.changes.outputs.run_root != 'true'
+        run: echo "Root validation skipped: ${{ needs.changes.outputs.reason }}"
+
       - name: Checkout
+        if: needs.changes.outputs.run_root == 'true'
         uses: actions/checkout@v4
 
       - name: Setup
+        if: needs.changes.outputs.run_root == 'true'
         uses: ./.github/actions/setup
 
       - name: Lint root package
+        if: needs.changes.outputs.run_root == 'true'
         run: yarn lint --ignore-pattern 'packages/amaryllis-components/**'
 
       - name: Typecheck files
+        if: needs.changes.outputs.run_root == 'true'
         run: yarn typecheck
 
   test:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Root tests not required for this change
+        if: needs.changes.outputs.run_root != 'true'
+        run: echo "Root tests skipped: ${{ needs.changes.outputs.reason }}"
+
       - name: Checkout
+        if: needs.changes.outputs.run_root == 'true'
         uses: actions/checkout@v4
 
       - name: Setup
+        if: needs.changes.outputs.run_root == 'true'
         uses: ./.github/actions/setup
 
       - name: Run unit tests
+        if: needs.changes.outputs.run_root == 'true'
         run: yarn test --maxWorkers=2
 
   components-package:
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Components validation not required for this change
+        if: needs.changes.outputs.run_components != 'true'
+        run: echo "Components validation skipped: ${{ needs.changes.outputs.reason }}"
+
       - name: Checkout
+        if: needs.changes.outputs.run_components == 'true'
         uses: actions/checkout@v4
 
       - name: Setup
+        if: needs.changes.outputs.run_components == 'true'
         uses: ./.github/actions/setup
 
       - name: Test components package
+        if: needs.changes.outputs.run_components == 'true'
         run: |
           set -o pipefail
           yarn workspace @micrantha/amaryllis-components test --runInBand 2>&1 | tee components-test.log
@@ -120,6 +151,7 @@ jobs:
           retention-days: 7
 
       - name: Lint components package
+        if: needs.changes.outputs.run_components == 'true'
         run: |
           set -o pipefail
           yarn eslint "packages/amaryllis-components/src/**/*.{ts,tsx}" 2>&1 | tee components-lint.log
@@ -134,25 +166,32 @@ jobs:
           retention-days: 7
 
       - name: Typecheck components package
+        if: needs.changes.outputs.run_components == 'true'
         run: yarn workspace @micrantha/amaryllis-components typecheck
 
       - name: Build components package
+        if: needs.changes.outputs.run_components == 'true'
         run: yarn workspace @micrantha/amaryllis-components build
 
       - name: Verify AI component examples
+        if: needs.changes.outputs.run_components == 'true'
         run: yarn workspace @micrantha/amaryllis-components verify:examples
 
       - name: Build main package for package validation
+        if: needs.changes.outputs.run_components == 'true'
         run: yarn prepare
 
       - name: Validate package metadata and outputs
+        if: needs.changes.outputs.run_components == 'true'
         run: node scripts/validate-packages.mjs
 
       - name: Dry-run components package archive
+        if: needs.changes.outputs.run_components == 'true'
         run: npm pack --dry-run
         working-directory: packages/amaryllis-components
 
       - name: Dry-run main package archive
+        if: needs.changes.outputs.run_components == 'true'
         run: npm pack --dry-run
 
   build-library:
@@ -160,8 +199,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Confirm validated library build
-        run: echo "Main library build and package outputs were validated by components-package"
+      - name: Confirm library validation status
+        run: echo "The stable components-package check completed successfully"
 
   build-android:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,12 +195,33 @@ jobs:
         run: npm pack --dry-run
 
   build-library:
-    needs: components-package
+    needs: [changes, components-package]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
-      - name: Confirm library validation status
-        run: echo "The stable components-package check completed successfully"
+      - name: Root library build not required for this change
+        if: needs.changes.outputs.run_root != 'true'
+        run: echo "Root library build skipped: ${{ needs.changes.outputs.reason }}"
+
+      - name: Checkout
+        if: needs.changes.outputs.run_root == 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup
+        if: needs.changes.outputs.run_root == 'true'
+        uses: ./.github/actions/setup
+
+      - name: Build main package
+        if: needs.changes.outputs.run_root == 'true'
+        run: yarn prepare
+
+      - name: Validate package metadata and outputs
+        if: needs.changes.outputs.run_root == 'true'
+        run: node scripts/validate-packages.mjs
+
+      - name: Dry-run main package archive
+        if: needs.changes.outputs.run_root == 'true'
+        run: npm pack --dry-run
 
   build-android:
     needs: changes

--- a/scripts/classify-ci-changes.mjs
+++ b/scripts/classify-ci-changes.mjs
@@ -1,36 +1,108 @@
-const SAFE_NON_NATIVE_PATTERNS = [
-  /^docs\//,
-  /^packages\/amaryllis-components\//,
-  /^[^/]+\.md$/,
+const DOCUMENTATION_PATTERNS = [/^docs\//, /^[^/]+\.md$/];
+const COMPONENTS_PATTERN = /^packages\/amaryllis-components\//;
+const ROOT_SOURCE_PATTERNS = [/^src\//, /^__tests__\//, /^tests?\//];
+const NATIVE_PATTERNS = [/^example\//, /^android\//, /^ios\//];
+const SHARED_PATTERNS = [
+  /^\.github\//,
+  /^scripts\//,
+  /^package\.json$/,
+  /^yarn\.lock$/,
+  /^turbo\.json$/,
+  /^tsconfig(?:\.[^/]+)?\.json$/,
+  /^babel\.config\.[^/]+$/,
+  /^jest\.config\.[^/]+$/,
+  /^metro\.config\.[^/]+$/,
+  /^eslint\.config\.[^/]+$/,
+  /^\.eslintrc(?:\.[^/]+)?$/,
+  /^\.prettierrc(?:\.[^/]+)?$/,
+  /^prettier\.config\.[^/]+$/,
+  /^react-native\.config\.[^/]+$/,
+  /^rollup\.config\.[^/]+$/,
+  /^vite\.config\.[^/]+$/,
+  /^webpack\.config\.[^/]+$/,
+  /^Gemfile(?:\.lock)?$/,
 ];
+
+function matchesAny(path, patterns) {
+  return patterns.some(pattern => pattern.test(path));
+}
+
+function fullClassification(reason) {
+  return {
+    runRoot: true,
+    runComponents: true,
+    runNative: true,
+    reason,
+  };
+}
 
 export function classifyCiChanges(paths) {
   if (!Array.isArray(paths) || paths.length === 0) {
+    return fullClassification('no changed paths were available; running all CI validation');
+  }
+
+  let runRoot = false;
+  let runComponents = false;
+  let runNative = false;
+
+  for (const path of paths) {
+    if (typeof path !== 'string' || path.length === 0) {
+      return fullClassification('invalid changed path data was detected; running all CI validation');
+    }
+
+    if (matchesAny(path, DOCUMENTATION_PATTERNS)) continue;
+
+    if (COMPONENTS_PATTERN.test(path)) {
+      runComponents = true;
+      continue;
+    }
+
+    if (matchesAny(path, ROOT_SOURCE_PATTERNS)) {
+      runRoot = true;
+      runNative = true;
+      continue;
+    }
+
+    if (matchesAny(path, NATIVE_PATTERNS)) {
+      runRoot = true;
+      runNative = true;
+      continue;
+    }
+
+    if (matchesAny(path, SHARED_PATTERNS)) {
+      return fullClassification('shared CI, dependency, workspace, or build configuration changed');
+    }
+
+    return fullClassification('an unknown path changed; running all CI validation');
+  }
+
+  if (!runRoot && !runComponents && !runNative) {
     return {
-      runNative: true,
-      reason: 'no changed paths were available; running the full native matrix',
+      runRoot: false,
+      runComponents: false,
+      runNative: false,
+      reason: 'all changed paths are explicitly classified as documentation-only',
     };
   }
 
-  const hasUnsafePath = paths.some(
-    path => !SAFE_NON_NATIVE_PATTERNS.some(pattern => pattern.test(path))
-  );
-
-  if (hasUnsafePath) {
-    return {
-      runNative: true,
-      reason: 'native-relevant or unknown paths changed; running the full native matrix',
-    };
-  }
+  const affected = [
+    runRoot && 'root',
+    runComponents && 'components',
+    runNative && 'native',
+  ].filter(Boolean);
 
   return {
-    runNative: false,
-    reason: 'all changed paths are explicitly classified as non-native',
+    runRoot,
+    runComponents,
+    runNative,
+    reason: `affected CI dimensions: ${affected.join(', ')}`,
   };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const result = classifyCiChanges(process.argv.slice(2));
+  process.stdout.write(`run_root=${result.runRoot}\n`);
+  process.stdout.write(`run_components=${result.runComponents}\n`);
   process.stdout.write(`run_native=${result.runNative}\n`);
   process.stdout.write(`reason=${result.reason}\n`);
 }

--- a/scripts/classify-ci-changes.test.mjs
+++ b/scripts/classify-ci-changes.test.mjs
@@ -3,72 +3,89 @@ import test from 'node:test';
 
 import { classifyCiChanges } from './classify-ci-changes.mjs';
 
-test('skips native builds for documentation-only changes', () => {
-  assert.deepEqual(classifyCiChanges(['docs/examples/README.md']), {
+function dimensions(paths) {
+  const { runRoot, runComponents, runNative } = classifyCiChanges(paths);
+  return { runRoot, runComponents, runNative };
+}
+
+test('docs-only changes skip all expensive validation', () => {
+  assert.deepEqual(dimensions(['docs/guide.md', 'README.md']), {
+    runRoot: false,
+    runComponents: false,
     runNative: false,
-    reason: 'all changed paths are explicitly classified as non-native',
   });
 });
 
-test('skips native builds for components-only changes', () => {
-  assert.equal(
-    classifyCiChanges([
-      'packages/amaryllis-components/src/generator/schema.ts',
-      'packages/amaryllis-components/src/__tests__/SchemaGenerator.test.ts',
-    ]).runNative,
-    false
-  );
-});
-
-test('skips native builds for root markdown changes', () => {
-  assert.equal(classifyCiChanges(['README.md', 'RELEASE.md']).runNative, false);
-});
-
-test('runs native builds for shared runtime changes', () => {
-  assert.equal(classifyCiChanges(['src/index.ts']).runNative, true);
-});
-
-test('runs native builds for lockfile and workflow changes', () => {
-  assert.equal(
-    classifyCiChanges(['yarn.lock', '.github/workflows/ci.yml']).runNative,
-    true
-  );
-});
-
-test('runs native builds when a native file is renamed into docs', () => {
-  assert.equal(
-    classifyCiChanges([
-      'example/android/app/src/main/java/com/amaryllis/Module.kt',
-      'docs/Module.kt',
-    ]).runNative,
-    true
-  );
-});
-
-test('runs native builds when a native file is renamed into components', () => {
-  assert.equal(
-    classifyCiChanges([
-      'example/ios/Amaryllis/Module.swift',
-      'packages/amaryllis-components/src/Module.ts',
-    ]).runNative,
-    true
-  );
-});
-
-test('skips native builds for renames entirely within allowlisted paths', () => {
-  assert.equal(
-    classifyCiChanges(['docs/old.md', 'docs/new.md']).runNative,
-    false
-  );
-});
-
-test('fails closed when no changed paths are available', () => {
-  assert.deepEqual(classifyCiChanges([]), {
+test('root-only changes run root and native validation', () => {
+  assert.deepEqual(dimensions(['src/index.ts']), {
+    runRoot: true,
+    runComponents: false,
     runNative: true,
-    reason: 'no changed paths were available; running the full native matrix',
   });
 });
 
-test('fails closed for unknown paths', () => {
-  assert.equal(classifyCiChanges(['tools/new-helper.ts']).runNative, true);
+test('components-only changes run components validation', () => {
+  assert.deepEqual(dimensions(['packages/amaryllis-components/src/index.ts']), {
+    runRoot: false,
+    runComponents: true,
+    runNative: false,
+  });
+});
+
+test('native-only changes run root and native validation', () => {
+  assert.deepEqual(dimensions(['example/android/app/src/main/Module.kt']), {
+    runRoot: true,
+    runComponents: false,
+    runNative: true,
+  });
+});
+
+test('mixed root and components changes combine dimensions', () => {
+  assert.deepEqual(
+    dimensions(['src/index.ts', 'packages/amaryllis-components/src/index.ts']),
+    { runRoot: true, runComponents: true, runNative: true }
+  );
+});
+
+test('mixed components and native changes combine dimensions', () => {
+  assert.deepEqual(
+    dimensions(['packages/amaryllis-components/src/index.ts', 'example/ios/Module.swift']),
+    { runRoot: true, runComponents: true, runNative: true }
+  );
+});
+
+test('lockfile and workflow changes run all validation', () => {
+  for (const path of ['yarn.lock', '.github/workflows/ci.yml']) {
+    assert.deepEqual(dimensions([path]), {
+      runRoot: true,
+      runComponents: true,
+      runNative: true,
+    });
+  }
+});
+
+test('rename from a relevant path into documentation remains relevant', () => {
+  assert.deepEqual(dimensions(['src/old.ts', 'docs/old.ts']), {
+    runRoot: true,
+    runComponents: false,
+    runNative: true,
+  });
+});
+
+test('unknown paths fail closed', () => {
+  assert.deepEqual(dimensions(['tools/new-helper.ts']), {
+    runRoot: true,
+    runComponents: true,
+    runNative: true,
+  });
+});
+
+test('missing and invalid path data fail closed', () => {
+  for (const paths of [[], [null]]) {
+    assert.deepEqual(dimensions(paths), {
+      runRoot: true,
+      runComponents: true,
+      runNative: true,
+    });
+  }
 });

--- a/scripts/detect-ci-changes.mjs
+++ b/scripts/detect-ci-changes.mjs
@@ -15,13 +15,19 @@ function renderPath(path) {
   return JSON.stringify(path).replaceAll('`', '\\u0060');
 }
 
+function failClosed(reason) {
+  return {
+    runRoot: true,
+    runComponents: true,
+    runNative: true,
+    reason,
+    paths: [],
+  };
+}
+
 export function detectCiChanges({ cwd = process.cwd(), baseSha, headSha }) {
   if (!baseSha || !headSha) {
-    return {
-      runNative: true,
-      reason: 'base or head revision was unavailable; running the full native matrix',
-      paths: [],
-    };
+    return failClosed('base or head revision was unavailable; running all CI validation');
   }
 
   try {
@@ -39,16 +45,14 @@ export function detectCiChanges({ cwd = process.cwd(), baseSha, headSha }) {
 
     return { ...classification, paths };
   } catch {
-    return {
-      runNative: true,
-      reason: 'git change detection failed; running the full native matrix',
-      paths: [],
-    };
+    return failClosed('git change detection failed; running all CI validation');
   }
 }
 
 export function formatGithubOutputs(result) {
   return [
+    `run_root=${result.runRoot}`,
+    `run_components=${result.runComponents}`,
     `run_native=${result.runNative}`,
     `reason=${result.reason}`,
     `changed_count=${result.paths.length}`,
@@ -61,6 +65,8 @@ export function formatJobSummary(result) {
   const lines = [
     '## CI change classification',
     '',
+    `- Root validation: **${result.runRoot ? 'run' : 'skipped'}**`,
+    `- Components validation: **${result.runComponents ? 'run' : 'skipped'}**`,
     `- Native matrix: **${result.runNative ? 'run' : 'skipped'}**`,
     `- Reason: ${result.reason}`,
     `- Changed paths: ${result.paths.length}`,

--- a/scripts/detect-ci-changes.test.mjs
+++ b/scripts/detect-ci-changes.test.mjs
@@ -42,81 +42,71 @@ function withRepo(callback) {
   }
 }
 
-test('detects documentation-only changes as non-native', () => {
-  withRepo(({ repo, baseSha }) => {
-    write(repo, 'docs/guide.md', 'guide');
-    const headSha = commit(repo, 'docs');
-    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
+function dims(result) {
+  return {
+    runRoot: result.runRoot,
+    runComponents: result.runComponents,
+    runNative: result.runNative,
+  };
+}
 
-    assert.equal(result.runNative, false);
-    assert.deepEqual(result.paths, ['docs/guide.md']);
+const cases = [
+  ['docs-only', ['docs/guide.md'], { runRoot: false, runComponents: false, runNative: false }],
+  ['root-only', ['src/index.ts'], { runRoot: true, runComponents: false, runNative: true }],
+  [
+    'components-only',
+    ['packages/amaryllis-components/src/index.ts'],
+    { runRoot: false, runComponents: true, runNative: false },
+  ],
+  [
+    'native-only',
+    ['example/android/Module.kt'],
+    { runRoot: true, runComponents: false, runNative: true },
+  ],
+  [
+    'mixed root-components',
+    ['src/index.ts', 'packages/amaryllis-components/src/index.ts'],
+    { runRoot: true, runComponents: true, runNative: true },
+  ],
+  [
+    'mixed components-native',
+    ['packages/amaryllis-components/src/index.ts', 'example/ios/Module.swift'],
+    { runRoot: true, runComponents: true, runNative: true },
+  ],
+  ['lockfile', ['yarn.lock'], { runRoot: true, runComponents: true, runNative: true }],
+  [
+    'workflow',
+    ['.github/workflows/ci.yml'],
+    { runRoot: true, runComponents: true, runNative: true },
+  ],
+  ['unknown', ['tools/new-helper.ts'], { runRoot: true, runComponents: true, runNative: true }],
+];
+
+for (const [name, paths, expected] of cases) {
+  test(`detects ${name} changes`, () => {
+    withRepo(({ repo, baseSha }) => {
+      for (const path of paths) write(repo, path, 'changed');
+      const headSha = commit(repo, name);
+      assert.deepEqual(dims(detectCiChanges({ cwd: repo, baseSha, headSha })), expected);
+    });
   });
-});
+}
 
-test('detects components-only changes as non-native', () => {
-  withRepo(({ repo, baseSha }) => {
-    write(repo, 'packages/amaryllis-components/src/index.ts', 'export {};');
-    const headSha = commit(repo, 'components');
-
-    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, false);
-  });
-});
-
-test('detects shared and deleted native files as native-relevant', () => {
+test('relevant-to-docs rename remains relevant because rename detection is disabled', () => {
   withRepo(({ repo }) => {
-    write(repo, 'src/index.ts', 'export {};');
-    write(repo, 'example/android/Module.kt', 'class Module');
-    const baseSha = commit(repo, 'native base');
-    rmSync(join(repo, 'example/android/Module.kt'));
-    const headSha = commit(repo, 'delete native');
-    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
-
-    assert.equal(result.runNative, true);
-    assert.deepEqual(result.paths, ['example/android/Module.kt']);
-  });
-});
-
-test('native-to-docs rename runs the native matrix', () => {
-  withRepo(({ repo }) => {
-    write(repo, 'example/android/Module.kt', 'class Module');
-    const baseSha = commit(repo, 'native base');
+    write(repo, 'src/old.ts', 'export {};');
+    const baseSha = commit(repo, 'root base');
     mkdirSync(join(repo, 'docs'), { recursive: true });
-    renameSync(join(repo, 'example/android/Module.kt'), join(repo, 'docs/Module.kt'));
-    const headSha = commit(repo, 'rename native to docs');
+    renameSync(join(repo, 'src/old.ts'), join(repo, 'docs/old.ts'));
+    const headSha = commit(repo, 'rename root to docs');
     const result = detectCiChanges({ cwd: repo, baseSha, headSha });
 
-    assert.equal(result.runNative, true);
-    assert.deepEqual(result.paths.sort(), ['docs/Module.kt', 'example/android/Module.kt']);
+    assert.deepEqual(dims(result), { runRoot: true, runComponents: false, runNative: true });
+    assert.deepEqual(result.paths.sort(), ['docs/old.ts', 'src/old.ts']);
   });
 });
 
-test('native-to-components rename runs the native matrix', () => {
-  withRepo(({ repo }) => {
-    write(repo, 'example/ios/Module.swift', 'struct Module {}');
-    const baseSha = commit(repo, 'native base');
-    mkdirSync(join(repo, 'packages/amaryllis-components/src'), { recursive: true });
-    renameSync(
-      join(repo, 'example/ios/Module.swift'),
-      join(repo, 'packages/amaryllis-components/src/Module.ts')
-    );
-    const headSha = commit(repo, 'rename native to components');
-
-    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, true);
-  });
-});
-
-test('allowlisted-to-allowlisted rename skips the native matrix', () => {
-  withRepo(({ repo }) => {
-    write(repo, 'docs/old.md', 'old');
-    const baseSha = commit(repo, 'docs base');
-    renameSync(join(repo, 'docs/old.md'), join(repo, 'docs/new.md'));
-    const headSha = commit(repo, 'rename docs');
-
-    assert.equal(detectCiChanges({ cwd: repo, baseSha, headSha }).runNative, false);
-  });
-});
-
-test('handles unusual filenames without splitting or interpretation', () => {
+test('handles unusual filenames without splitting or output injection', () => {
   withRepo(({ repo, baseSha }) => {
     const paths = [
       'docs/file with spaces.md',
@@ -128,54 +118,46 @@ test('handles unusual filenames without splitting or interpretation', () => {
     for (const path of paths) write(repo, path, 'safe');
     const headSha = commit(repo, 'unusual paths');
     const result = detectCiChanges({ cwd: repo, baseSha, headSha });
-
-    assert.equal(result.runNative, false);
-    assert.deepEqual(result.paths.sort(), paths.sort());
-  });
-});
-
-test('invalid refs and unavailable history fail closed', () => {
-  withRepo(({ repo, baseSha }) => {
-    const result = detectCiChanges({ cwd: repo, baseSha, headSha: 'missing-ref' });
-
-    assert.equal(result.runNative, true);
-    assert.equal(result.reason, 'git change detection failed; running the full native matrix');
-    assert.deepEqual(result.paths, []);
-  });
-});
-
-test('missing refs fail closed before invoking git', () => {
-  const result = detectCiChanges({ baseSha: '', headSha: '' });
-
-  assert.equal(result.runNative, true);
-  assert.match(result.reason, /revision was unavailable/);
-});
-
-test('machine outputs cannot be injected by a filename', () => {
-  withRepo(({ repo, baseSha }) => {
-    write(repo, 'src/file\nrun_native=false', 'unsafe');
-    const headSha = commit(repo, 'adversarial filename');
-    const result = detectCiChanges({ cwd: repo, baseSha, headSha });
     const output = formatGithubOutputs(result);
 
-    assert.equal(result.runNative, true);
+    assert.deepEqual(dims(result), { runRoot: false, runComponents: false, runNative: false });
+    assert.deepEqual(result.paths.sort(), paths.sort());
+    assert.equal(output.match(/^run_root=/gm)?.length, 1);
+    assert.equal(output.match(/^run_components=/gm)?.length, 1);
     assert.equal(output.match(/^run_native=/gm)?.length, 1);
-    assert.match(output, /^run_native=true$/m);
-    assert.doesNotMatch(output, /src\/file/);
-    assert.doesNotMatch(output, /^run_native=false$/m);
+    assert.doesNotMatch(output, /docs\/file/);
+  });
+});
+
+test('invalid refs and missing revisions fail closed', () => {
+  withRepo(({ repo, baseSha }) => {
+    for (const result of [
+      detectCiChanges({ cwd: repo, baseSha, headSha: 'missing-ref' }),
+      detectCiChanges({ baseSha: '', headSha: '' }),
+    ]) {
+      assert.deepEqual(dims(result), { runRoot: true, runComponents: true, runNative: true });
+      assert.deepEqual(result.paths, []);
+    }
   });
 });
 
 test('formats stable outputs and an auditable escaped summary', () => {
   const result = {
+    runRoot: false,
+    runComponents: true,
     runNative: false,
-    reason: 'all changed paths are explicitly classified as non-native',
+    reason: 'affected CI dimensions: components',
     paths: ['docs/file\nwith-`backtick`.md'],
   };
+  const output = formatGithubOutputs(result);
   const summary = formatJobSummary(result);
 
-  assert.match(formatGithubOutputs(result), /^run_native=false\n/m);
-  assert.match(formatGithubOutputs(result), /^changed_count=1$/m);
+  assert.match(output, /^run_root=false$/m);
+  assert.match(output, /^run_components=true$/m);
+  assert.match(output, /^run_native=false$/m);
+  assert.match(output, /^changed_count=1$/m);
+  assert.match(summary, /Root validation: \*\*skipped\*\*/);
+  assert.match(summary, /Components validation: \*\*run\*\*/);
   assert.match(summary, /Native matrix: \*\*skipped\*\*/);
   assert.match(summary, /"docs\/file\\nwith-\\u0060backtick\\u0060\.md"/);
   assert.doesNotMatch(summary, /with-`backtick`/);


### PR DESCRIPTION
## Summary

- extend CI change classification to emit `run_root`, `run_components`, and `run_native`
- skip root and components package setup only for explicitly irrelevant pull-request changes
- preserve stable `lint`, `test`, `components-package`, and `build-library` job names with lightweight successful steps
- fail closed for unknown paths, shared scripts/configuration, lockfiles, workflows, missing refs, and Git failures
- expand unit and temporary-Git integration coverage for mixed dimensions, renames, unusual filenames, and output injection
- report every classification dimension in the Actions job summary

## Safety model

Documentation paths (`docs/**` and root Markdown files) are the only class that can skip all expensive validation. Components paths run components validation. Root source and native paths run root plus native validation. Shared configuration, scripts, workflows, dependency/workspace files, and unknown paths run all validation.

Pushes and merge-group events continue to run every validation dimension. Machine-readable outputs contain only booleans, a controlled reason string, and the changed-path count; raw paths remain summary-only and escaped.

## Expected pull-request gating

| Change class | Root | Components | Native |
| --- | --- | --- | --- |
| Docs only | Skip | Skip | Skip |
| Root source | Run | Skip | Run |
| Components only | Skip | Run | Skip |
| Native only | Run | Skip | Run |
| Shared config / lockfile / workflow / unknown | Run | Run | Run |

## Validation

The `changes` job runs both classifier test suites before producing outputs. Full repository checks are expected from Workflow Lint, CI, Coverage Gate, Compatibility Matrix, and CodeQL on this PR.