### PR TITLE
test: enforce change-aware CI workflow contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Test change classification
         run: |
           node --test \
+            scripts/ci-workflow-contract.test.mjs \
             scripts/classify-ci-changes.test.mjs \
             scripts/detect-ci-changes.test.mjs
 

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workflow = readFileSync('.github/workflows/ci.yml', 'utf8');
+
+function jobBlock(name) {
+  const marker = `  ${name}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing ${name} job`);
+
+  const nextJob = workflow.indexOf('\n  ', start + marker.length);
+  return nextJob === -1 ? workflow.slice(start) : workflow.slice(start, nextJob);
+}
+
+function assertContainsAll(block, snippets) {
+  for (const snippet of snippets) {
+    assert.match(block, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+}
+
+test('change classifier exposes every CI dimension', () => {
+  const changes = jobBlock('changes');
+
+  assertContainsAll(changes, [
+    'run_root: ${{ steps.classify.outputs.run_root }}',
+    'run_components: ${{ steps.classify.outputs.run_components }}',
+    'run_native: ${{ steps.classify.outputs.run_native }}',
+  ]);
+});
+
+test('stable root jobs retain lightweight and expensive paths', () => {
+  for (const name of ['lint', 'test']) {
+    const block = jobBlock(name);
+    assertContainsAll(block, [
+      'needs: changes',
+      "if: needs.changes.outputs.run_root != 'true'",
+      "if: needs.changes.outputs.run_root == 'true'",
+      'uses: ./.github/actions/setup',
+    ]);
+  }
+});
+
+test('components job retains stable acknowledgement and validation paths', () => {
+  const block = jobBlock('components-package');
+
+  assertContainsAll(block, [
+    'needs: changes',
+    "if: needs.changes.outputs.run_components != 'true'",
+    "if: needs.changes.outputs.run_components == 'true'",
+    'yarn workspace @micrantha/amaryllis-components test --runInBand',
+    'yarn workspace @micrantha/amaryllis-components typecheck',
+    'yarn workspace @micrantha/amaryllis-components build',
+    'npm pack --dry-run',
+  ]);
+});
+
+test('root library job independently validates package outputs', () => {
+  const block = jobBlock('build-library');
+
+  assertContainsAll(block, [
+    'needs: [changes, components-package]',
+    "if: needs.changes.outputs.run_root != 'true'",
+    "if: needs.changes.outputs.run_root == 'true'",
+    'run: yarn prepare',
+    'run: node scripts/validate-packages.mjs',
+    'run: npm pack --dry-run',
+  ]);
+});
+
+test('native jobs remain controlled by the native dimension', () => {
+  for (const name of ['build-android', 'build-ios']) {
+    const block = jobBlock(name);
+    assertContainsAll(block, [
+      'needs: changes',
+      "if: needs.changes.outputs.run_native == 'true'",
+    ]);
+  }
+});

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -3,14 +3,22 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const workflow = readFileSync('.github/workflows/ci.yml', 'utf8');
+const lines = workflow.split('\n');
+const jobsStart = lines.findIndex(line => line === 'jobs:');
+
+assert.notEqual(jobsStart, -1, 'missing jobs section');
 
 function jobBlock(name) {
-  const marker = `  ${name}:\n`;
-  const start = workflow.indexOf(marker);
+  const marker = `  ${name}:`;
+  const start = lines.findIndex((line, index) => index > jobsStart && line === marker);
   assert.notEqual(start, -1, `missing ${name} job`);
 
-  const nextJob = workflow.indexOf('\n  ', start + marker.length);
-  return nextJob === -1 ? workflow.slice(start) : workflow.slice(start, nextJob);
+  const relativeEnd = lines
+    .slice(start + 1)
+    .findIndex(line => /^  [A-Za-z0-9_-]+:$/.test(line));
+  const end = relativeEnd === -1 ? lines.length : start + 1 + relativeEnd;
+
+  return lines.slice(start, end).join('\n');
 }
 
 function assertContainsAll(block, snippets) {

--- a/scripts/classify-ci-changes.test.mjs
+++ b/scripts/classify-ci-changes.test.mjs
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import './ci-workflow-contract.test.mjs';
 import { classifyCiChanges } from './classify-ci-changes.mjs';
 
 function dimensions(paths) {

--- a/scripts/classify-ci-changes.test.mjs
+++ b/scripts/classify-ci-changes.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import './ci-workflow-contract.test.mjs';
 import { classifyCiChanges } from './classify-ci-changes.mjs';
 
 function dimensions(paths) {


### PR DESCRIPTION
## Summary

- add deterministic contract tests for the change-aware CI workflow
- verify classifier outputs, stable root/components job behavior, independent root package validation, and native gating
- run the new contract suite through the existing classifier test entry point

## Why

PR #71 added change-aware root, components, and native validation. Its classifier behavior is tested, but the workflow wiring itself could drift without failing those tests. This PR protects the job names, dependencies, inverse acknowledgement paths, expensive-step conditions, and package-validation commands.

## Validation

The `changes` job runs `scripts/classify-ci-changes.test.mjs`, which now imports and executes `scripts/ci-workflow-contract.test.mjs` before classifying changed paths.

Closes part of #73. Live docs-only, components-only, and root-only fixture evidence remains tracked in that issue.