### PR TITLE
docs: refresh the public Amaryllis site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Amaryllis — Governed on-device AI for mobile</title>
+    <title>Amaryllis — On-device AI with enforceable boundaries</title>
     <meta
       name="description"
-      content="Amaryllis combines a React Native on-device multimodal AI runtime with governed, spec-driven adaptive components."
+      content="Amaryllis is an open-source React Native implementation for on-device multimodal AI, offline-first context, and governed adaptive components."
     />
+    <meta name="author" content="Micrantha" />
+    <meta name="theme-color" content="#f6f4ee" />
+    <meta property="og:title" content="Amaryllis — On-device AI with enforceable boundaries" />
+    <meta
+      property="og:description"
+      content="A React Native implementation for local multimodal inference and governed, spec-driven adaptive UI."
+    />
+    <meta property="og:type" content="website" />
     <link rel="stylesheet" href="site.css" />
   </head>
   <body>
@@ -17,9 +25,10 @@
         <span>Amaryllis</span>
       </a>
       <nav class="nav-links" aria-label="Primary navigation">
-        <a href="#outcomes">Outcomes</a>
+        <a href="#implementation">Implementation</a>
         <a href="#architecture">Architecture</a>
-        <a href="#components">Components</a>
+        <a href="#components">Governance</a>
+        <a href="#fit">Fit</a>
         <a href="#quickstart">Quickstart</a>
         <a href="https://github.com/hackelia-micrantha/amaryllis">GitHub</a>
       </nav>
@@ -31,53 +40,80 @@
           <img src="amaryllis-128.png" alt="Amaryllis flower mark" />
         </div>
         <div>
-          <p class="eyebrow">Private mobile AI · governed adaptive UI</p>
-          <h1>Build mobile AI that stays local, bounded, and reviewable.</h1>
+          <p class="eyebrow">Open-source React Native systems engineering</p>
+          <h1>On-device mobile AI with enforceable application boundaries.</h1>
           <p class="lead">
-            Amaryllis is a React Native foundation for on-device multimodal inference,
-            streaming interaction, offline-first context, and spec-driven AI-enabled
-            components. It is designed for teams that need useful AI behavior without
-            turning runtime model output into an unrestricted code execution surface.
+            Amaryllis combines local multimodal inference, streaming interaction,
+            offline-first context, and governed adaptive components. The implementation
+            explores how useful AI behavior can remain private and responsive without
+            making probabilistic model output authoritative over application code,
+            policy, or rendering.
           </p>
           <div class="actions">
-            <a class="button" href="#quickstart">Start with the runtime</a>
-            <a class="button button-outline" href="#components">Explore components</a>
-            <a class="button button-outline" href="https://github.com/hackelia-micrantha/amaryllis/tree/main/docs">Read the docs</a>
+            <a class="button" href="#implementation">Review the implementation</a>
+            <a class="button button-outline" href="https://github.com/hackelia-micrantha/amaryllis/tree/main/docs">Technical documentation</a>
+            <a class="button button-outline" href="https://github.com/hackelia-micrantha/amaryllis/actions">Source and CI</a>
+          </div>
+          <div class="status-row" aria-label="Project status">
+            <span>Active 0.1.x implementation</span>
+            <span>Android and iOS</span>
+            <span>MIT licensed</span>
           </div>
           <div class="signal-grid">
-            <div><strong>Local-first</strong><span>Prompts, images, and inference can remain on-device.</span></div>
-            <div><strong>Structured output</strong><span>Runtime personalization returns validated data, not executable UI code.</span></div>
-            <div><strong>Production boundary</strong><span>Policy, provenance, CI, and package checks are part of the implementation.</span></div>
+            <div>
+              <strong>Local-first execution</strong>
+              <span>Prompts, images, context, and inference can remain within the mobile application boundary.</span>
+            </div>
+            <div>
+              <strong>Deterministic controls</strong>
+              <span>Schemas, registries, policy, and validators remain authoritative when model output is probabilistic.</span>
+            </div>
+            <div>
+              <strong>Production-minded delivery</strong>
+              <span>Lifecycle handling, compatibility CI, package checks, SBOMs, and provenance are treated as implementation concerns.</span>
+            </div>
           </div>
         </div>
       </section>
 
-      <section id="outcomes" class="section">
+      <section id="implementation" class="section">
         <div class="section-heading">
           <p class="eyebrow">Current implementation</p>
-          <h2>Two layers, one explicit trust model.</h2>
+          <h2>Three layers with explicit ownership and trust boundaries.</h2>
           <p>
-            The repository now contains both the native inference runtime and the
-            companion component system. The boundary between them is intentional:
-            inference produces signals and structured data; application code and
-            component specifications remain authoritative.
+            Native inference provides model capability. The context layer provides
+            application-owned retrieval. The component layer constrains how generated
+            output can affect user interfaces. Each layer can be tested, replaced,
+            restricted, or disabled independently.
           </p>
         </div>
         <div class="card-grid three">
           <article class="card tint-blue">
             <p class="label">Runtime</p>
             <h3>On-device multimodal inference</h3>
-            <p>React Native APIs bridge to native Android and iOS model execution with streaming results, cancellation, image inputs, and explicit lifecycle control.</p>
+            <p>
+              React Native APIs bridge to Android and iOS model execution with streamed
+              results, image inputs, cancellation, typed errors, and explicit lifecycle
+              control.
+            </p>
           </article>
           <article class="card tint-green">
             <p class="label">Context</p>
             <h3>Offline-first retrieval interfaces</h3>
-            <p>An interface-driven context engine supports application-owned storage, bounded retrieval, TTL policy, validation, and optional scoring without forcing a cloud dependency.</p>
+            <p>
+              An interface-driven context engine supports application-owned storage,
+              bounded retrieval, TTL policy, validation, and optional scoring without
+              requiring a hosted data service.
+            </p>
           </article>
           <article class="card tint-amber">
             <p class="label">Components</p>
             <h3>Governed adaptive UI</h3>
-            <p>Typed ComponentSpecs, schema validation, registries, generators, policy checks, and bounded personalization primitives constrain how AI can affect rendered interfaces.</p>
+            <p>
+              Typed ComponentSpecs, registries, generators, schema validation, policy
+              checks, and bounded personalization constrain how AI can influence rendered
+              interfaces.
+            </p>
           </article>
         </div>
       </section>
@@ -87,15 +123,18 @@
           <p class="eyebrow">Architecture</p>
           <h2>Keep model capability behind application-owned contracts.</h2>
           <p>
-            Amaryllis separates native inference, context retrieval, component
-            definition, and runtime personalization so each boundary can be tested,
-            governed, replaced, or disabled independently.
+            The model is a capability provider, not the authority. Application code owns
+            model selection, storage, lifecycle, rendering, fallback behavior, and policy.
+            Runtime model output is treated as untrusted input before it reaches product UI.
           </p>
+          <a class="text-link" href="https://github.com/hackelia-micrantha/amaryllis/blob/main/docs/security-model.md">Read the security model</a>
         </div>
         <div class="flow" aria-label="Amaryllis architecture flow">
           <div><span>Application UI</span><small>React Native components and product logic</small></div>
           <b>↓</b>
-          <div><span>Amaryllis APIs</span><small>Provider, hooks, controller, context interfaces</small></div>
+          <div><span>Contracts and policy</span><small>Specs, schemas, registries, validation, and lifecycle rules</small></div>
+          <b>↓</b>
+          <div><span>Amaryllis APIs</span><small>Provider, hooks, controller, and context interfaces</small></div>
           <b>↓</b>
           <div><span>Native runtime</span><small>Android and iOS on-device model execution</small></div>
           <b>↓</b>
@@ -105,13 +144,29 @@
 
       <section class="section">
         <div class="section-heading">
-          <p class="eyebrow">Operational outcomes</p>
-          <h2>Built past the demo boundary.</h2>
+          <p class="eyebrow">Engineering scope</p>
+          <h2>The implementation includes more than a happy-path AI demo.</h2>
+          <p>
+            Amaryllis is also a systems-engineering exercise across native mobile APIs,
+            deterministic validation, secure delivery, and long-lived package boundaries.
+          </p>
         </div>
         <div class="card-grid three compact">
