### PR TITLE
test(ci): validate docs-only gating fixture

### DIFF
--- a/docs/ci-gating-docs-only-fixture.md
+++ b/docs/ci-gating-docs-only-fixture.md
@@ -1,0 +1,12 @@
+# CI gating docs-only fixture
+
+This temporary document exists solely to validate the docs-only pull-request path tracked by issue #73.
+
+Expected classification:
+
+- root validation: skipped
+- components validation: skipped
+- native validation: skipped
+- stable required checks: terminal and successful
+
+This fixture should not be merged.


### PR DESCRIPTION
## Superseded

This original docs-only fixture predates restoration of the primary CI workflow in PR #76 and cannot provide valid gating evidence.

Replaced by fresh fixture PR #79, based on the restored `main`.

Closed without merging.