-          <article class="card"><h3>Predictable failure modes</h3><p>Cancellation, lifecycle cleanup, bounded inputs, typed errors, and validation paths are explicit API concerns.</p></article>
-          <article class="card"><h3>Reviewable generation</h3><p>Build-time component generation passes through schemas, policy, static checks, deterministic packaging, and human review.</p></article>
-          <article class="card"><h3>Supply-chain evidence</h3><p>CI includes compatibility checks, package validation, repository and package-scoped SBOM generation, and release provenance controls.</p></article>
+          <article class="card">
+            <p class="label">Mobile systems</p>
+            <h3>Native runtime integration</h3>
+            <p>React Native modules, Android and iOS build paths, native resource management, streaming APIs, cancellation, and compatibility testing.</p>
+          </article>
+          <article class="card">
+            <p class="label">AI governance</p>
+            <h3>Deterministic control surfaces</h3>
+            <p>Typed contracts, schema validation, import and capability restrictions, registry authority, bounded patches, and explicit non-goals.</p>
+          </article>
+          <article class="card">
+            <p class="label">Delivery assurance</p>
+            <h3>Reviewable software supply chain</h3>
+            <p>Change-aware CI, package and entrypoint validation, compatibility matrices, repository and package SBOMs, and release provenance controls.</p>
+          </article>
         </div>
       </section>
 
@@ -120,21 +175,65 @@
           <p class="eyebrow">@micrantha/amaryllis-components</p>
           <h2>Adaptive components without arbitrary runtime code generation.</h2>
           <p>
-            ComponentSpec is the source of truth. It declares structure, props,
-            target runtime, allowed AI behavior, and generation contracts before a
-            model is involved.
+            ComponentSpec is the source of truth. It declares structure, props, target
+            runtime, allowed AI behavior, and generation contracts before a model is
+            involved.
           </p>
         </div>
         <div class="mode-grid">
-          <article><span>01</span><h3>Scaffold</h3><p>Generate source at build time, then validate, inspect, test, and publish it through the normal software delivery path.</p></article>
-          <article><span>02</span><h3>Customize</h3><p>Create bounded variants within declared slots, design tokens, copy rules, layouts, and import allowlists.</p></article>
-          <article><span>03</span><h3>Personalize</h3><p>Return schema-validated props, variants, slot text, or constrained JSON patches at runtime—never raw JSX, TSX, imports, or scripts.</p></article>
+          <article>
+            <span>01</span>
+            <h3>Scaffold</h3>
+            <p>Generate source at build time, then validate, inspect, test, and publish it through the normal software delivery path.</p>
+          </article>
+          <article>
+            <span>02</span>
+            <h3>Customize</h3>
+            <p>Create bounded variants within declared slots, design tokens, copy rules, layouts, and import allowlists.</p>
+          </article>
+          <article>
+            <span>03</span>
+            <h3>Personalize</h3>
+            <p>Return schema-validated props, variants, slot text, or constrained JSON patches at runtime—never raw JSX, TSX, imports, or scripts.</p>
+          </article>
         </div>
         <div class="guardrails">
-          <div><strong>Authoritative registry</strong><span>Only known component identities and versions can be resolved.</span></div>
-          <div><strong>Schema + policy validation</strong><span>Every generated or personalized output is treated as untrusted input.</span></div>
-          <div><strong>Capability limits</strong><span>Network, imports, tokens, slots, and patch paths can be explicitly constrained.</span></div>
-          <div><strong>Provenance</strong><span>Generation inputs, outputs, versions, and approvals can remain attributable.</span></div>
+          <div><strong>Authoritative registry</strong><span>Only known component identities, versions, and implementations can be resolved.</span></div>
+          <div><strong>Schema and policy validation</strong><span>Every generated or personalized output is treated as untrusted input.</span></div>
+          <div><strong>Capability limits</strong><span>Network use, imports, design tokens, slots, and patch paths can be explicitly constrained.</span></div>
+          <div><strong>Attributable changes</strong><span>Generation inputs, outputs, versions, validator results, and approvals can remain reviewable.</span></div>
+        </div>
+      </section>
+
+      <section id="fit" class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Where it fits</p>
+          <h2>A focused foundation, not a universal AI platform.</h2>
+          <p>
+            The strongest fit is mobile software where privacy, offline behavior,
+            latency, application ownership, and constrained adaptation matter more than
+            access to the largest hosted model.
+          </p>
+        </div>
+        <div class="fit-grid">
+          <article class="fit-card fit-positive">
+            <p class="label">Strong fit</p>
+            <ul>
+              <li>Privacy-sensitive or intermittently connected mobile workflows</li>
+              <li>On-device text and image features with responsive streaming UI</li>
+              <li>Adaptive interfaces governed by schemas, policy, and known components</li>
+              <li>Teams that need inspectable AI-assisted generation and release evidence</li>
+            </ul>
+          </article>
+          <article class="fit-card">
+            <p class="label">Current constraints</p>
+            <ul>
+              <li>The project is an active 0.1.x implementation and APIs may evolve</li>
+              <li>Applications own model distribution, storage, updates, and device performance budgets</li>
+              <li>Local inference shifts risk; it does not remove client compromise, reverse engineering, or model tampering concerns</li>
+              <li>It is not a replacement for server-scale training, fleet orchestration, or unrestricted generative UI</li>
+            </ul>
+          </article>
         </div>
       </section>
 
@@ -163,7 +262,9 @@
           </div>
           <div class="code-card">
             <p class="label">Streaming</p>
-            <pre><code>const generate = useInferenceAsync({
+            <pre><code>import { useInferenceAsync } from '@micrantha/react-native-amaryllis';
+
+const generate = useInferenceAsync({
   onResult: (chunk, isFinal) =&gt; {
     append(chunk);
     if (isFinal) finish();
@@ -179,10 +280,10 @@ await generate({ prompt, images });</code></pre>
       <section class="section callout">
         <div>
           <p class="eyebrow">Project direction</p>
-          <h2>Private-by-default mobile intelligence with enforceable UI boundaries.</h2>
+          <h2>Private mobile intelligence with explicit control boundaries.</h2>
           <p>
             Current work continues to harden native compatibility, model delivery,
-            package publication, context integration, component governance, and
+            context integration, package publication, component governance, and
             evidence-producing release workflows.
           </p>
         </div>
@@ -195,7 +296,7 @@ await generate({ prompt, images });</code></pre>
 
     <footer class="footer shell">
       <span>Amaryllis by Micrantha</span>
-      <span>MIT licensed</span>
+      <span>Open source · MIT</span>
       <a href="https://github.com/hackelia-micrantha/amaryllis/blob/main/SECURITY.md">Security policy</a>
     </footer>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,272 +3,172 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>React Native Amaryllis</title>
+    <title>Amaryllis — Governed on-device AI for mobile</title>
     <meta
       name="description"
-      content="A React Native on-device multimodal AI module, with a companion amaryllis-components proposal for governed adaptive components."
+      content="Amaryllis combines a React Native on-device multimodal AI runtime with governed, spec-driven adaptive components."
     />
     <link rel="stylesheet" href="site.css" />
   </head>
   <body>
-    <div class="bg-orbit"></div>
-    <header class="nav">
-      <div class="brand">
-        <img src="amaryllis-128.png" alt="Amaryllis logo" />
-        <span>React Native Amaryllis</span>
-      </div>
-      <nav class="nav-links">
-        <a href="#features">Features</a>
-        <a href="#best-practices">Best practices</a>
-        <a href="#rfc">RFC</a>
-        <a href="#usage">Usage</a>
-        <a href="#demo">Demo</a>
+    <header class="nav shell">
+      <a class="brand" href="#top" aria-label="Amaryllis home">
+        <img src="amaryllis-128.png" alt="" />
+        <span>Amaryllis</span>
+      </a>
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="#outcomes">Outcomes</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#components">Components</a>
+        <a href="#quickstart">Quickstart</a>
         <a href="https://github.com/hackelia-micrantha/amaryllis">GitHub</a>
       </nav>
     </header>
 
-    <main>
-      <section class="hero">
-        <div class="hero-text">
-          <p class="eyebrow">On-device multimodal AI for React Native</p>
-          <h1>Ship native mobile AI experiences with streaming results.</h1>
+    <main id="top" class="shell page-stack">
+      <section class="hero panel">
+        <div class="hero-mark">
+          <img src="amaryllis-128.png" alt="Amaryllis flower mark" />
+        </div>
+        <div>
+          <p class="eyebrow">Private mobile AI · governed adaptive UI</p>
+          <h1>Build mobile AI that stays local, bounded, and reviewable.</h1>
           <p class="lead">
-            Amaryllis helps teams ship private, responsive offline AI for local
-            text, image, and streaming workflows. A companion module, working name
-            amaryllis-components, extends that foundation into governed adaptive
-            components.
+            Amaryllis is a React Native foundation for on-device multimodal inference,
+            streaming interaction, offline-first context, and spec-driven AI-enabled
+            components. It is designed for teams that need useful AI behavior without
+            turning runtime model output into an unrestricted code execution surface.
           </p>
-          <p class="lead">
-            You choose which models run on-device; Google Gemma is the recommended
-            starting point.
-          </p>
-          <div class="cta-row">
-            <a class="btn primary" href="#usage">Use on-device inference</a>
-            <a class="btn ghost" href="#rfc">Explore amaryllis-components</a>
+          <div class="actions">
+            <a class="button" href="#quickstart">Start with the runtime</a>
+            <a class="button button-outline" href="#components">Explore components</a>
+            <a class="button button-outline" href="https://github.com/hackelia-micrantha/amaryllis/tree/main/docs">Read the docs</a>
           </div>
-        </div>
-        <div class="hero-card">
-          <div class="card-header">Install</div>
-          <pre><code>npm install react-native-amaryllis
-# or
-yarn add react-native-amaryllis
-# or
-pnpm add react-native-amaryllis</code></pre>
-          <div class="chip-row">
-            <span class="chip">Android</span>
-            <span class="chip">iOS</span>
-            <span class="chip">Streaming</span>
-            <span class="chip">Multimodal</span>
-            <span class="chip">Components RFC</span>
+          <div class="signal-grid">
+            <div><strong>Local-first</strong><span>Prompts, images, and inference can remain on-device.</span></div>
+            <div><strong>Structured output</strong><span>Runtime personalization returns validated data, not executable UI code.</span></div>
+            <div><strong>Production boundary</strong><span>Policy, provenance, CI, and package checks are part of the implementation.</span></div>
           </div>
         </div>
       </section>
 
-      <section id="features" class="features">
-        <div class="section-title">
-          <h2>Why teams use Amaryllis</h2>
+      <section id="outcomes" class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Current implementation</p>
+          <h2>Two layers, one explicit trust model.</h2>
           <p>
-            Keep inference on-device for offline AI, lower latency, stronger
-            privacy, and native mobile experiences without giving up streaming,
-            multimodal requests, or developer control.
+            The repository now contains both the native inference runtime and the
+            companion component system. The boundary between them is intentional:
+            inference produces signals and structured data; application code and
+            component specifications remain authoritative.
           </p>
         </div>
-        <div class="feature-grid">
-          <article class="feature">
-            <h3>Native LLM engine</h3>
-            <p>
-              Optimized pipelines for Android and iOS with predictable startup.
-            </p>
+        <div class="card-grid three">
+          <article class="card tint-blue">
+            <p class="label">Runtime</p>
+            <h3>On-device multimodal inference</h3>
+            <p>React Native APIs bridge to native Android and iOS model execution with streaming results, cancellation, image inputs, and explicit lifecycle control.</p>
           </article>
-          <article class="feature">
-            <h3>Multimodal support</h3>
-            <p>Send prompts with images for grounded, visual responses.</p>
+          <article class="card tint-green">
+            <p class="label">Context</p>
+            <h3>Offline-first retrieval interfaces</h3>
+            <p>An interface-driven context engine supports application-owned storage, bounded retrieval, TTL policy, validation, and optional scoring without forcing a cloud dependency.</p>
           </article>
-          <article class="feature">
-            <h3>Streaming hooks</h3>
-            <p>Use hooks and observables to render partial tokens fast.</p>
-          </article>
-          <article class="feature">
-            <h3>Context provider</h3>
-            <p>Centralize configuration for the entire React Native app.</p>
-          </article>
-          <article class="feature">
-            <h3>LoRA customization</h3>
-            <p>Fine tune behavior with LoRA adapters on GPU devices.</p>
-          </article>
-          <article class="feature">
-            <h3>Developer control</h3>
-            <p>Cancel and manage sessions with explicit APIs.</p>
+          <article class="card tint-amber">
+            <p class="label">Components</p>
+            <h3>Governed adaptive UI</h3>
+            <p>Typed ComponentSpecs, schema validation, registries, generators, policy checks, and bounded personalization primitives constrain how AI can affect rendered interfaces.</p>
           </article>
         </div>
       </section>
 
-      <section id="best-practices" class="best-practices">
-        <div class="section-title">
-          <h2>Best practices for production apps</h2>
-          <p>Keep performance, memory, and safety predictable.</p>
+      <section id="architecture" class="section split">
+        <div class="section-heading">
+          <p class="eyebrow">Architecture</p>
+          <h2>Keep model capability behind application-owned contracts.</h2>
+          <p>
+            Amaryllis separates native inference, context retrieval, component
+            definition, and runtime personalization so each boundary can be tested,
+            governed, replaced, or disabled independently.
+          </p>
         </div>
-        <div class="feature-grid">
-          <article class="feature">
-            <h3>Stream by default</h3>
-            <p>Show partial tokens early for a responsive UX.</p>
-          </article>
-          <article class="feature">
-            <h3>Cancel on unmount</h3>
-            <p>Always cancel async inference in cleanup handlers.</p>
-          </article>
-          <article class="feature">
-            <h3>Constrain inputs</h3>
-            <p>Limit image count and size to protect memory.</p>
-          </article>
-          <article class="feature">
-            <h3>Validate file paths</h3>
-            <p>Prevent invalid or unsafe native file access.</p>
-          </article>
-          <article class="feature">
-            <h3>Handle errors explicitly</h3>
-            <p>Surface custom error types and graceful fallbacks.</p>
-          </article>
-          <article class="feature">
-            <h3>Document model sources</h3>
-            <p>Track model versions and update strategies.</p>
-          </article>
+        <div class="flow" aria-label="Amaryllis architecture flow">
+          <div><span>Application UI</span><small>React Native components and product logic</small></div>
+          <b>↓</b>
+          <div><span>Amaryllis APIs</span><small>Provider, hooks, controller, context interfaces</small></div>
+          <b>↓</b>
+          <div><span>Native runtime</span><small>Android and iOS on-device model execution</small></div>
+          <b>↓</b>
+          <div><span>Model assets</span><small>Application-selected local models and adapters</small></div>
         </div>
       </section>
 
-      <section id="rfc" class="rfc">
-        <div class="section-title">
-          <p class="eyebrow">Companion module RFC</p>
-          <h2>Components for adaptive on-device UI</h2>
+      <section class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Operational outcomes</p>
+          <h2>Built past the demo boundary.</h2>
+        </div>
+        <div class="card-grid three compact">
+          <article class="card"><h3>Predictable failure modes</h3><p>Cancellation, lifecycle cleanup, bounded inputs, typed errors, and validation paths are explicit API concerns.</p></article>
+          <article class="card"><h3>Reviewable generation</h3><p>Build-time component generation passes through schemas, policy, static checks, deterministic packaging, and human review.</p></article>
+          <article class="card"><h3>Supply-chain evidence</h3><p>CI includes compatibility checks, package validation, repository and package-scoped SBOM generation, and release provenance controls.</p></article>
+        </div>
+      </section>
+
+      <section id="components" class="section feature-panel">
+        <div class="section-heading">
+          <p class="eyebrow">@micrantha/amaryllis-components</p>
+          <h2>Adaptive components without arbitrary runtime code generation.</h2>
           <p>
-            The proposed companion module adds governed component specs,
-            build-time generation workflows, and safe runtime personalization on
-            top of the base Amaryllis inference layer.
+            ComponentSpec is the source of truth. It declares structure, props,
+            target runtime, allowed AI behavior, and generation contracts before a
+            model is involved.
           </p>
         </div>
-        <div class="companion-callout">
-          <div>
-            <div class="card-header">Proposed package</div>
-            <h3>amaryllis-components</h3>
+        <div class="mode-grid">
+          <article><span>01</span><h3>Scaffold</h3><p>Generate source at build time, then validate, inspect, test, and publish it through the normal software delivery path.</p></article>
+          <article><span>02</span><h3>Customize</h3><p>Create bounded variants within declared slots, design tokens, copy rules, layouts, and import allowlists.</p></article>
+          <article><span>03</span><h3>Personalize</h3><p>Return schema-validated props, variants, slot text, or constrained JSON patches at runtime—never raw JSX, TSX, imports, or scripts.</p></article>
+        </div>
+        <div class="guardrails">
+          <div><strong>Authoritative registry</strong><span>Only known component identities and versions can be resolved.</span></div>
+          <div><strong>Schema + policy validation</strong><span>Every generated or personalized output is treated as untrusted input.</span></div>
+          <div><strong>Capability limits</strong><span>Network, imports, tokens, slots, and patch paths can be explicitly constrained.</span></div>
+          <div><strong>Provenance</strong><span>Generation inputs, outputs, versions, and approvals can remain attributable.</span></div>
+        </div>
+      </section>
+
+      <section id="quickstart" class="section">
+        <div class="section-heading">
+          <p class="eyebrow">Quickstart</p>
+          <h2>Start with local inference.</h2>
+          <p>The application owns model selection, distribution, storage, privacy decisions, and fallback behavior.</p>
+        </div>
+        <div class="code-grid">
+          <div class="code-card">
+            <p class="label">Install</p>
+            <pre><code>npm install @micrantha/react-native-amaryllis</code></pre>
           </div>
-          <p>
-            Keep <strong>react-native-amaryllis</strong> focused on on-device
-            multimodal inference. Put adaptive component specs, registries,
-            validators, and personalization contracts in a companion package.
-          </p>
-        </div>
-        <div class="rfc-modes" aria-label="AI modes">
-          <article class="rfc-mode">
-            <span>Mode 1</span>
-            <h3>Scaffold</h3>
-            <p>
-              Build-time AI creates component source from a ComponentSpec, then
-              the result goes through validation, review, and publishing.
-            </p>
-          </article>
-          <article class="rfc-mode">
-            <span>Mode 2</span>
-            <h3>Customize</h3>
-            <p>
-              AI creates bounded variants within declared slots, layouts, copy
-              rules, and design-token constraints.
-            </p>
-          </article>
-          <article class="rfc-mode">
-            <span>Mode 3</span>
-            <h3>Runtime personalization</h3>
-            <p>
-              On-device AI returns schema-validated props, variants, slot text,
-              or JSON patches. It does not emit executable component code.
-            </p>
-          </article>
-        </div>
-        <div class="rfc-grid">
-          <article class="rfc-panel">
-            <div class="card-header">Source of truth</div>
-            <h3>ComponentSpec</h3>
-            <p>
-              A typed, versioned spec defines UI structure, behavior, allowed AI
-              operations, target runtime, and policy requirements before code is
-              generated.
-            </p>
-          </article>
-          <article class="rfc-panel">
-            <div class="card-header">Generation model</div>
-            <h3>Validated pipeline</h3>
-            <p>
-              Build-time TSX generation moves through validation, static checks,
-              preview, diff review, and artifact publishing instead of direct
-              freeform AI code edits.
-            </p>
-          </article>
-          <article class="rfc-panel">
-            <div class="card-header">On-device AI</div>
-            <h3>Structured customization</h3>
-            <p>
-              Runtime AI can fill slots, choose variants, and select design
-              tokens, but it must return validated data, not executable TSX,
-              JSX, JavaScript, imports, or raw markup.
-            </p>
-          </article>
-          <article class="rfc-panel">
-            <div class="card-header">Governance</div>
-            <h3>Policy enforcement</h3>
-            <p>
-              Import allowlists, accessibility checks, design token rules,
-              network restrictions, provenance metadata, and approval gates keep
-              generated output reviewable.
-            </p>
-          </article>
-        </div>
-        <div class="rfc-flow" aria-label="RFC workflow">
-          <span>Spec</span>
-          <span>Validation</span>
-          <span>Build-time code</span>
-          <span>Runtime data</span>
-          <span>Static checks</span>
-          <span>Preview</span>
-          <span>Publish</span>
-        </div>
-        <div class="rfc-actions">
-          <a class="btn ghost" href="amaryllis-components-one-pager.md"
-            >Read the external one-pager</a
-          >
-        </div>
-      </section>
+          <div class="code-card">
+            <p class="label">Provider</p>
+            <pre><code>import { LLMProvider } from '@micrantha/react-native-amaryllis';
 
-      <section id="usage" class="usage">
-        <div class="section-title">
-          <h2>Quickstart</h2>
-          <p>Wrap your app, then generate from hooks.</p>
-        </div>
-        <div class="usage-grid">
-          <div class="usage-card">
-            <div class="card-header">Provider setup</div>
-            <pre><code>import { LLMProvider } from 'react-native-amaryllis';
-
-&lt;LLMProvider
-  config={{
-    modelPath: 'gemma3-1b-it-int4.task',
-    visionEncoderPath: 'mobilenet_v3_small.tflite',
-    visionAdapterPath: 'mobilenet_v3_small.tflite',
-    maxTopK: 32,
-    maxNumImages: 2,
-    maxTokens: 512,
-  }}
-&gt;
-  {/* App components */}
+&lt;LLMProvider config={{
+  modelPath: 'gemma3-1b-it-int4.task',
+  maxTokens: 512,
+  maxNumImages: 2,
+}}&gt;
+  &lt;App /&gt;
 &lt;/LLMProvider&gt;</code></pre>
           </div>
-          <div class="usage-card">
-            <div class="card-header">Streaming inference</div>
-            <pre><code>import { useInferenceAsync } from 'react-native-amaryllis';
-
-const generate = useInferenceAsync({
+          <div class="code-card">
+            <p class="label">Streaming</p>
+            <pre><code>const generate = useInferenceAsync({
   onResult: (chunk, isFinal) =&gt; {
-    // Update UI with tokens
+    append(chunk);
+    if (isFinal) finish();
   },
-  onError: (err) =&gt; setError(err),
+  onError: handleError,
 });
 
 await generate({ prompt, images });</code></pre>
@@ -276,26 +176,27 @@ await generate({ prompt, images });</code></pre>
         </div>
       </section>
 
-      <section id="demo" class="demo">
-        <div class="section-title">
-          <h2>Live demo preview</h2>
-          <p>Sample UI built on top of Amaryllis streaming hooks.</p>
+      <section class="section callout">
+        <div>
+          <p class="eyebrow">Project direction</p>
+          <h2>Private-by-default mobile intelligence with enforceable UI boundaries.</h2>
+          <p>
+            Current work continues to harden native compatibility, model delivery,
+            package publication, context integration, component governance, and
+            evidence-producing release workflows.
+          </p>
         </div>
-        <div class="demo-card">
-          <video controls preload="metadata" poster="amaryllis.png">
-            <source src="demo.mp4" type="video/mp4" />
-            Your browser does not support the video tag.
-          </video>
+        <div class="actions">
+          <a class="button" href="https://github.com/hackelia-micrantha/amaryllis">View the implementation</a>
+          <a class="button button-outline" href="https://github.com/hackelia-micrantha/amaryllis/issues">Review the roadmap</a>
         </div>
       </section>
     </main>
 
-    <footer class="footer">
-      <div class="footer-content">
-        <span>Amaryllis for React Native</span>
-        <span>MIT licensed</span>
-        <span>Security &amp; Support in repo</span>
-      </div>
+    <footer class="footer shell">
+      <span>Amaryllis by Micrantha</span>
+      <span>MIT licensed</span>
+      <a href="https://github.com/hackelia-micrantha/amaryllis/blob/main/SECURITY.md">Security policy</a>
     </footer>
   </body>
 </html>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,491 +1,125 @@
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,800&family=Space+Grotesk:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;9..144,700&family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  --bg: #0f1513;
-  --bg-2: #18211d;
-  --accent: #f2a14a;
-  --accent-2: #e46d5a;
-  --mint: #69d2b4;
-  --text: #f5f0e9;
-  --muted: #b9b2a7;
-  --card: #121b18;
-  --stroke: #2a3632;
-  --shadow: rgba(5, 6, 8, 0.55);
+  --ink: #17211f;
+  --muted: #5f6b68;
+  --line: #dce3df;
+  --paper: #f6f4ee;
+  --surface: rgba(255, 255, 255, 0.82);
+  --green: #1f6d55;
+  --green-soft: #e8f2ec;
+  --blue-soft: #e8f0f7;
+  --amber-soft: #f7efe0;
+  --shadow: 0 18px 44px rgba(31, 42, 42, 0.09);
 }
 
-* {
-  box-sizing: border-box;
-}
-
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
 body {
   margin: 0;
-  font-family: 'Space Grotesk', system-ui, sans-serif;
-  color: var(--text);
+  color: var(--ink);
   background:
-    radial-gradient(1200px 600px at 20% 0%, #1e2c26 0%, transparent 60%),
-    radial-gradient(900px 500px at 80% 10%, #2d1f1a 0%, transparent 55%),
-    linear-gradient(140deg, var(--bg), var(--bg-2));
-  min-height: 100vh;
-  position: relative;
-  overflow-x: hidden;
+    radial-gradient(circle at 10% 0%, rgba(210, 228, 218, 0.65), transparent 32rem),
+    radial-gradient(circle at 92% 8%, rgba(218, 229, 240, 0.72), transparent 34rem),
+    var(--paper);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
 }
 
-.bg-orbit {
-  position: fixed;
-  inset: -30vh -20vw;
-  background:
-    radial-gradient(
-      circle at 60% 40%,
-      rgba(105, 210, 180, 0.12),
-      transparent 55%
-    ),
-    radial-gradient(
-      circle at 40% 30%,
-      rgba(242, 161, 74, 0.12),
-      transparent 50%
-    ),
-    repeating-linear-gradient(
-      115deg,
-      rgba(255, 255, 255, 0.03) 0,
-      rgba(255, 255, 255, 0.03) 1px,
-      transparent 1px,
-      transparent 12px
-    );
-  pointer-events: none;
-  z-index: 0;
-  opacity: 0.8;
-}
+a { color: var(--green); }
+.shell { width: min(1180px, calc(100% - 40px)); margin-inline: auto; }
 
 .nav {
-  position: sticky;
-  top: 0;
-  z-index: 2;
+  min-height: 76px;
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  padding: 24px clamp(20px, 5vw, 72px);
-  backdrop-filter: blur(18px);
-  background: rgba(9, 13, 12, 0.7);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.brand img {
-  width: 36px;
-  height: 36px;
-}
-
-.nav-links {
-  display: flex;
-  gap: 20px;
-}
-
-.nav-links a {
-  color: var(--muted);
-  text-decoration: none;
-  font-weight: 500;
-  transition: color 0.2s ease;
-}
-
-.nav-links a:hover {
-  color: var(--text);
-}
-
-main {
-  position: relative;
-  z-index: 1;
-}
-
-.hero {
-  display: grid;
-  gap: 32px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  padding: 72px clamp(20px, 6vw, 90px) 56px;
-}
-
-.hero-text h1 {
-  font-family: 'Fraunces', serif;
-  font-size: clamp(2.4rem, 3.6vw, 3.6rem);
-  line-height: 1.05;
-  margin: 12px 0 16px;
-}
-
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.28em;
-  font-size: 0.72rem;
-  color: var(--mint);
-  margin: 0;
-}
-
-.lead {
-  color: var(--muted);
-  font-size: 1.1rem;
-  line-height: 1.6;
-  max-width: 520px;
-}
-
-.cta-row {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 22px;
-}
-
-.btn {
-  padding: 12px 20px;
-  border-radius: 999px;
-  text-decoration: none;
-  font-weight: 600;
-  border: 1px solid transparent;
-  transition:
-    transform 0.2s ease,
-    border 0.2s ease;
-}
-
-.btn.primary {
-  background: linear-gradient(120deg, var(--accent), var(--accent-2));
-  color: #14100d;
-  box-shadow: 0 12px 30px rgba(228, 109, 90, 0.35);
-}
-
-.btn.primary:hover {
-  transform: translateY(-2px);
-}
-
-.btn.ghost {
-  border-color: var(--stroke);
-  color: var(--text);
-}
-
-.hero-card {
-  background: var(--card);
-  border-radius: 20px;
-  padding: 24px;
-  box-shadow: 0 24px 60px var(--shadow);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.card-header {
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.7rem;
-  color: var(--muted);
-  margin-bottom: 12px;
-}
-
-pre {
-  margin: 0 0 18px;
-  padding: 16px;
-  background: #0b100f;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  overflow-x: auto;
-}
-
-code {
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
-  font-size: 0.85rem;
-  color: #fbd9b2;
-}
-
-.chip-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.chip {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(105, 210, 180, 0.12);
-  color: var(--mint);
-  font-size: 0.8rem;
-  border: 1px solid rgba(105, 210, 180, 0.35);
-}
-
-.section-title {
-  padding: 0 clamp(20px, 6vw, 90px);
-}
-
-.section-title h2 {
-  font-family: 'Fraunces', serif;
-  font-size: clamp(1.9rem, 2.8vw, 2.6rem);
-  margin-bottom: 8px;
-}
-
-.section-title p {
-  color: var(--muted);
-  margin-top: 0;
-}
-
-.features {
-  padding: 40px 0 20px;
-}
-
-.best-practices {
-  padding: 30px 0 10px;
-}
-
-.feature-grid {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding: 24px clamp(20px, 6vw, 90px);
-}
-
-.feature {
-  background: rgba(18, 27, 24, 0.8);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 18px;
-  border-radius: 16px;
-  transition:
-    transform 0.25s ease,
-    border 0.2s ease;
-}
-
-.feature:hover {
-  transform: translateY(-4px);
-  border-color: rgba(242, 161, 74, 0.4);
-}
-
-.feature h3 {
-  margin-top: 0;
-}
-
-.feature p {
-  color: var(--muted);
-  margin-bottom: 0;
-}
-
-.usage {
-  padding: 30px 0 20px;
-}
-
-.rfc {
-  padding: 36px 0 24px;
-}
-
-.rfc-grid {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  padding: 24px clamp(20px, 6vw, 90px) 16px;
-}
-
-.companion-callout {
-  align-items: center;
-  background: rgba(18, 27, 24, 0.88);
-  border: 1px solid rgba(105, 210, 180, 0.22);
-  border-radius: 16px;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: minmax(180px, 0.75fr) minmax(260px, 1.25fr);
-  margin: 24px clamp(20px, 6vw, 90px) 0;
-  padding: 20px;
-}
-
-.companion-callout h3 {
-  margin: 0;
-}
-
-.companion-callout p {
-  color: var(--muted);
-  line-height: 1.55;
-  margin: 0;
-}
-
-.rfc-modes {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding: 24px clamp(20px, 6vw, 90px) 0;
-}
-
-.rfc-mode {
-  background: rgba(242, 161, 74, 0.1);
-  border: 1px solid rgba(242, 161, 74, 0.28);
-  border-radius: 16px;
-  padding: 18px;
-}
-
-.rfc-mode span {
-  color: var(--accent);
-  display: block;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  margin-bottom: 10px;
-  text-transform: uppercase;
-}
-
-.rfc-mode h3 {
-  margin: 0 0 8px;
-}
-
-.rfc-mode p {
-  color: var(--muted);
-  line-height: 1.55;
-  margin: 0;
-}
-
-.rfc-panel {
-  background: rgba(18, 27, 24, 0.88);
-  border: 1px solid rgba(105, 210, 180, 0.18);
-  border-radius: 16px;
-  padding: 20px;
-  box-shadow: 0 18px 38px var(--shadow);
-}
-
-.rfc-panel h3 {
-  margin: 0 0 10px;
-}
-
-.rfc-panel p {
-  color: var(--muted);
-  line-height: 1.55;
-  margin: 0;
-}
-
-.rfc-flow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 4px clamp(20px, 6vw, 90px) 0;
-}
-
-.rfc-flow span {
-  color: var(--text);
-  background: rgba(242, 161, 74, 0.12);
-  border: 1px solid rgba(242, 161, 74, 0.28);
-  border-radius: 999px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  padding: 8px 12px;
-}
-
-.rfc-actions {
-  padding: 22px clamp(20px, 6vw, 90px) 0;
-}
-
-.usage-grid {
-  display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  padding: 24px clamp(20px, 6vw, 90px);
-}
-
-.usage-card {
-  background: var(--card);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 20px;
-  box-shadow: 0 20px 40px var(--shadow);
-}
-
-.demo {
-  padding: 30px 0 70px;
-}
-
-.demo-card {
-  margin: 20px clamp(20px, 6vw, 90px) 0;
-  background: rgba(12, 18, 16, 0.8);
-  border-radius: 20px;
-  padding: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 16px 40px var(--shadow);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.demo video {
-  width: 100%;
-  border-radius: 14px;
-  max-width: 360px;
-  aspect-ratio: 9/20;
-}
-
-.footer {
-  padding: 26px clamp(20px, 6vw, 90px) 40px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.footer-content {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 12px;
-  color: var(--muted);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation: none !important;
-    transition: none !important;
-  }
-}
-
-@media (max-width: 720px) {
-  .nav {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-  }
-
-  .nav-links {
-    flex-wrap: wrap;
-  }
-
-  .companion-callout {
-    grid-template-columns: 1fr;
-  }
-}
-
-.hero,
-.feature,
-.companion-callout,
-.rfc-mode,
-.rfc-panel,
-.usage-card,
-.demo-card {
-  animation: float-in 0.8s ease both;
-}
-
-.feature:nth-child(2) {
-  animation-delay: 0.05s;
-}
-
-.feature:nth-child(3) {
-  animation-delay: 0.1s;
-}
-
-.feature:nth-child(4) {
-  animation-delay: 0.15s;
-}
-
-.feature:nth-child(5) {
-  animation-delay: 0.2s;
-}
-
-.feature:nth-child(6) {
-  animation-delay: 0.25s;
-}
-
-@keyframes float-in {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  gap: 24px;
+  border-bottom: 1px solid rgba(95, 107, 104, 0.18);
+}
+.brand { display: inline-flex; align-items: center; gap: 11px; color: var(--ink); text-decoration: none; font-weight: 700; }
+.brand img { width: 38px; height: 38px; }
+.nav-links { display: flex; flex-wrap: wrap; gap: 18px; }
+.nav-links a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 600; }
+.nav-links a:hover { color: var(--green); }
+
+.page-stack { display: grid; gap: 74px; padding-block: 42px 84px; }
+.panel, .feature-panel, .callout {
+  border: 1px solid rgba(255,255,255,0.88);
+  background: linear-gradient(135deg, rgba(250,248,242,0.96), rgba(236,243,238,0.94) 52%, rgba(226,235,244,0.94));
+  box-shadow: var(--shadow);
+  border-radius: 32px;
+}
+.hero { display: grid; grid-template-columns: 190px 1fr; gap: 42px; align-items: center; padding: clamp(28px, 5vw, 56px); }
+.hero-mark { border: 1px solid #d9e2dd; border-radius: 30px; background: linear-gradient(180deg, rgba(219,234,247,0.85), rgba(255,255,255,0.96)); padding: 24px; box-shadow: 0 16px 36px rgba(31,42,42,0.09); }
+.hero-mark img { display: block; width: 100%; height: auto; }
+.eyebrow { margin: 0; color: var(--green); font-size: 0.72rem; line-height: 1.3; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase; }
+h1, h2 { font-family: Fraunces, Georgia, serif; line-height: 1.08; letter-spacing: -0.025em; }
+h1 { max-width: 830px; margin: 14px 0 20px; font-size: clamp(2.5rem, 5vw, 4.5rem); }
+h2 { margin: 10px 0 14px; font-size: clamp(2rem, 3.8vw, 3.15rem); }
+h3 { margin: 8px 0; line-height: 1.25; }
+.lead, .section-heading > p:last-child, .callout p { max-width: 820px; color: var(--muted); font-size: 1.04rem; }
+.actions { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 26px; }
+.button { display: inline-flex; align-items: center; justify-content: center; min-height: 43px; padding: 0 18px; border: 1px solid var(--green); border-radius: 999px; color: white; background: var(--green); text-decoration: none; font-size: 0.9rem; font-weight: 700; }
+.button:hover { transform: translateY(-1px); }
+.button-outline { color: var(--green); background: rgba(255,255,255,0.64); }
+.signal-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 34px; }
+.signal-grid div, .guardrails div { border: 1px solid var(--line); border-radius: 18px; background: rgba(255,255,255,0.76); padding: 15px; }
+.signal-grid strong, .signal-grid span, .guardrails strong, .guardrails span { display: block; }
+.signal-grid span, .guardrails span { margin-top: 5px; color: var(--muted); font-size: 0.84rem; line-height: 1.5; }
+
+.section { display: grid; gap: 24px; }
+.section-heading { max-width: 880px; }
+.card-grid { display: grid; gap: 16px; }
+.card-grid.three { grid-template-columns: repeat(3, 1fr); }
+.card { min-height: 220px; border: 1px solid var(--line); border-radius: 22px; background: var(--surface); padding: 24px; box-shadow: 0 12px 28px rgba(31,42,42,0.06); }
+.card p { color: var(--muted); }
+.card .label, .label { margin: 0 0 13px; color: #68726f; font-size: 0.69rem; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; }
+.tint-blue { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--blue-soft)); }
+.tint-green { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--green-soft)); }
+.tint-amber { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--amber-soft)); }
+.compact .card { min-height: 0; }
+
+.split { grid-template-columns: minmax(0, 1fr) minmax(360px, 0.8fr); align-items: start; }
+.flow { display: grid; gap: 9px; padding: 24px; border: 1px solid var(--line); border-radius: 24px; background: rgba(255,255,255,0.76); box-shadow: var(--shadow); }
+.flow div { padding: 15px 17px; border: 1px solid var(--line); border-radius: 15px; background: white; }
+.flow span, .flow small { display: block; }
+.flow span { font-weight: 700; }
+.flow small { margin-top: 3px; color: var(--muted); }
+.flow b { text-align: center; color: var(--green); }
+
+.feature-panel { padding: clamp(26px, 5vw, 52px); }
+.mode-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; }
+.mode-grid article { border: 1px solid rgba(31,109,85,0.22); border-radius: 20px; background: rgba(255,255,255,0.72); padding: 22px; }
+.mode-grid span { color: var(--green); font-weight: 800; font-size: 0.76rem; letter-spacing: 0.2em; }
+.mode-grid p { color: var(--muted); }
+.guardrails { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+
+.code-grid { display: grid; grid-template-columns: 0.65fr 1.35fr 1.35fr; gap: 16px; }
+.code-card { min-width: 0; border: 1px solid #26332f; border-radius: 20px; background: #111a17; padding: 19px; box-shadow: 0 18px 38px rgba(14,23,20,0.18); }
+.code-card .label { color: #9eb5ad; }
+pre { margin: 0; overflow-x: auto; white-space: pre; }
+code { color: #e8f2ed; font: 0.82rem/1.65 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+.callout { display: flex; align-items: end; justify-content: space-between; gap: 32px; padding: clamp(26px, 5vw, 48px); }
+.callout .actions { flex-shrink: 0; }
+.footer { display: flex; justify-content: space-between; gap: 20px; padding-block: 26px 42px; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.86rem; }
+.footer a { color: inherit; }
+
+@media (max-width: 900px) {
+  .hero { grid-template-columns: 1fr; }
+  .hero-mark { width: 140px; }
+  .signal-grid, .card-grid.three, .mode-grid, .code-grid { grid-template-columns: 1fr; }
+  .split { grid-template-columns: 1fr; }
+  .callout { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 680px) {
+  .shell { width: min(100% - 24px, 1180px); }
+  .nav { align-items: flex-start; flex-direction: column; padding-block: 16px; }
+  .nav-links { gap: 12px; }
+  .page-stack { gap: 54px; padding-top: 24px; }
+  .hero, .feature-panel, .callout { border-radius: 24px; }
+  .guardrails { grid-template-columns: 1fr; }
+  .footer { flex-direction: column; }
 }

--- a/docs/site.css
+++ b/docs/site.css
@@ -7,14 +7,21 @@
   --paper: #f6f4ee;
   --surface: rgba(255, 255, 255, 0.82);
   --green: #1f6d55;
+  --green-dark: #15513f;
   --green-soft: #e8f2ec;
   --blue-soft: #e8f0f7;
   --amber-soft: #f7efe0;
   --shadow: 0 18px 44px rgba(31, 42, 42, 0.09);
 }
 
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   color: var(--ink);
@@ -22,12 +29,19 @@ body {
     radial-gradient(circle at 10% 0%, rgba(210, 228, 218, 0.65), transparent 32rem),
     radial-gradient(circle at 92% 8%, rgba(218, 229, 240, 0.72), transparent 34rem),
     var(--paper);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
   line-height: 1.6;
 }
 
-a { color: var(--green); }
-.shell { width: min(1180px, calc(100% - 40px)); margin-inline: auto; }
+a {
+  color: var(--green);
+}
+
+.shell {
+  width: min(1180px, calc(100% - 40px));
+  margin-inline: auto;
+}
 
 .nav {
   min-height: 76px;
@@ -37,89 +51,503 @@ a { color: var(--green); }
   gap: 24px;
   border-bottom: 1px solid rgba(95, 107, 104, 0.18);
 }
-.brand { display: inline-flex; align-items: center; gap: 11px; color: var(--ink); text-decoration: none; font-weight: 700; }
-.brand img { width: 38px; height: 38px; }
-.nav-links { display: flex; flex-wrap: wrap; gap: 18px; }
-.nav-links a { color: var(--muted); text-decoration: none; font-size: 0.9rem; font-weight: 600; }
-.nav-links a:hover { color: var(--green); }
 
-.page-stack { display: grid; gap: 74px; padding-block: 42px 84px; }
-.panel, .feature-panel, .callout {
-  border: 1px solid rgba(255,255,255,0.88);
-  background: linear-gradient(135deg, rgba(250,248,242,0.96), rgba(236,243,238,0.94) 52%, rgba(226,235,244,0.94));
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.brand img {
+  width: 38px;
+  height: 38px;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 18px;
+}
+
+.nav-links a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  color: var(--green);
+}
+
+.page-stack {
+  display: grid;
+  gap: 74px;
+  padding-block: 42px 84px;
+}
+
+.panel,
+.feature-panel,
+.callout {
+  border: 1px solid rgba(255, 255, 255, 0.88);
+  background: linear-gradient(
+    135deg,
+    rgba(250, 248, 242, 0.96),
+    rgba(236, 243, 238, 0.94) 52%,
+    rgba(226, 235, 244, 0.94)
+  );
   box-shadow: var(--shadow);
   border-radius: 32px;
 }
-.hero { display: grid; grid-template-columns: 190px 1fr; gap: 42px; align-items: center; padding: clamp(28px, 5vw, 56px); }
-.hero-mark { border: 1px solid #d9e2dd; border-radius: 30px; background: linear-gradient(180deg, rgba(219,234,247,0.85), rgba(255,255,255,0.96)); padding: 24px; box-shadow: 0 16px 36px rgba(31,42,42,0.09); }
-.hero-mark img { display: block; width: 100%; height: auto; }
-.eyebrow { margin: 0; color: var(--green); font-size: 0.72rem; line-height: 1.3; font-weight: 700; letter-spacing: 0.22em; text-transform: uppercase; }
-h1, h2 { font-family: Fraunces, Georgia, serif; line-height: 1.08; letter-spacing: -0.025em; }
-h1 { max-width: 830px; margin: 14px 0 20px; font-size: clamp(2.5rem, 5vw, 4.5rem); }
-h2 { margin: 10px 0 14px; font-size: clamp(2rem, 3.8vw, 3.15rem); }
-h3 { margin: 8px 0; line-height: 1.25; }
-.lead, .section-heading > p:last-child, .callout p { max-width: 820px; color: var(--muted); font-size: 1.04rem; }
-.actions { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 26px; }
-.button { display: inline-flex; align-items: center; justify-content: center; min-height: 43px; padding: 0 18px; border: 1px solid var(--green); border-radius: 999px; color: white; background: var(--green); text-decoration: none; font-size: 0.9rem; font-weight: 700; }
-.button:hover { transform: translateY(-1px); }
-.button-outline { color: var(--green); background: rgba(255,255,255,0.64); }
-.signal-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 34px; }
-.signal-grid div, .guardrails div { border: 1px solid var(--line); border-radius: 18px; background: rgba(255,255,255,0.76); padding: 15px; }
-.signal-grid strong, .signal-grid span, .guardrails strong, .guardrails span { display: block; }
-.signal-grid span, .guardrails span { margin-top: 5px; color: var(--muted); font-size: 0.84rem; line-height: 1.5; }
 
-.section { display: grid; gap: 24px; }
-.section-heading { max-width: 880px; }
-.card-grid { display: grid; gap: 16px; }
-.card-grid.three { grid-template-columns: repeat(3, 1fr); }
-.card { min-height: 220px; border: 1px solid var(--line); border-radius: 22px; background: var(--surface); padding: 24px; box-shadow: 0 12px 28px rgba(31,42,42,0.06); }
-.card p { color: var(--muted); }
-.card .label, .label { margin: 0 0 13px; color: #68726f; font-size: 0.69rem; font-weight: 700; letter-spacing: 0.2em; text-transform: uppercase; }
-.tint-blue { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--blue-soft)); }
-.tint-green { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--green-soft)); }
-.tint-amber { background: linear-gradient(145deg, rgba(255,255,255,0.9), var(--amber-soft)); }
-.compact .card { min-height: 0; }
+.hero {
+  display: grid;
+  grid-template-columns: 190px 1fr;
+  gap: 42px;
+  align-items: center;
+  padding: clamp(28px, 5vw, 56px);
+}
 
-.split { grid-template-columns: minmax(0, 1fr) minmax(360px, 0.8fr); align-items: start; }
-.flow { display: grid; gap: 9px; padding: 24px; border: 1px solid var(--line); border-radius: 24px; background: rgba(255,255,255,0.76); box-shadow: var(--shadow); }
-.flow div { padding: 15px 17px; border: 1px solid var(--line); border-radius: 15px; background: white; }
-.flow span, .flow small { display: block; }
-.flow span { font-weight: 700; }
-.flow small { margin-top: 3px; color: var(--muted); }
-.flow b { text-align: center; color: var(--green); }
+.hero-mark {
+  border: 1px solid #d9e2dd;
+  border-radius: 30px;
+  background: linear-gradient(
+    180deg,
+    rgba(219, 234, 247, 0.85),
+    rgba(255, 255, 255, 0.96)
+  );
+  padding: 24px;
+  box-shadow: 0 16px 36px rgba(31, 42, 42, 0.09);
+}
 
-.feature-panel { padding: clamp(26px, 5vw, 52px); }
-.mode-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; }
-.mode-grid article { border: 1px solid rgba(31,109,85,0.22); border-radius: 20px; background: rgba(255,255,255,0.72); padding: 22px; }
-.mode-grid span { color: var(--green); font-weight: 800; font-size: 0.76rem; letter-spacing: 0.2em; }
-.mode-grid p { color: var(--muted); }
-.guardrails { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.hero-mark img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
 
-.code-grid { display: grid; grid-template-columns: 0.65fr 1.35fr 1.35fr; gap: 16px; }
-.code-card { min-width: 0; border: 1px solid #26332f; border-radius: 20px; background: #111a17; padding: 19px; box-shadow: 0 18px 38px rgba(14,23,20,0.18); }
-.code-card .label { color: #9eb5ad; }
-pre { margin: 0; overflow-x: auto; white-space: pre; }
-code { color: #e8f2ed; font: 0.82rem/1.65 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+.eyebrow {
+  margin: 0;
+  color: var(--green);
+  font-size: 0.72rem;
+  line-height: 1.3;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
 
-.callout { display: flex; align-items: end; justify-content: space-between; gap: 32px; padding: clamp(26px, 5vw, 48px); }
-.callout .actions { flex-shrink: 0; }
-.footer { display: flex; justify-content: space-between; gap: 20px; padding-block: 26px 42px; border-top: 1px solid var(--line); color: var(--muted); font-size: 0.86rem; }
-.footer a { color: inherit; }
+h1,
+h2 {
+  font-family: Fraunces, Georgia, serif;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+}
+
+h1 {
+  max-width: 900px;
+  margin: 14px 0 20px;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+}
+
+h2 {
+  margin: 10px 0 14px;
+  font-size: clamp(2rem, 3.8vw, 3.15rem);
+}
+
+h3 {
+  margin: 8px 0;
+  line-height: 1.25;
+}
+
+.lead,
+.section-heading > p:last-of-type,
+.callout p {
+  max-width: 840px;
+  color: var(--muted);
+  font-size: 1.04rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+  margin-top: 26px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 43px;
+  padding: 0 18px;
+  border: 1px solid var(--green);
+  border-radius: 999px;
+  color: white;
+  background: var(--green);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+  background: var(--green-dark);
+}
+
+.button-outline {
+  color: var(--green);
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.button-outline:hover,
+.button-outline:focus-visible {
+  color: white;
+}
+
+.text-link {
+  display: inline-flex;
+  margin-top: 8px;
+  font-weight: 700;
+  text-underline-offset: 4px;
+}
+
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 22px;
+}
+
+.status-row span {
+  padding: 6px 10px;
+  border: 1px solid rgba(31, 109, 85, 0.22);
+  border-radius: 999px;
+  color: var(--green-dark);
+  background: rgba(232, 242, 236, 0.74);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.signal-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.signal-grid div,
+.guardrails div {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 15px;
+}
+
+.signal-grid strong,
+.signal-grid span,
+.guardrails strong,
+.guardrails span {
+  display: block;
+}
+
+.signal-grid span,
+.guardrails span {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.section {
+  display: grid;
+  gap: 24px;
+  scroll-margin-top: 24px;
+}
+
+.section-heading {
+  max-width: 900px;
+}
+
+.card-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.card-grid.three {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.card {
+  min-height: 220px;
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--surface);
+  padding: 24px;
+  box-shadow: 0 12px 28px rgba(31, 42, 42, 0.06);
+}
+
+.card p {
+  color: var(--muted);
+}
+
+.card .label,
+.label {
+  margin: 0 0 13px;
+  color: #68726f;
+  font-size: 0.69rem;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.tint-blue {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), var(--blue-soft));
+}
+
+.tint-green {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), var(--green-soft));
+}
+
+.tint-amber {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.9), var(--amber-soft));
+}
+
+.compact .card {
+  min-height: 0;
+}
+
+.split {
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.8fr);
+  align-items: start;
+}
+
+.flow {
+  display: grid;
+  gap: 9px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: var(--shadow);
+}
+
+.flow div {
+  padding: 15px 17px;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  background: white;
+}
+
+.flow span,
+.flow small {
+  display: block;
+}
+
+.flow span {
+  font-weight: 700;
+}
+
+.flow small {
+  margin-top: 3px;
+  color: var(--muted);
+}
+
+.flow b {
+  text-align: center;
+  color: var(--green);
+}
+
+.feature-panel {
+  padding: clamp(26px, 5vw, 52px);
+}
+
+.mode-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 15px;
+}
+
+.mode-grid article {
+  border: 1px solid rgba(31, 109, 85, 0.22);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.72);
+  padding: 22px;
+}
+
+.mode-grid span {
+  color: var(--green);
+  font-weight: 800;
+  font-size: 0.76rem;
+  letter-spacing: 0.2em;
+}
+
+.mode-grid p {
+  color: var(--muted);
+}
+
+.guardrails {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.fit-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.fit-card {
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.78);
+  padding: 24px;
+  box-shadow: 0 12px 28px rgba(31, 42, 42, 0.05);
+}
+
+.fit-positive {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), var(--green-soft));
+}
+
+.fit-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.fit-card li + li {
+  margin-top: 11px;
+}
+
+.code-grid {
+  display: grid;
+  grid-template-columns: 0.65fr 1.35fr 1.35fr;
+  gap: 16px;
+}
+
+.code-card {
+  min-width: 0;
+  border: 1px solid #26332f;
+  border-radius: 20px;
+  background: #111a17;
+  padding: 19px;
+  box-shadow: 0 18px 38px rgba(14, 23, 20, 0.18);
+}
+
+.code-card .label {
+  color: #9eb5ad;
+}
+
+pre {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+code {
+  color: #e8f2ed;
+  font: 0.82rem/1.65 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace;
+}
+
+.callout {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 32px;
+  padding: clamp(26px, 5vw, 48px);
+}
+
+.callout .actions {
+  flex-shrink: 0;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding-block: 26px 42px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.footer a {
+  color: inherit;
+}
+
+@media (max-width: 980px) {
+  .nav {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-block: 16px;
+  }
+
+  .nav-links {
+    justify-content: flex-start;
+  }
+}
 
 @media (max-width: 900px) {
-  .hero { grid-template-columns: 1fr; }
-  .hero-mark { width: 140px; }
-  .signal-grid, .card-grid.three, .mode-grid, .code-grid { grid-template-columns: 1fr; }
-  .split { grid-template-columns: 1fr; }
-  .callout { align-items: flex-start; flex-direction: column; }
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-mark {
+    width: 140px;
+  }
+
+  .signal-grid,
+  .card-grid.three,
+  .mode-grid,
+  .code-grid,
+  .fit-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .callout {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 680px) {
-  .shell { width: min(100% - 24px, 1180px); }
-  .nav { align-items: flex-start; flex-direction: column; padding-block: 16px; }
-  .nav-links { gap: 12px; }
-  .page-stack { gap: 54px; padding-top: 24px; }
-  .hero, .feature-panel, .callout { border-radius: 24px; }
-  .guardrails { grid-template-columns: 1fr; }
-  .footer { flex-direction: column; }
+  .shell {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .nav-links {
+    gap: 12px;
+  }
+
+  .page-stack {
+    gap: 54px;
+    padding-top: 24px;
+  }
+
+  .hero,
+  .feature-panel,
+  .callout {
+    border-radius: 24px;
+  }
+
+  .guardrails {
+    grid-template-columns: 1fr;
+  }
+
+  .footer {
+    flex-direction: column;
+  }
 }


### PR DESCRIPTION
## Summary

Refresh the GitHub Pages/public site for public technical readers and organizations evaluating the project or its engineering work.

The site now presents Amaryllis as an active open-source implementation rather than a finished product or feature-branch proposal.

## Changes

- describes the current three-layer implementation: native inference runtime, offline-first context interfaces, and governed adaptive components
- explains the trust model: application code, contracts, registries, policy, and deterministic validation remain authoritative over model output
- makes the active `0.1.x` maturity level and evolving API surface explicit
- adds company-relevant engineering proof points across native mobile systems, AI governance, CI, packaging, SBOMs, and provenance
- adds a candid fit-and-constraints section to prevent overclaiming
- documents implemented component modes and runtime guardrails
- corrects the quickstart package name and completes the streaming import example
- restyles the page using the light, botanical, rounded-card visual language used by `hackelia-micrantha/web` / micrantha.com
- adds social metadata, clearer navigation, responsive layouts, and visible focus behavior

## Scope

Static public-site changes only:

- `docs/index.html`
- `docs/site.css`

No runtime or package behavior changes.

## Validation

- CI: passed
- Coverage Gate: passed
- Compatibility Matrix: passed on Node.js 20, 22, and 24
- CodeQL: passed