### PR TITLE
docs: align public documentation with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Mobile AI often forces a poor choice between a thin hosted assistant and unrestr
 - inference can remain on device;
 - application code owns model selection, lifecycle, storage, rendering, and fallback behavior;
 - model output is treated as untrusted input;
-- schemas, registries, policy, and deterministic validation remain authoritative;
-- runtime personalization uses bounded structured data rather than executable JSX or TSX.
+- registered component implementations and runtime contracts remain authoritative;
+- runtime personalization uses bounded structured data rather than executable JSX or TSX;
+- broader semantic and capability policy remains explicit rather than hidden inside the model.
 
 ## Architecture
 
@@ -37,22 +38,30 @@ The repository contains three related layers:
 
 3. **Amaryllis Components**
    - typed and versioned `ComponentSpec` contracts;
-   - schema and policy validation;
+   - specification schema and policy primitives;
    - generation, registry, and packaging primitives;
-   - bounded runtime personalization.
+   - bounded runtime personalization;
+   - JSON Schema, unsafe-key, and JSON Patch validation.
 
 ```text
 Application UI and product logic
-  -> contracts, policy, and validation
+  -> application policy, lifecycle, and fallback
   -> Amaryllis provider / hooks / controller
   -> native Android and iOS inference
   -> application-selected model assets
 
-ComponentSpec
-  -> schema and policy validation
-  -> registry-approved implementation
-  -> validated props, variants, slots, or patches
-  -> render
+Build and CLI component flow
+  ComponentSpec
+    -> schema and policy validation
+    -> generated or customized artifacts
+    -> normal review and delivery controls
+
+Runtime personalization flow
+  registered component and contract
+    -> untrusted structured output
+    -> schema, unsafe-key, and patch validation
+    -> bounded prop overlay
+    -> registered implementation render
 ```
 
 The model is a capability provider, not the authority over application behavior.
@@ -160,7 +169,7 @@ Retrieved context remains untrusted input. Output validation must not depend on 
 
 - **Scaffold:** generate reviewable source at build or CI time;
 - **Customize:** produce bounded variants within declared layouts, slots, tokens, and imports;
-- **Personalize:** return validated props, variants, slot text, or constrained JSON patches at runtime.
+- **Personalize:** return contract-validated props, variants, slot text, design-token values, or constrained JSON patches at runtime.
 
 ```ts
 import { parseSpec } from '@micrantha/amaryllis-components/dist/parser/yaml';
@@ -187,7 +196,9 @@ ai:
 `);
 ```
 
-Runtime AI does not directly register implementations, mutate authoritative specs, bypass policy, or introduce executable imports.
+Runtime AI cannot directly register implementations, mutate authoritative specs, or introduce executable imports. The current runtime path validates against the registered JSON contract and patch bounds.
+
+The full package `PolicyEngine` is currently applied by build and CLI generation/customization flows, not automatically by every programmatic `PersonalizedComponent` call. Applications must compose additional policy for network access, sensitive capabilities, semantic business rules, accessibility, and data handling where required.
 
 ## Security Model
 
@@ -197,17 +208,20 @@ The central security principle is:
 AI output is not authoritative.
 ```
 
-Amaryllis keeps authority in deterministic application-controlled systems:
+Implemented runtime controls include:
 
-- component specs and runtime contracts;
-- registries and implementation identities;
-- schema and policy validation;
-- lifecycle and rendering code;
-- build review and release controls.
+- registry lookup of a reviewed implementation and contract;
+- JSON Schema validation;
+- unsafe prototype-related key detection;
+- JSON Patch path and value validation;
+- post-patch schema validation;
+- fallback to base props on validation failure.
+
+Build and CLI workflows provide separate specification-policy and generated-artifact controls.
 
 Local inference reduces some network exposure, but it does not eliminate client compromise, reverse engineering, malicious model assets, resource exhaustion, or privacy leakage through application logging and fallback behavior.
 
-See [Security Model](docs/security-model.md) and [Threat Model](docs/threat-model.md).
+See [Security Model](docs/security-model.md), [Threat Model](docs/threat-model.md), and [Registry and validation](docs/registry-and-validation.md).
 
 ## Delivery and Supply Chain
 
@@ -247,10 +261,12 @@ Amaryllis is not currently intended to provide:
 - server-scale training or fleet orchestration;
 - a universal model distribution service;
 - unrestricted runtime source generation;
+- automatic full-policy enforcement for every runtime personalization call;
+- automatic semantic safety from schema validation alone;
 - automatic security merely because inference is local;
 - stable compatibility across every React Native, operating-system, device, and model combination.
 
-Applications remain responsible for model licensing, distribution, integrity, storage, updates, device performance budgets, privacy policy, fallback behavior, and operational monitoring.
+Applications remain responsible for model licensing, distribution, integrity, storage, updates, device performance budgets, privacy policy, sensitive capability authorization, fallback behavior, and operational monitoring.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,63 @@
-# react-native-amaryllis
+# Amaryllis
 
-![amaryllis](docs/amaryllis-128.png)
+![Amaryllis](docs/amaryllis-128.png)
 
-[![npm version](https://img.shields.io/npm/v/react-native-amaryllis.svg)](https://www.npmjs.com/package/react-native-amaryllis) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@micrantha/react-native-amaryllis.svg)](https://www.npmjs.com/package/@micrantha/react-native-amaryllis)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-> **Amaryllis Hippeastrum**: Symbolizes hope and emergence, blooming even in tough conditions.
+> **Amaryllis Hippeastrum** symbolizes hope and emergence, blooming even in difficult conditions.
 
-Amaryllis is a React Native runtime for on-device multimodal AI. It exposes local inference, streaming interaction, and offline-first context integration through a native mobile API surface.
+Amaryllis is an open-source React Native foundation for on-device multimodal AI. It combines native Android and iOS inference, streaming interaction, offline-first context interfaces, and a companion component system for governed AI-enabled UI.
 
-On the `feature/ai-components` branch, that base runtime is extended with a companion workspace, `@micrantha/amaryllis-components`, for spec-driven, governed, AI-enabled React components.
+The project is an active `0.1.x` implementation. APIs and model integration details may evolve while the core trust boundaries are stabilized.
 
----
+## Why Amaryllis
 
-## What lives in this branch
+Mobile AI often forces a poor choice between a thin hosted assistant and unrestricted generated UI. Amaryllis explores a more controlled model:
 
-This branch contains two related layers:
+- inference can remain on device;
+- application code owns model selection, lifecycle, storage, rendering, and fallback behavior;
+- model output is treated as untrusted input;
+- schemas, registries, policy, and deterministic validation remain authoritative;
+- runtime personalization uses bounded structured data rather than executable JSX or TSX.
 
-1. **Base Amaryllis runtime**
-   - on-device multimodal inference for React Native
-   - local model execution on Android and iOS
-   - streaming hooks, provider, and controller APIs
-   - offline-first context and retrieval interfaces
+## Architecture
 
-2. **Amaryllis Components companion module**
-   - a typed `ComponentSpec`
-   - schema validation and policy enforcement
-   - generation and registry primitives
-   - bounded runtime personalization contracts
-   - a draft RFC for governed AI-enabled components
+The repository contains three related layers:
 
-At a high level:
+1. **On-device runtime**
+   - native model execution on Android and iOS;
+   - React Native provider, hooks, and controller APIs;
+   - streaming output, cancellation, image inputs, and typed errors.
+
+2. **Context Engine**
+   - interface-first memory and retrieval;
+   - application-owned storage;
+   - bounded retrieval, TTL policy, validation, and optional scoring.
+
+3. **Amaryllis Components**
+   - typed and versioned `ComponentSpec` contracts;
+   - schema and policy validation;
+   - generation, registry, and packaging primitives;
+   - bounded runtime personalization.
 
 ```text
-React Native components
-  -> LLMProvider / hooks / controller
-  -> TurboModule bridge
-  -> native inference runtime
-  -> on-device model assets
+Application UI and product logic
+  -> contracts, policy, and validation
+  -> Amaryllis provider / hooks / controller
+  -> native Android and iOS inference
+  -> application-selected model assets
 
-ComponentSpec / policy / registry
-  -> @micrantha/amaryllis-components
-  -> validated generation or personalization outputs
-  -> governed component rendering
+ComponentSpec
+  -> schema and policy validation
+  -> registry-approved implementation
+  -> validated props, variants, slots, or patches
+  -> render
 ```
 
----
+The model is a capability provider, not the authority over application behavior.
 
-## Branch-aware documentation
-
-- [Architecture](docs/architecture.md)
-- [Local AI and MediaPipe](docs/local-ai.md)
-- [Concepts](docs/concepts.md)
-- [AI-enabled components](docs/ai-enabled-components.md)
-- [Runtime personalization](docs/runtime-personalization.md)
-- [Registry and validation](docs/registry-and-validation.md)
-- [CopilotKit and AG-UI alignment](docs/copilotkit-ag-ui.md)
-- [Security model](docs/security-model.md)
-- [Amaryllis Components RFC](docs/amaryllis_ai_component_module_rfc.md)
-- [Context Engine](docs/context-engine.md)
-- [Examples](docs/examples)
-- [Runtime validation flow example](docs/examples/runtime-validation-flow.md)
-
----
-
-## 🚀 Installation
+## Installation
 
 ```sh
 npm install @micrantha/react-native-amaryllis
@@ -73,59 +67,33 @@ yarn add @micrantha/react-native-amaryllis
 pnpm add @micrantha/react-native-amaryllis
 ```
 
-For the companion package in this branch:
+The companion package is developed in the same workspace:
 
 ```sh
 yarn workspace @micrantha/amaryllis-components build
 ```
 
----
+## Requirements
 
-## ✅ Requirements
+- React Native and React as peer dependencies;
+- Node.js 24 for repository development, as defined by `.nvmrc`;
+- React 18 or newer for `@micrantha/amaryllis-components`.
 
-- React Native and React (peer dependencies)
-- Node.js v24.0.0 for development (see `.nvmrc`)
-- React 18+ for `@micrantha/amaryllis-components`
+## Compatibility
 
----
-
-## 📱 Compatibility
-
-| Area | Status |
+| Area | Current repository coverage |
 | --- | --- |
-| React Native | Tested with 0.83.x in this repo |
-| Android | Example app built in CI on ubuntu-latest |
-| iOS | Example app built in CI with Xcode 16.4 |
-| Components workspace | Present on `feature/ai-components` |
+| React Native | Tested with the repository's pinned React Native version |
+| Android | Example application built in CI |
+| iOS | Example application built in CI with Xcode 16.4 |
+| Node.js | Compatibility checks on Node.js 20, 22, and 24 |
+| Components | Included as `@micrantha/amaryllis-components` |
 
----
+Compatibility coverage is evidence for the tested repository configuration, not a promise that every device, model, or React Native combination is supported.
 
-## 📦 Features
+## Runtime Quickstart
 
-### Base runtime
-
-- Native on-device LLM engine for Android & iOS
-- Multimodal support (text + images)
-- Streaming inference with hooks & observables
-- Easy integration with React Native context/provider
-- Offline-first context retrieval and memory interfaces
-- LoRA customization (GPU only)
-
-### Companion module (`@micrantha/amaryllis-components`)
-
-- Typed `ComponentSpec` model
-- JSON schema and policy validation
-- CLI and generator scaffolding
-- Personalization runtime primitives
-- Bounded outputs for variants, props, and JSON patch workflows
-
----
-
-## 🛠️ Usage
-
-### Provider Setup
-
-Wrap your application with `LLMProvider` and provide the necessary model paths. The models should be downloaded to the device.
+Wrap the application with `LLMProvider` and provide application-managed model paths:
 
 ```tsx
 import { LLMProvider } from '@micrantha/react-native-amaryllis';
@@ -140,71 +108,59 @@ import { LLMProvider } from '@micrantha/react-native-amaryllis';
     maxTokens: 512,
   }}
 >
-  {/* Your app components */}
-</LLMProvider>
+  <App />
+</LLMProvider>;
 ```
 
-You can access the LLM controller with a `useLLMContext` hook. See **Core API** for details on the controller API.
-
-```tsx
-const {
-  config,
-  controller,
-  error,
-  isReady,
-} = useLLMContext();
-```
-
-### Inference Hook
-
-Use the `useInferenceAsync` hook to access the LLM runtime.
+Use `useInferenceAsync` for streaming generation:
 
 ```tsx
 import { useInferenceAsync } from '@micrantha/react-native-amaryllis';
-import { useCallback, useMemo, useState } from 'react';
-import { View, TextInput, Button, Text } from 'react-native';
 
-const LLMPrompt = () => {
-  const [prompt, setPrompt] = useState('');
-  const [results, setResults] = useState<string[]>([]);
-  const [images, setImages] = useState<string[]>([]);
-  const [error, setError] = useState<Error | undefined>(undefined);
-  const [isBusy, setIsBusy] = useState(false);
+const generate = useInferenceAsync({
+  onResult: (chunk, isFinal) => {
+    append(chunk);
+    if (isFinal) finish();
+  },
+  onError: handleError,
+});
 
-  const props = useMemo(
-    () => ({
-      onGenerate: () => {
-        setError(undefined);
-        setIsBusy(true);
-      },
-      onResult: (result: string, isFinal: boolean) => {
-        setResults((prev) => [...prev, result]);
-        if (isFinal) {
-          setIsBusy(false);
-        }
-      },
-      onError: (err: Error) => setError(err),
-    }),
-    []
-  );
-
-  const generate = useInferenceAsync(props);
-
-  const infer = useCallback(async () => {
-    await generate({ prompt, images });
-  }, [prompt, generate, images]);
-
-  return (
-    <View>
-      <TextInput value={prompt} onChangeText={setPrompt} placeholder="Enter prompt..." />
-      <Button title="Generate" onPress={infer} disabled={isBusy} />
-      <Text>{error ? error.message : results.join('\n')}</Text>
-    </View>
-  );
-};
+await generate({ prompt, images });
 ```
 
-### Companion Module Example
+Applications should cancel active work during lifecycle cleanup and bound image count, image size, and token budgets for predictable resource use.
+
+## Context Engine
+
+The Context Engine provides memory and retrieval without imposing a hosted storage dependency. Applications supply a `ContextStore`, such as SQLite, files, or another database.
+
+```ts
+import { ContextEngine } from '@micrantha/react-native-amaryllis/context';
+
+const engine = new ContextEngine({
+  store: myStore,
+  policy: {
+    maxItems: 1000,
+    defaultTtlSeconds: 60 * 60 * 24,
+  },
+});
+
+await engine.add([
+  { id: 'memory-1', text: 'Quest started', createdAt: Date.now() },
+]);
+
+const results = await engine.search({ text: 'quest', limit: 5 });
+```
+
+Retrieved context remains untrusted input. Output validation must not depend on the context source being safe.
+
+## Governed Components
+
+`@micrantha/amaryllis-components` defines a spec-driven component model with three modes:
+
+- **Scaffold:** generate reviewable source at build or CI time;
+- **Customize:** produce bounded variants within declared layouts, slots, tokens, and imports;
+- **Personalize:** return validated props, variants, slot text, or constrained JSON patches at runtime.
 
 ```ts
 import { parseSpec } from '@micrantha/amaryllis-components/dist/parser/yaml';
@@ -231,91 +187,75 @@ ai:
 `);
 ```
 
----
+Runtime AI does not directly register implementations, mutate authoritative specs, bypass policy, or introduce executable imports.
 
-## ✅ Best Practices
+## Security Model
 
-- Stream results for responsive UIs and show partial tokens
-- Cancel async generation on unmount to avoid leaks
-- Limit image sizes and count for consistent memory usage
-- Validate file paths before passing them to native APIs
-- Keep model assets and prompts within your app’s privacy boundary
-- Treat runtime AI output as untrusted data until validated
-- Keep the `ComponentSpec` and registry authoritative over personalization overlays
+The central security principle is:
 
----
-
-## ❓ FAQ
-
-**Does Amaryllis require a network connection?**  
-No. Inference runs on-device; any network usage is up to your app.
-
-**Is this branch only about chat UIs?**  
-No. The base runtime supports multimodal local inference, and the companion workspace explores governed AI-enabled components.
-
-**Can on-device AI emit arbitrary JSX or TSX?**  
-Not in the component model described by this branch. The RFC constrains device-time outputs to structured data such as props, variants, slot text, or limited JSON patch overlays.
-
----
-
-## 🧠 Context Engine
-
-The Context Engine is an interface-first layer for memory and retrieval. You bring your own `ContextStore` (SQLite, files, or custom DB) while the engine handles validation, policy bounds, and optional scoring.
-Context APIs are also available via the `@micrantha/react-native-amaryllis/context` subpath.
-
-```ts
-import { ContextEngine } from '@micrantha/react-native-amaryllis/context';
-
-const engine = new ContextEngine({
-  store: myStore,
-  policy: { maxItems: 1000, defaultTtlSeconds: 60 * 60 * 24 },
-});
-
-await engine.add([{ id: 'mem-1', text: 'Quest started', createdAt: Date.now() }]);
-const results = await engine.search({ text: 'quest', limit: 5 });
+```text
+AI output is not authoritative.
 ```
 
-See `docs/context-engine.md` for details.
+Amaryllis keeps authority in deterministic application-controlled systems:
 
----
+- component specs and runtime contracts;
+- registries and implementation identities;
+- schema and policy validation;
+- lifecycle and rendering code;
+- build review and release controls.
 
-## 📚 Documentation
+Local inference reduces some network exposure, but it does not eliminate client compromise, reverse engineering, malicious model assets, resource exhaustion, or privacy leakage through application logging and fallback behavior.
 
-- [API Reference](src/Types.ts)
+See [Security Model](docs/security-model.md) and [Threat Model](docs/threat-model.md).
+
+## Delivery and Supply Chain
+
+The repository includes production-minded delivery controls such as:
+
+- lint, tests, type checking, and native builds;
+- compatibility matrices;
+- package metadata and entrypoint validation;
+- change-aware CI gating;
+- repository and package-scoped CycloneDX SBOMs;
+- release provenance and artifact attestation workflows.
+
+These controls improve reviewability and traceability; they do not replace application-specific security review or device testing.
+
+## Documentation
+
 - [Architecture](docs/architecture.md)
-- [Local AI and MediaPipe](docs/local-ai.md)
 - [Concepts](docs/concepts.md)
+- [Local AI and MediaPipe](docs/local-ai.md)
+- [Context Engine](docs/context-engine.md)
 - [AI-enabled components](docs/ai-enabled-components.md)
 - [Runtime personalization](docs/runtime-personalization.md)
 - [Registry and validation](docs/registry-and-validation.md)
 - [CopilotKit and AG-UI alignment](docs/copilotkit-ag-ui.md)
 - [Security model](docs/security-model.md)
+- [Threat model](docs/threat-model.md)
 - [Amaryllis Components RFC](docs/amaryllis_ai_component_module_rfc.md)
-- [Context Engine](docs/context-engine.md)
 - [Examples](docs/examples)
-- [Runtime validation flow example](docs/examples/runtime-validation-flow.md)
-- [Example App](example/)
 - [Development workflow](CONTRIBUTING.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Security policy](SECURITY.md)
 - [Support](SUPPORT.md)
 
----
+## Current Constraints
 
-## 🔒 Security & Privacy
+Amaryllis is not currently intended to provide:
 
-Amaryllis runs inference on-device. You control model files, prompts, and image inputs. Ensure your app follows your organization’s data handling and privacy requirements.
+- server-scale training or fleet orchestration;
+- a universal model distribution service;
+- unrestricted runtime source generation;
+- automatic security merely because inference is local;
+- stable compatibility across every React Native, operating-system, device, and model combination.
 
-For the companion component model, runtime AI output should be treated as untrusted until it passes schema and policy validation.
+Applications remain responsible for model licensing, distribution, integrity, storage, updates, device performance budgets, privacy policy, fallback behavior, and operational monitoring.
 
----
+## Contributing
 
-## 🤝 Contributing
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development and contribution guidance.
 
-We welcome contributions. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+## License
 
----
-
-## 📄 License
-
-This project is [MIT licensed](LICENSE).
+Amaryllis is [MIT licensed](LICENSE).

--- a/docs/ai-enabled-components.md
+++ b/docs/ai-enabled-components.md
@@ -1,295 +1,219 @@
 # AI-enabled Components
 
-This document explains the direction explored by the `feature/ai-components` branch.
+This document explains the component-governance model implemented by `@micrantha/amaryllis-components`.
 
-The branch introduces a companion workspace, `@micrantha/amaryllis-components`, that explores how AI can participate in component systems without turning the runtime into an unrestricted code-generation environment.
-
-The core idea is:
+The core principle is:
 
 > Components remain declarative and authoritative while AI participates through bounded contracts.
 
----
+## Motivation
 
-# Motivation
+AI-enabled UI commonly falls into one of two extremes:
 
-Many current AI UI systems fall into one of two categories:
+1. a chat assistant attached to otherwise static UI;
+2. unrestricted source or runtime UI generation.
 
-1. AI as a chat assistant attached to otherwise static UI
-2. AI as an unrestricted source-code generator
+The first limits adaptation. The second creates serious governance, reproducibility, accessibility, security, and design-consistency problems.
 
-The first approach limits adaptability.
+Amaryllis explores a middle path: useful AI capability inside application-owned component contracts.
 
-The second approach creates serious problems for:
-
-- governance
-- reproducibility
-- accessibility
-- security
-- design consistency
-- runtime trust boundaries
-
-This branch explores a middle path.
-
----
-
-# Core Principle
-
-The most important principle in this branch is:
+## Authority Model
 
 ```text
-The spec is authoritative.
-AI is a bounded implementation and personalization tool.
+ComponentSpec, registry, policy, and validation are authoritative.
+AI output is advisory until it passes those controls.
 ```
 
-This changes the role of AI substantially.
+The model cannot directly:
 
-Instead of:
+- register an implementation;
+- replace a component identity;
+- mutate authoritative policy;
+- introduce executable imports at runtime;
+- bypass validation;
+- decide what code is renderable.
 
-```text
-AI writes arbitrary UI
-```
+## ComponentSpec
 
-The architecture becomes:
+`ComponentSpec` is a typed, versioned, and reviewable declaration of:
 
-```text
-AI participates within constrained contracts
-```
+- component identity and metadata;
+- props and structure;
+- target framework and runtime;
+- behavior constraints;
+- AI execution mode;
+- policy requirements;
+- generation contracts.
 
----
+The specification exists before a model participates and remains the source of truth after generation or personalization.
 
-# Component Model
+## AI Execution Modes
 
-The companion module introduces a `ComponentSpec`.
+### Scaffold
 
-The spec defines:
+AI generates implementation artifacts in local tooling, build pipelines, or CI.
 
-- component identity
-- props
-- UI structure
-- allowed runtime behavior
-- AI execution mode
-- policy constraints
-- generation contracts
+Typical outputs include TSX, component scaffolding, tests, and derived contracts.
 
-The spec is intended to be:
+Because the output may be executable, it must pass normal software-delivery controls:
 
-- typed
-- versioned
-- reviewable
-- enforceable
-- portable
+- schema and source validation;
+- static analysis and tests;
+- import and capability policy;
+- preview and diff review;
+- package validation;
+- provenance and approval evidence.
 
----
+### Customize
 
-# AI Execution Modes
+AI adapts bounded parts of an existing component contract.
 
-The RFC currently defines three major modes.
+Examples include:
 
-## Scaffold
+- selecting known variants;
+- choosing approved layouts;
+- filling declared slots;
+- selecting design tokens;
+- producing constrained copy.
 
-AI helps generate implementation artifacts.
+Customization cannot change implementation identity, policy, imports, or undeclared capabilities.
 
-Typical environment:
+### Personalize
 
-- local tooling
-- CI
-- build pipelines
+AI participates at device time using structured output.
 
-Typical outputs:
+Examples include:
 
-- TSX
-- generated components
-- implementation scaffolding
+- local summaries;
+- adaptive slot content;
+- known variant selection;
+- validated props;
+- bounded JSON patch overlays.
 
-This mode assumes stronger validation and review controls.
+This is the most constrained mode because output reaches the user-facing runtime without the same review window available to build-time source generation.
 
----
-
-## Customize
-
-AI adapts or modifies bounded parts of a component.
-
-Examples:
-
-- choosing variants
-- changing layout selections
-- filling approved slots
-- selecting design tokens
-
-Customization is more constrained than unrestricted generation.
-
----
-
-## Personalize
-
-AI participates at runtime on device.
-
-Examples:
-
-- local summaries
-- adaptive UI behavior
-- slot text generation
-- local variant selection
-- bounded overlays
-
-This mode is intentionally the most constrained.
-
----
-
-# Why Local AI Matters
-
-The base Amaryllis runtime already supports on-device multimodal inference.
-
-That matters because AI-enabled components become much more useful when:
-
-- latency is low
-- network access is optional
-- user data remains local
-- multimodal state stays close to the UI
-- offline interaction is possible
-
-This is one reason the branch strongly separates:
-
-```text
-capability provider
-```
-
-from:
-
-```text
-hosted assistant service
-```
-
----
-
-# Runtime Safety Model
-
-The runtime model in this branch is intentionally conservative.
+## Runtime Safety Model
 
 At device time:
 
-- AI output is treated as untrusted
-- executable source generation is restricted
-- overlays must be validated
-- registries remain authoritative
-- policies remain external to the model
+- model output is untrusted;
+- executable source generation is not the default path;
+- registry-controlled implementations remain authoritative;
+- schemas and policy are enforced outside the model;
+- invalid output is rejected rather than coerced into authority;
+- fallback behavior remains application-controlled.
 
-This is a deliberate architectural choice.
+The intended flow is:
 
-The branch is attempting to support adaptive interfaces without implicitly trusting model output as executable runtime authority.
+```text
+prompt, context, or media
+  -> model capability
+  -> structured output
+  -> schema validation
+  -> policy validation
+  -> bounded overlay
+  -> registry-approved render
+```
 
----
+## Runtime Overlays
 
-# Runtime Overlays
+An overlay is a bounded modification applied to an authoritative component contract.
 
-The runtime model prefers overlays rather than arbitrary mutation.
+Supported patterns may include:
 
-Examples:
+- approved prop changes;
+- known variant selection;
+- declared slot text;
+- allowlisted JSON patch operations.
 
-- props updates
-- slot text
-- variant changes
-- bounded JSON patches
+Overlay validation should enforce:
 
-This allows the system to preserve:
+- allowed paths and operations;
+- value types and enum membership;
+- component and contract identity;
+- capability and network restrictions;
+- design-token and accessibility rules.
 
-- component identity
-- policy guarantees
-- design consistency
-- accessibility guarantees
-- registry authority
+Ambiguous recursive merging is avoided where explicit patch semantics provide a safer contract.
 
-while still allowing runtime adaptation.
+## Registry-centric Rendering
 
----
-
-# Registry-Centric Rendering
-
-The branch leans toward a registry-centric rendering model.
-
-Conceptually:
+The registry maps component, specification, contract, version, and implementation identities.
 
 ```text
 ComponentSpec
   -> validation
-  -> registry
+  -> registry resolution
   -> approved implementation
-  -> runtime overlays
+  -> validated overlay
   -> render
 ```
 
-This prevents the model from becoming the direct runtime source of executable UI.
+This preserves executable ownership in reviewed application code while allowing bounded adaptation.
 
----
+## Why Local AI Matters
 
-# CopilotKit And AG-UI Fit
+The Amaryllis runtime supports on-device multimodal inference. Local execution can provide:
 
-CopilotKit and AG-UI are useful integration surfaces for agent actions, shared frontend state, and generative UI orchestration.
+- lower interaction latency;
+- offline workflows;
+- application-controlled network behavior;
+- local image and text processing;
+- reduced dependency on hosted-data processing.
 
-Amaryllis should factor into those systems as a local-first capability and governance layer:
+Locality does not make model output trustworthy. It shifts the security and operational boundary to the application and device.
+
+Applications remain responsible for:
+
+- model distribution and integrity;
+- licensing and updates;
+- device resource budgets;
+- logging and persistence;
+- fallback behavior;
+- client compromise and reverse-engineering risk.
+
+## CopilotKit and AG-UI Integration
+
+CopilotKit and AG-UI can provide orchestration for agent actions, shared frontend state, and generative UI flows.
+
+Amaryllis fits as a local capability and governance boundary:
 
 ```text
 agent action
   -> Amaryllis inference
   -> structured output
-  -> ComponentSpec contract validation
-  -> registry-approved render overlay
+  -> ComponentSpec validation
+  -> registry-approved overlay
+  -> render
 ```
 
-The companion package therefore exposes dependency-free adapter contracts rather than importing CopilotKit directly. This keeps CopilotKit/AG-UI optional while preserving the Amaryllis rule that model output is advisory until validation passes.
+The companion package uses optional adapter contracts rather than requiring a specific orchestration framework. See [CopilotKit and AG-UI alignment](./copilotkit-ag-ui.md).
 
-See [CopilotKit and AG-UI alignment](./copilotkit-ag-ui.md).
+## Current Implementation
 
----
+The repository includes:
 
-# Why This Direction Exists
+- `ComponentSpec` types and schemas;
+- YAML and object parsing;
+- policy primitives;
+- registry and identity validation;
+- React source generation scaffolding;
+- bounded personalization outputs;
+- patch and overlay validation;
+- package and example verification;
+- CI, SBOM, and provenance controls.
 
-The broader goal is not merely:
+The project remains an active `0.1.x` implementation. Areas still evolving include preview ergonomics, approval workflows, runtime observability, model-delivery integrity, replayable evidence, and broader framework integration.
 
-```text
-React components with AI chat
-```
+## Explicit Non-goals
 
-The branch is exploring:
+The component system is not intended to provide:
 
-```text
-Declarative, governable, AI-enabled interfaces
-```
+- unrestricted device-time JSX or TSX generation;
+- autonomous mutation of application policy;
+- arbitrary runtime imports;
+- replacement of design-system governance;
+- implicit trust in local or hosted model output;
+- a universal generative UI protocol.
 
-That includes:
-
-- multimodal interactions
-- local inference
-- adaptive behavior
-- bounded personalization
-- spec-driven rendering
-- reproducible generation workflows
-- policy-aware runtime behavior
-
----
-
-# Current State
-
-This branch is exploratory.
-
-Several parts are already present:
-
-- `ComponentSpec` types
-- JSON schema generation
-- validation tooling
-- policy engine primitives
-- runtime overlay concepts
-- CLI and generator scaffolding
-- draft governance RFC
-
-But many areas remain intentionally open:
-
-- registry implementation details
-- preview systems
-- diff tooling
-- approval workflows
-- determinism guarantees
-- runtime observability
-- governance ergonomics
-
-The current goal is to establish strong architectural boundaries before scaling the generation surface.
+The goal is declarative, governable, AI-enabled interfaces with explicit limits and reviewable authority.

--- a/docs/ai-enabled-components.md
+++ b/docs/ai-enabled-components.md
@@ -20,18 +20,21 @@ Amaryllis explores a middle path: useful AI capability inside application-owned 
 ## Authority Model
 
 ```text
-ComponentSpec, registry, policy, and validation are authoritative.
-AI output is advisory until it passes those controls.
+ComponentSpec and registered implementations are authoritative.
+Runtime contracts determine acceptable personalization data.
+Model output is untrusted until validated.
 ```
 
 The model cannot directly:
 
 - register an implementation;
 - replace a component identity;
-- mutate authoritative policy;
+- mutate the canonical specification;
 - introduce executable imports at runtime;
-- bypass validation;
-- decide what code is renderable.
+- decide what React implementation is renderable;
+- bypass the registered personalization contract.
+
+Broader application policy remains external to the model. The current runtime path does not automatically invoke every package policy rule for programmatically registered components.
 
 ## ComponentSpec
 
@@ -55,18 +58,21 @@ AI generates implementation artifacts in local tooling, build pipelines, or CI.
 
 Typical outputs include TSX, component scaffolding, tests, and derived contracts.
 
-Because the output may be executable, it must pass normal software-delivery controls:
+Because the output may be executable, it should pass normal software-delivery controls:
 
-- schema and source validation;
+- specification schema and policy validation;
+- generated-source validation;
 - static analysis and tests;
-- import and capability policy;
+- import and capability rules;
 - preview and diff review;
 - package validation;
 - provenance and approval evidence.
 
+The package's CLI generation path applies policy before generation, but applications remain responsible for their complete build and review process.
+
 ### Customize
 
-AI adapts bounded parts of an existing component contract.
+AI adapts bounded parts of an existing component specification during tooling or build workflows.
 
 Examples include:
 
@@ -76,7 +82,7 @@ Examples include:
 - selecting design tokens;
 - producing constrained copy.
 
-Customization cannot change implementation identity, policy, imports, or undeclared capabilities.
+The CLI customization path validates the specification against policy before producing output. Generated changes remain subject to normal review and testing.
 
 ### Personalize
 
@@ -88,53 +94,58 @@ Examples include:
 - adaptive slot content;
 - known variant selection;
 - validated props;
-- bounded JSON patch overlays.
+- bounded JSON Patch overlays.
 
 This is the most constrained mode because output reaches the user-facing runtime without the same review window available to build-time source generation.
 
-## Runtime Safety Model
+## Implemented Runtime Safety Model
 
 At device time:
 
 - model output is untrusted;
-- executable source generation is not the default path;
+- output is validated against a registered JSON Schema contract;
+- unsafe prototype-related object keys are rejected;
+- JSON Patch paths and values are validated;
+- patches are revalidated against the contract after application;
 - registry-controlled implementations remain authoritative;
-- schemas and policy are enforced outside the model;
-- invalid output is rejected rather than coerced into authority;
-- fallback behavior remains application-controlled.
+- invalid output falls back to base props;
+- fallback and retry behavior remain application-controlled.
 
-The intended flow is:
+The implemented path is:
 
 ```text
 prompt, context, or media
   -> model capability
-  -> structured output
-  -> schema validation
-  -> policy validation
-  -> bounded overlay
-  -> registry-approved render
+  -> untrusted structured output
+  -> registered contract validation
+  -> unsafe-key and patch validation
+  -> bounded prop overlay
+  -> registered component render
 ```
+
+The full `PolicyEngine` is currently used by build/CLI generation and customization flows. It is not automatically executed by every `PersonalizedComponent` call.
 
 ## Runtime Overlays
 
-An overlay is a bounded modification applied to an authoritative component contract.
+An overlay is a bounded data modification applied to base props for an authoritative registered component.
 
 Supported patterns may include:
 
 - approved prop changes;
 - known variant selection;
 - declared slot text;
-- allowlisted JSON patch operations.
+- declared design-token values;
+- JSON Patch operations targeting declared paths.
 
-Overlay validation should enforce:
+The runtime contract should encode all mechanically enforceable field, enum, path, and value restrictions.
 
-- allowed paths and operations;
-- value types and enum membership;
-- component and contract identity;
-- capability and network restrictions;
-- design-token and accessibility rules.
+Application-level checks are still required for rules that cannot be proven from JSON Schema alone, including:
 
-Ambiguous recursive merging is avoided where explicit patch semantics provide a safer contract.
+- whether a validated URL or identifier grants a sensitive capability;
+- accessibility behavior that depends on rendered output;
+- semantic business rules;
+- network and data-handling policy;
+- review or approval requirements.
 
 ## Registry-centric Rendering
 
@@ -142,14 +153,15 @@ The registry maps component, specification, contract, version, and implementatio
 
 ```text
 ComponentSpec
-  -> validation
-  -> registry resolution
-  -> approved implementation
-  -> validated overlay
+  -> registration and identity checks
+  -> registered implementation and contract
+  -> contract-validated overlay
   -> render
 ```
 
 This preserves executable ownership in reviewed application code while allowing bounded adaptation.
+
+Runtime registry hashes are deterministic identity values, not cryptographic signatures or proof of provenance.
 
 ## Why Local AI Matters
 
@@ -176,18 +188,18 @@ Applications remain responsible for:
 
 CopilotKit and AG-UI can provide orchestration for agent actions, shared frontend state, and generative UI flows.
 
-Amaryllis fits as a local capability and governance boundary:
+Amaryllis fits as a local capability and contract-validation boundary:
 
 ```text
 agent action
   -> Amaryllis inference
   -> structured output
-  -> ComponentSpec validation
-  -> registry-approved overlay
+  -> PersonalizationEngine validation
+  -> registered component overlay
   -> render
 ```
 
-The companion package uses optional adapter contracts rather than requiring a specific orchestration framework. See [CopilotKit and AG-UI alignment](./copilotkit-ag-ui.md).
+The companion package uses optional adapter contracts rather than requiring a specific orchestration framework. Additional policy checks can be composed by the application. See [CopilotKit and AG-UI alignment](./copilotkit-ag-ui.md).
 
 ## Current Implementation
 
@@ -195,15 +207,15 @@ The repository includes:
 
 - `ComponentSpec` types and schemas;
 - YAML and object parsing;
-- policy primitives;
-- registry and identity validation;
+- policy primitives and CLI policy validation;
+- registry identity and replacement checks;
 - React source generation scaffolding;
 - bounded personalization outputs;
-- patch and overlay validation;
+- JSON Schema, unsafe-key, patch-path, patch-value, and post-patch validation;
 - package and example verification;
 - CI, SBOM, and provenance controls.
 
-The project remains an active `0.1.x` implementation. Areas still evolving include preview ergonomics, approval workflows, runtime observability, model-delivery integrity, replayable evidence, and broader framework integration.
+The project remains an active `0.1.x` implementation. Areas still evolving include automatic runtime policy composition, preview ergonomics, approval workflows, runtime observability, model-delivery integrity, replayable evidence, and broader framework integration.
 
 ## Explicit Non-goals
 
@@ -212,8 +224,9 @@ The component system is not intended to provide:
 - unrestricted device-time JSX or TSX generation;
 - autonomous mutation of application policy;
 - arbitrary runtime imports;
+- automatic semantic safety from schema validation alone;
 - replacement of design-system governance;
 - implicit trust in local or hosted model output;
 - a universal generative UI protocol.
 
-The goal is declarative, governable, AI-enabled interfaces with explicit limits and reviewable authority.
+The goal is declarative, governable, AI-enabled interfaces with explicit limits and accurately documented authority.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,208 +1,222 @@
 # Architecture
 
-This document explains the architecture of the `feature/ai-components` branch.
+This document provides a working mental model for the current Amaryllis repository. It is intentionally lighter than the component RFC and focuses on subsystem ownership, data flow, and trust boundaries.
 
-It is intentionally lighter than the RFC. The goal here is to provide a working mental model for contributors and users before they dive into the more normative component-governance material.
+## System Layers
 
-## Branch Structure
+Amaryllis contains three related but independently governed layers.
 
-This branch contains two related but distinct layers:
+### 1. On-device runtime
 
-1. **Base Amaryllis runtime**
-   - a React Native runtime for on-device multimodal AI
-   - native inference bridges for mobile
-   - hooks, provider, controller, and context integration
+The runtime is responsible for:
 
-2. **`@micrantha/amaryllis-components` companion module**
-   - a spec-driven component layer
-   - validation, policy, generation, and personalization primitives
-   - a path toward governed AI-enabled components
+- exposing React Native provider, hook, and controller APIs;
+- initializing native model runtimes;
+- managing multimodal sessions;
+- streaming output and cancellation;
+- integrating optional context retrieval;
+- keeping network fallback under application control.
 
-The important separation is that the base runtime is primarily concerned with **local inference**, while the companion module is concerned with **how AI is allowed to influence component behavior and generation**.
+At this layer, Amaryllis is an inference SDK. It does not own product policy or rendering authority.
 
----
+### 2. Context Engine
+
+The Context Engine is an interface-first memory and retrieval subsystem.
+
+It provides:
+
+- application-owned storage integration;
+- bounded retrieval;
+- TTL and item-count policy;
+- validation hooks;
+- optional scoring and ranking.
+
+It does not define component policy, replace the component registry, or make retrieved content trustworthy.
+
+### 3. Component governance
+
+`@micrantha/amaryllis-components` defines how AI may participate in component generation and runtime personalization.
+
+It provides:
+
+- typed and versioned `ComponentSpec` contracts;
+- schema validation;
+- policy enforcement;
+- registry and implementation identity primitives;
+- generation scaffolding;
+- bounded runtime overlays.
+
+The component layer answers a different question from the inference runtime:
+
+> How can AI influence component generation or behavior without becoming an unbounded runtime code-execution authority?
 
 ## Layered View
 
 ```text
 Application UI
   -> React Native components
-  -> app state / navigation / business logic
+  -> navigation, state, and business logic
 
-Amaryllis Runtime Layer
+Application-owned contracts
+  -> model configuration and lifecycle policy
+  -> ComponentSpec
+  -> schemas and validation
+  -> registry and implementation identity
+
+Amaryllis runtime
   -> LLMProvider
   -> hooks
   -> controller
   -> Context Engine
 
-Native Inference Layer
+Native inference
   -> TurboModule bridge
-  -> platform runtime
+  -> Android and iOS runtime
   -> on-device model execution
 
-Component Governance Layer
-  -> ComponentSpec
-  -> schema validation
-  -> policy engine
-  -> registry / runtime overlays
-
-Generated or Personalized Output
-  -> validated props
-  -> variant selection
+Validated component output
+  -> props
+  -> variants
   -> slot content
-  -> bounded JSON patch overlays
+  -> bounded JSON patches
+  -> registry-approved render
 ```
 
----
+The application owns the top-level authority. The model supplies capability within those boundaries.
 
-## Base Runtime Responsibilities
+## Authority Model
 
-The base runtime is responsible for:
+The architecture distinguishes probabilistic capability from deterministic authority.
 
-- initializing the local model runtime
-- exposing a React Native API surface
-- managing sessions for multimodal flows
-- handling streaming output
-- integrating optional context retrieval
-- keeping inference local to the device unless the application chooses otherwise
+Authoritative systems include:
 
-At this layer, the system is still fundamentally an inference SDK.
+- application code;
+- component specifications;
+- schemas and policy;
+- registries and implementation identities;
+- lifecycle and rendering code;
+- build and release controls.
 
----
-
-## Companion Module Responsibilities
-
-The companion module exists to answer a different question:
-
-> How should AI participate in component generation or runtime personalization without turning the UI into an unbounded code-execution surface?
-
-That module introduces a typed `ComponentSpec` and a supporting toolchain for:
-
-- parsing and validating specs
-- enforcing policy constraints
-- generating artifacts
-- constraining runtime personalization
-- preserving an authoritative component contract
-
-This is the branch’s most important architectural move.
-
----
+Model output is advisory until it has passed the relevant validation and policy checks.
 
 ## Why the Separation Matters
 
-Without a clear separation, the system easily drifts into one of two poor extremes:
+Without explicit boundaries, AI-enabled UI tends to drift toward one of two extremes.
 
-### Extreme 1: AI as arbitrary source generator
+### Arbitrary source generation
 
-This is fast for experimentation, but weak for governance, reproducibility, and security.
+Allowing a model to produce authoritative runtime JSX or TSX is flexible, but weak for security, reviewability, reproducibility, accessibility, and design governance.
 
-### Extreme 2: AI as a thin chat layer bolted onto static UI
+### Static UI with a chat layer
 
-This is safer, but it does not really unlock AI-enabled components or adaptive interfaces.
+Keeping AI isolated in a chat surface is easier to reason about, but does not enable meaningful component adaptation.
 
-The architecture in this branch aims for the middle path:
+Amaryllis takes a middle path:
 
-- local AI is available as a capability
-- component behavior is spec-driven
-- runtime outputs are bounded and validated
-- the authoritative UI contract remains outside the model
+- local inference is available as a capability;
+- component behavior is contract-driven;
+- runtime output is structured and validated;
+- executable implementations remain registry-controlled;
+- application code remains responsible for final behavior.
 
----
+## Build-Time and Device-Time AI
 
-## Build-Time vs Device-Time AI
-
-A critical distinction in this branch is the difference between:
+The architecture treats build-time generation and device-time personalization as different trust classes.
 
 ### Build-time or CI-time generation
 
-This is where the system can allow more powerful transformations, including source generation, so long as policy, validation, and review controls are enforced.
+Build-time workflows may generate source or larger artifacts because the output can pass through:
 
-Typical outputs:
+- schema and source validation;
+- policy enforcement;
+- static analysis;
+- tests and previews;
+- human review;
+- provenance and artifact tracking.
 
-- generated React code
-- generated artifacts
-- reviewable diffs
-- provenance metadata
+Typical outputs include generated React source, implementation scaffolding, reviewable diffs, and package artifacts.
 
 ### Device-time personalization
 
-This is much more constrained.
+Device-time output is substantially more constrained. The model acts as an untrusted structured-data producer rather than a source-code generator.
 
-On device, AI should behave as an **untrusted structured-data producer**, not as a code generator.
+Typical outputs include:
 
-Typical outputs:
+- props JSON;
+- variant selection;
+- slot text;
+- constrained JSON patch operations.
 
-- props JSON
-- variant selection
-- slot text
-- limited JSON patch overlays
+This distinction is central to the runtime safety model.
 
-That distinction is central to the safety model of the branch.
+## Context Placement
 
----
-
-## Context Engine Placement
-
-The Context Engine sits beside the inference runtime, not above the component spec layer.
-
-Its role is to provide:
-
-- memory
-- retrieval
-- bounded context augmentation
-- interface-first storage integration
-
-It should not be confused with a policy engine or a component registry. It is a supporting subsystem for prompt and interaction context.
-
----
-
-## CopilotKit And AG-UI Placement
-
-CopilotKit and AG-UI fit at the application orchestration boundary, above Amaryllis inference and component governance.
-
-In this branch, they are treated as optional integration protocols for actions, frontend-rendered tool output, and generative UI flows. They do not replace the Amaryllis registry or validation model.
-
-The intended flow is:
+The Context Engine sits beside the inference runtime. It enriches prompts and interactions, but does not sit above the component policy layer.
 
 ```text
-AG-UI/CopilotKit action
-  -> Amaryllis local inference capability
-  -> structured output
-  -> amaryllis-components validation
-  -> registry-approved component overlay
+ContextStore
+  -> bounded retrieval
+  -> prompt or interaction context
+  -> model capability
+  -> independently validated output
 ```
 
-That keeps Amaryllis responsible for local AI execution and render authority while allowing CopilotKit-style applications to orchestrate agent UI flows.
+Retrieval provenance can improve attribution, but does not make retrieved content safe.
 
----
+## CopilotKit and AG-UI Placement
+
+CopilotKit and AG-UI fit at the application orchestration boundary. They may coordinate actions, shared frontend state, and generative UI flows, but they do not replace Amaryllis validation or registry authority.
+
+```text
+AG-UI or CopilotKit action
+  -> Amaryllis inference capability
+  -> structured output
+  -> component contract validation
+  -> registry-approved overlay
+  -> render
+```
+
+The companion package therefore uses optional adapter contracts rather than making orchestration frameworks part of the core runtime.
 
 ## Security Boundaries
 
-This branch creates several important trust boundaries:
+The primary boundaries are:
 
-1. **Model output is not authoritative**
-2. **Component specs are authoritative**
-3. **Registry and validation decide what can be rendered**
-4. **Device-time AI output must be schema- and policy-validated**
-5. **Source generation is treated differently from runtime personalization**
+1. application input crossing into native inference;
+2. retrieved context crossing into prompts;
+3. model output crossing into application-controlled logic;
+4. generated artifacts crossing into source and package outputs;
+5. registry identities crossing into rendered implementations;
+6. model assets crossing into the application trust boundary.
 
-That lets the system support adaptive behavior without implicitly trusting the model as a code author at runtime.
+The corresponding rules are:
 
----
+- model output is not authoritative;
+- context is not trusted merely because it is local;
+- component specs and registries remain authoritative;
+- runtime output must be schema- and policy-validated;
+- build-time source and device-time data use different review controls;
+- local inference shifts risk rather than eliminating it.
 
 ## Design Direction
 
-The overall direction of this branch is:
+The current direction is to:
 
-- keep Amaryllis as the local AI runtime substrate
-- build a companion component model on top of it
-- make AI-enabled components declarative, typed, and governable
-- preserve a strong distinction between inference capability and UI authority
+- keep Amaryllis focused on local mobile AI execution;
+- keep the Context Engine storage-agnostic and application-owned;
+- make AI-enabled components declarative, typed, and governable;
+- improve model delivery and integrity controls;
+- strengthen runtime observability and failure recovery;
+- preserve a clear boundary between inference capability and product authority.
 
-For the detailed component contract and enforcement model, see:
+For more detail, see:
 
-- [AI-enabled components](./ai-enabled-components.md)
 - [Concepts](./concepts.md)
+- [AI-enabled components](./ai-enabled-components.md)
+- [Runtime personalization](./runtime-personalization.md)
+- [Registry and validation](./registry-and-validation.md)
 - [Local AI and MediaPipe](./local-ai.md)
 - [CopilotKit and AG-UI alignment](./copilotkit-ag-ui.md)
+- [Security model](./security-model.md)
+- [Threat model](./threat-model.md)
 - [Amaryllis Components RFC](./amaryllis_ai_component_module_rfc.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,10 +41,11 @@ It provides:
 
 - typed and versioned `ComponentSpec` contracts;
 - schema validation;
-- policy enforcement;
+- policy primitives and build/CLI policy validation;
 - registry and implementation identity primitives;
 - generation scaffolding;
-- bounded runtime overlays.
+- bounded runtime overlays;
+- runtime JSON Schema, unsafe-key, and patch validation.
 
 The component layer answers a different question from the inference runtime:
 
@@ -55,31 +56,31 @@ The component layer answers a different question from the inference runtime:
 ```text
 Application UI
   -> React Native components
-  -> navigation, state, and business logic
+  -> navigation, state, business logic, and application policy
 
-Application-owned contracts
-  -> model configuration and lifecycle policy
-  -> ComponentSpec
-  -> schemas and validation
-  -> registry and implementation identity
+Application-owned configuration
+  -> model assets and lifecycle
+  -> ContextStore
+  -> fallback and network behavior
 
 Amaryllis runtime
   -> LLMProvider
   -> hooks
   -> controller
   -> Context Engine
+  -> native Android and iOS inference
 
-Native inference
-  -> TurboModule bridge
-  -> Android and iOS runtime
-  -> on-device model execution
+Component tooling
+  -> ComponentSpec schema validation
+  -> build/CLI policy validation
+  -> generated artifacts and registered implementations
 
-Validated component output
-  -> props
-  -> variants
-  -> slot content
-  -> bounded JSON patches
-  -> registry-approved render
+Runtime personalization
+  -> registry lookup
+  -> registered JSON contract
+  -> schema, unsafe-key, and patch validation
+  -> bounded data overlay
+  -> registered component render
 ```
 
 The application owns the top-level authority. The model supplies capability within those boundaries.
@@ -90,14 +91,16 @@ The architecture distinguishes probabilistic capability from deterministic autho
 
 Authoritative systems include:
 
-- application code;
+- application code and policy;
 - component specifications;
-- schemas and policy;
+- runtime personalization contracts;
 - registries and implementation identities;
 - lifecycle and rendering code;
 - build and release controls.
 
-Model output is advisory until it has passed the relevant validation and policy checks.
+Model output is advisory until it has passed the checks actually composed into its execution path.
+
+At runtime, the current package automatically enforces the registered JSON contract, unsafe-key restrictions, and JSON Patch bounds. Broader policy such as network, accessibility, semantic business rules, and review requirements must be encoded in the contract, kept in component code, or composed by the application.
 
 ## Why the Separation Matters
 
@@ -115,9 +118,9 @@ Amaryllis takes a middle path:
 
 - local inference is available as a capability;
 - component behavior is contract-driven;
-- runtime output is structured and validated;
+- runtime output is structured and schema-validated;
 - executable implementations remain registry-controlled;
-- application code remains responsible for final behavior.
+- application code remains responsible for final behavior and policy.
 
 ## Build-Time and Device-Time AI
 
@@ -127,8 +130,9 @@ The architecture treats build-time generation and device-time personalization as
 
 Build-time workflows may generate source or larger artifacts because the output can pass through:
 
-- schema and source validation;
-- policy enforcement;
+- specification schema validation;
+- package policy validation;
+- generated-source analysis;
 - static analysis;
 - tests and previews;
 - human review;
@@ -145,9 +149,10 @@ Typical outputs include:
 - props JSON;
 - variant selection;
 - slot text;
-- constrained JSON patch operations.
+- design-token values;
+- constrained JSON Patch operations.
 
-This distinction is central to the runtime safety model.
+The current automatic runtime checks are contract/schema, unsafe-key, and patch validation. Full package policy evaluation is not implicitly performed for every programmatic runtime registration.
 
 ## Context Placement
 
@@ -165,18 +170,18 @@ Retrieval provenance can improve attribution, but does not make retrieved conten
 
 ## CopilotKit and AG-UI Placement
 
-CopilotKit and AG-UI fit at the application orchestration boundary. They may coordinate actions, shared frontend state, and generative UI flows, but they do not replace Amaryllis validation or registry authority.
+CopilotKit and AG-UI fit at the application orchestration boundary. They may coordinate actions, shared frontend state, and generative UI flows, but they do not replace Amaryllis registry or contract validation.
 
 ```text
 AG-UI or CopilotKit action
   -> Amaryllis inference capability
   -> structured output
-  -> component contract validation
-  -> registry-approved overlay
+  -> PersonalizationEngine validation
+  -> registered component overlay
   -> render
 ```
 
-The companion package therefore uses optional adapter contracts rather than making orchestration frameworks part of the core runtime.
+The companion package therefore uses optional adapter contracts rather than making orchestration frameworks part of the core runtime. Applications can compose additional policy around those adapters.
 
 ## Security Boundaries
 
@@ -194,7 +199,8 @@ The corresponding rules are:
 - model output is not authoritative;
 - context is not trusted merely because it is local;
 - component specs and registries remain authoritative;
-- runtime output must be schema- and policy-validated;
+- runtime output must satisfy its registered contract;
+- additional semantic and capability policy must be explicitly composed;
 - build-time source and device-time data use different review controls;
 - local inference shifts risk rather than eliminating it.
 
@@ -205,6 +211,7 @@ The current direction is to:
 - keep Amaryllis focused on local mobile AI execution;
 - keep the Context Engine storage-agnostic and application-owned;
 - make AI-enabled components declarative, typed, and governable;
+- compose broader policy into runtime personalization without conflating it with schema validation;
 - improve model delivery and integrity controls;
 - strengthen runtime observability and failure recovery;
 - preserve a clear boundary between inference capability and product authority.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -21,13 +21,7 @@ The runtime provides model capability. It does not own product policy or renderi
 
 The lower-level interface to the native inference engine.
 
-Typical responsibilities include:
-
-- initialization;
-- model and session lifecycle;
-- synchronous and streaming generation;
-- multimodal requests;
-- cancellation and cleanup.
+Typical responsibilities include initialization, model and session lifecycle, synchronous and streaming generation, multimodal requests, cancellation, and cleanup.
 
 ### Session
 
@@ -81,7 +75,7 @@ A spec may define:
 - policy requirements;
 - generation contracts.
 
-The spec is authoritative. Model output is not.
+The specification is authoritative. Model output is not.
 
 ### Generation contract
 
@@ -93,32 +87,43 @@ Examples include:
 - props JSON;
 - variant selection;
 - slot text;
-- constrained JSON patch overlays.
+- constrained JSON Patch overlays.
+
+For runtime personalization, the registered JSON Schema contract is the automatic validation boundary implemented by `PersonalizationEngine`.
 
 ### Registry
 
 The authoritative mapping between:
 
-- component identity;
-- spec and contract identity;
-- version;
+- component name and version;
+- specification and personalization contract;
+- deterministic identity hashes;
 - executable implementation identity.
 
-The registry decides what implementation is renderable. The model cannot register arbitrary runtime code.
+The registry decides what implementation is renderable. Model output cannot register arbitrary runtime code.
+
+Registry hashes currently provide deterministic identity and drift detection. They are not cryptographic signatures.
 
 ### Overlay
 
-A bounded modification applied on top of an authoritative component contract.
+A bounded data modification applied to base props for an authoritative registered component.
 
-Examples include approved prop updates, known variant selection, slot text, and constrained patch operations.
+Examples include approved prop updates, known variant selection, slot text, design-token values, and constrained patch operations.
 
-Overlays must pass schema and policy validation before rendering.
+The current runtime requires overlays to pass:
+
+- the registered JSON Schema contract;
+- unsafe object-key validation;
+- JSON Patch path and value validation where patches are used;
+- schema validation after patches are applied.
+
+Additional semantic, capability, accessibility, network, or business policy must be encoded in the contract or composed by the application.
 
 ### Runtime personalization
 
 AI-influenced rendering behavior where the model does not become the authoritative source of executable UI.
 
-Typical outputs include props, variants, slot text, and bounded overlays. Runtime personalization is intentionally more constrained than build-time source generation.
+Typical outputs include props, variants, slot text, design-token values, and bounded overlays. Runtime personalization is intentionally more constrained than build-time source generation.
 
 ## AI Concepts
 
@@ -148,13 +153,15 @@ Model output constrained to a schema or bounded contract.
 
 Examples include JSON, typed props, variant identifiers, and patch operations.
 
-Structured output is easier to validate and govern than arbitrary executable source, but it is not inherently safe.
+Structured output is easier to validate and govern than arbitrary executable source, but it is not inherently safe or semantically correct.
 
 ### Deterministic control
 
 Application-owned logic whose behavior can be validated independently of model output.
 
 Examples include schemas, policy engines, registry identity checks, patch validation, static analysis, and release gates.
+
+A deterministic control is effective only when it is actually composed into the relevant execution path.
 
 ## Governance Concepts
 
@@ -172,20 +179,24 @@ Policy may cover:
 - accessibility requirements;
 - review and approval requirements.
 
-Policy is enforced outside the model.
+Policy is defined and enforced outside the model.
+
+In the current package, `PolicyEngine` is used by build and CLI generation/customization flows. Programmatic runtime personalization does not automatically execute the complete policy engine.
 
 ### Validation
 
-The process of confirming that:
+The process of confirming that an input or artifact satisfies the checks composed into its path.
 
-- specs and contracts are well formed;
-- identities and versions match;
-- outputs satisfy schemas;
-- overlays remain within allowed bounds;
-- generated artifacts satisfy source and package policy;
-- failures are observable and recoverable.
+Examples include:
 
-Validation remains deterministic even when generation is probabilistic.
+- specification schema validation;
+- runtime personalization contract validation;
+- registry name, version, and hash checks;
+- unsafe-key and patch validation;
+- build/CLI policy validation;
+- generated-source and package checks.
+
+Validation remains deterministic even when generation is probabilistic. Passing one validation layer does not imply that every semantic or security policy has been evaluated.
 
 ### Authoritative boundary
 
@@ -194,14 +205,16 @@ The boundary defining which subsystem has final control over behavior.
 In Amaryllis:
 
 - the model is not authoritative;
-- application code, specs, policy, registries, and validators are authoritative;
-- runtime output must be validated before rendering or execution.
+- application code and registered implementations remain authoritative over execution;
+- specifications and runtime contracts remain authoritative over declared structure and personalization data;
+- application policy remains authoritative over sensitive behavior;
+- runtime output must pass its registered contract before rendering.
 
 ### Provenance
 
 Evidence describing where an artifact or decision came from.
 
-Potential provenance includes spec, contract, model, policy, validator, generation, build, review, and release identities.
+Potential provenance includes specification, contract, model, policy, validator, generation, build, review, and release identities.
 
 Provenance improves attribution and replayability. It does not prove correctness or safety.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,268 +1,214 @@
 # Concepts
 
-This document defines the core terminology used throughout the `feature/ai-components` branch.
+This document defines the core terminology used across the Amaryllis runtime, Context Engine, component workspace, and governance model.
 
-The goal is to establish a consistent mental model across:
+## Runtime Concepts
 
-- the base runtime
-- the Context Engine
-- the companion components workspace
-- the RFC and governance model
+### Runtime
 
----
+The React Native-facing AI subsystem. It coordinates inference and interaction state through:
 
-# Base Runtime Concepts
+- providers;
+- hooks;
+- controller APIs;
+- streaming interfaces;
+- context integration;
+- lifecycle and cancellation handling.
 
-## Runtime
+The runtime provides model capability. It does not own product policy or rendering authority.
 
-The React Native-facing AI subsystem.
+### Controller
 
-The runtime exposes:
+The lower-level interface to the native inference engine.
 
-- hooks
-- providers
-- controller APIs
-- streaming interfaces
-- context integration
+Typical responsibilities include:
 
-The runtime is responsible for coordinating inference and interaction state.
+- initialization;
+- model and session lifecycle;
+- synchronous and streaming generation;
+- multimodal requests;
+- cancellation and cleanup.
 
----
+### Session
 
-## Controller
+Inference state that persists across related requests.
 
-The controller is the direct interface to the native inference engine.
+A session may support images, conversational continuity, or personalization context. It is not necessarily equivalent to a stored chat transcript.
 
-Examples:
+### Model asset
 
-- initialization
-- session management
-- synchronous generation
-- streaming generation
-- cancellation
+An application-selected model, adapter, encoder, or related file used by the native runtime.
 
-The controller is lower-level than hooks or providers.
+Applications own model licensing, distribution, integrity verification, storage, updates, rollback, and device compatibility.
 
----
+## Context Concepts
 
-## Session
+### Context Engine
 
-A session represents inference state that persists across requests.
-
-Sessions are particularly important for multimodal workflows involving:
-
-- images
-- conversational continuity
-- runtime personalization context
-
-A session is not equivalent to a chat transcript.
-
----
-
-## Context Engine
-
-The Context Engine is an interface-first memory and retrieval layer.
+An interface-first memory and retrieval layer.
 
 It provides:
 
-- retrieval
-- bounded context augmentation
-- validation hooks
-- optional scoring
-- storage abstraction
+- application-owned storage abstraction;
+- bounded retrieval;
+- TTL and item-count policy;
+- validation hooks;
+- optional scoring.
 
-It does not:
+It does not define component policy, govern rendering authority, or make retrieved content trustworthy.
 
-- define component policy
-- govern rendering authority
-- replace the component registry
+### ContextStore
 
----
+The application-provided persistence interface used by the Context Engine. Implementations may use SQLite, files, another database, or a custom service.
 
-# Component Model Concepts
+### Retrieved context
 
-## ComponentSpec
+Data selected for prompt or interaction augmentation. Retrieved context remains untrusted even when it originated locally or has known provenance.
+
+## Component Model Concepts
+
+### ComponentSpec
 
 The authoritative declarative definition of a component.
 
-The spec defines:
+A spec may define:
 
-- metadata
-- props
-- UI structure
-- behavior constraints
-- AI boundaries
-- policy constraints
-- generation contracts
+- metadata and version;
+- props and structure;
+- target framework and runtime;
+- behavior and capability constraints;
+- allowed AI execution mode;
+- policy requirements;
+- generation contracts.
 
-The spec is authoritative.
+The spec is authoritative. Model output is not.
 
-AI output is not.
+### Generation contract
 
----
+A declaration of what an AI workflow may produce, where it may execute, and how its output is validated.
 
-## Generation Contract
+Examples include:
 
-The generation contract defines:
+- build-time TSX generation;
+- props JSON;
+- variant selection;
+- slot text;
+- constrained JSON patch overlays.
 
-- what AI may produce
-- which formats are allowed
-- how output is validated
-- where execution is allowed
+### Registry
 
-Examples:
+The authoritative mapping between:
 
-- TSX generation
-- props JSON
-- variant selection
-- JSON patch overlays
+- component identity;
+- spec and contract identity;
+- version;
+- executable implementation identity.
 
----
+The registry decides what implementation is renderable. The model cannot register arbitrary runtime code.
 
-## Runtime Personalization
+### Overlay
 
-Runtime personalization means:
+A bounded modification applied on top of an authoritative component contract.
 
-> AI influences rendered behavior without becoming the authoritative source of executable UI.
+Examples include approved prop updates, known variant selection, slot text, and constrained patch operations.
 
-Typical outputs:
+Overlays must pass schema and policy validation before rendering.
 
-- props
-- variants
-- slot text
-- bounded overlays
+### Runtime personalization
 
-Runtime personalization is intentionally more constrained than build-time generation.
+AI-influenced rendering behavior where the model does not become the authoritative source of executable UI.
 
----
+Typical outputs include props, variants, slot text, and bounded overlays. Runtime personalization is intentionally more constrained than build-time source generation.
 
-## Registry
+## AI Concepts
 
-The registry is the authoritative mapping between:
+### Local AI
 
-- component identity
-- implementation identity
-- spec identity
-- runtime contract identity
+Inference executed on the device rather than requiring a hosted inference service.
 
-The registry decides what is renderable.
+Local execution can reduce network exposure and latency, but remains subject to client compromise, model tampering, resource limits, logging, storage, and fallback risks.
 
-The registry is not the model.
+Locality is a deployment characteristic, not a guarantee of trust.
 
----
+### Capability provider
 
-## Overlay
+A model runtime or service capable of performing a bounded task, such as:
 
-An overlay is a bounded runtime modification applied on top of an authoritative component contract.
+- summarization;
+- image understanding;
+- personalization;
+- variant selection;
+- slot generation.
 
-Examples:
+Amaryllis models AI as one or more capability providers rather than assuming a single authoritative assistant.
 
-- variant selection
-- slot text
-- approved props updates
-- limited JSON patch operations
+### Structured output
 
-Overlays must pass validation before rendering.
+Model output constrained to a schema or bounded contract.
 
----
+Examples include JSON, typed props, variant identifiers, and patch operations.
 
-# AI Concepts
+Structured output is easier to validate and govern than arbitrary executable source, but it is not inherently safe.
 
-## Local AI
+### Deterministic control
 
-Inference executed on device.
+Application-owned logic whose behavior can be validated independently of model output.
 
-Examples:
+Examples include schemas, policy engines, registry identity checks, patch validation, static analysis, and release gates.
 
-- MediaPipe-backed inference
-- mobile multimodal sessions
-- local summarization
-- offline personalization
+## Governance Concepts
 
-Local AI is a deployment characteristic, not a trust boundary.
+### Policy
 
----
+Rules defining what a workflow or runtime is allowed to do.
 
-## Capability Provider
+Policy may cover:
 
-A capability provider is a runtime capable of performing a bounded AI task.
-
-Examples:
-
-- image understanding
-- summarization
-- personalization
-- variant selection
-- slot generation
-
-This branch intentionally thinks in terms of:
-
-```text
-AI capability providers
-```
-
-rather than:
-
-```text
-single assistant model
-```
-
----
-
-## Structured Output
-
-Structured output is model output constrained to a schema or bounded contract.
-
-Examples:
-
-- JSON
-- variant identifiers
-- patch operations
-- typed props
-
-Structured output is preferred for runtime personalization because it is more governable than arbitrary source generation.
-
----
-
-# Governance Concepts
-
-## Policy
-
-Policy defines what the system allows.
-
-Examples:
-
-- import restrictions
-- runtime restrictions
-- review requirements
-- allowed operations
-- forbidden operations
+- imports and dependencies;
+- runtime execution modes;
+- network behavior;
+- allowed and forbidden operations;
+- slots, variants, and design tokens;
+- accessibility requirements;
+- review and approval requirements.
 
 Policy is enforced outside the model.
 
----
+### Validation
 
-## Validation
+The process of confirming that:
 
-Validation is the process of confirming that:
+- specs and contracts are well formed;
+- identities and versions match;
+- outputs satisfy schemas;
+- overlays remain within allowed bounds;
+- generated artifacts satisfy source and package policy;
+- failures are observable and recoverable.
 
-- specs are well-formed
-- outputs match contracts
-- overlays stay within allowed bounds
-- generated artifacts satisfy policy
+Validation remains deterministic even when generation is probabilistic.
 
-Validation is central to the branch architecture.
+### Authoritative boundary
 
----
+The boundary defining which subsystem has final control over behavior.
 
-## Authoritative Boundary
+In Amaryllis:
 
-The authoritative boundary defines which subsystem has final control.
+- the model is not authoritative;
+- application code, specs, policy, registries, and validators are authoritative;
+- runtime output must be validated before rendering or execution.
 
-In this branch:
+### Provenance
 
-- the model is not authoritative
-- specs and registries are authoritative
-- runtime outputs must be validated before rendering
+Evidence describing where an artifact or decision came from.
 
-That distinction is the foundation of the branch’s governance model.
+Potential provenance includes spec, contract, model, policy, validator, generation, build, review, and release identities.
+
+Provenance improves attribution and replayability. It does not prove correctness or safety.
+
+### Build-time generation
+
+AI-assisted generation occurring in local tooling, build pipelines, or CI. It may produce executable artifacts because stronger validation, testing, review, and evidence controls can be applied.
+
+### Device-time personalization
+
+AI-assisted adaptation occurring in the user-facing runtime. It is constrained to bounded structured output because the review and recovery conditions are materially different from build-time generation.

--- a/docs/registry-and-validation.md
+++ b/docs/registry-and-validation.md
@@ -1,211 +1,147 @@
 # Registry and Validation
 
-The registry and validation pipeline preserve executable ownership when AI participates in component generation or runtime personalization.
+The registry and validation path preserve executable ownership when AI participates in component generation or runtime personalization.
 
 ```text
-The registry is authoritative.
-Validation is mandatory.
-Model output is advisory.
+The registry is authoritative over implementations.
+The runtime contract is authoritative over personalization data.
+Model output is untrusted until validated.
 ```
 
-This document focuses on runtime contract resolution and validation rather than generation prompts or model behavior.
-
-## Why Registry-centric Rendering Exists
-
-Without an authoritative registry, AI-enabled UI can drift toward:
-
-- arbitrary runtime mutation;
-- hidden implementation replacement;
-- unreviewed rendering behavior;
-- inconsistent policy attachment;
-- design-system fragmentation;
-- ambiguous version and contract identity.
-
-The registry preserves component identity, implementation authority, validation requirements, and rendering stability.
+This document distinguishes controls implemented in the current runtime path from broader policy and delivery controls used at build or CLI time.
 
 ## Registry Responsibilities
 
-A registry entry binds:
+A registered component binds:
 
 ```text
-component identity
-  -> version
+component name and version
+  -> ComponentSpec
+  -> personalization contract
   -> implementation identity
-  -> ComponentSpec identity
-  -> generation or runtime contract
-  -> validators and policy
+  -> deterministic spec and contract hashes
 ```
 
-The registry determines:
+`ComponentRegistry.register` verifies that supplied names, versions, and optional hashes match the specification and contract. Replacement is explicit through `{ replace: true }`.
 
-- what implementation may render;
-- which specification and contract versions apply;
-- which variants, slots, props, and overlays are legal;
-- which validators must run;
-- which runtime capabilities are allowed;
-- how replacement or upgrade semantics work.
+The registry therefore determines which reviewed implementation can render for a known component entry. Runtime model output cannot register or replace executable component code.
 
-The model cannot bypass or mutate the registry.
+The current hashes are deterministic identity and drift-detection values. They are not cryptographic signatures or proof that an implementation is trustworthy.
 
-## Runtime Flow
+## Implemented Runtime Path
+
+`PersonalizedComponent` currently follows this path:
 
 ```text
-ComponentSpec
+component name
   -> registry lookup
-  -> contract and implementation resolution
-  -> AI invocation
+  -> registered personalization contract
   -> untrusted structured output
-  -> validation pipeline
-  -> bounded overlay
-  -> render
+  -> JSON Schema validation
+  -> unsafe object-key validation
+  -> JSON Patch path and value validation
+  -> post-patch schema validation
+  -> bounded prop overlay
+  -> registered implementation render
 ```
 
-Validation sits between probabilistic output and authoritative rendering.
+The runtime rejects invalid personalization data and reverts to base props. Optional callbacks expose validation errors and diagnostics to the application.
 
-## Validation Pipeline
+### Contract validation
 
-Validation is layered so each concern remains explicit and testable.
+`PersonalizationEngine.validate` currently enforces:
 
-```text
-identity and version checks
-  -> schema validation
-  -> policy validation
-  -> accessibility and design validation
-  -> overlay validation
-  -> render eligibility
-```
+- JSON Schema shape, types, required fields, enums, and additional-property rules declared by the contract;
+- rejection of unsafe object keys such as `__proto__`, `constructor`, and `prototype`;
+- JSON Patch paths restricted to declared `props`, `slots`, and `designTokens`, plus the top-level `variant` field;
+- rejection of unsafe values within patch operations;
+- schema validation again after patches are applied.
 
-Unknown identities, schema versions, operations, or capabilities should fail closed.
+`PersonalizationEngine.apply` uses bounded recursive merging and ignores unsafe object keys when combining validated personalization data with base props.
 
-## Validation Categories
+### Registry identity checks
 
-### Identity and version validation
+Registration and hydration validate:
 
-Confirms:
+- component name against `spec.metadata.name`;
+- version against `spec.metadata.version`;
+- optional spec and runtime-contract hashes against recomputed values;
+- explicit replacement semantics for an existing versioned key.
 
-- the component is registered;
-- spec, contract, and implementation identities match;
-- versions are compatible;
-- replacement semantics are explicit;
-- the requested runtime mode is supported.
+An unversioned lookup resolves the registry's latest known entry for that component name. The project does not yet provide full compatibility negotiation or signed manifest verification.
 
-### Schema validation
+## Policy Enforcement Boundary
 
-Confirms:
+The package contains a `PolicyEngine`, and the `generate` and `customize` CLI flows validate specifications against policy before producing artifacts.
 
-- required fields exist;
-- types and formats are correct;
-- enums are bounded;
-- output structure matches the declared contract;
-- additional fields are rejected where appropriate.
+The current programmatic runtime personalization path does **not** automatically invoke the full `PolicyEngine`. Registering a component directly and rendering it through `PersonalizedComponent` guarantees contract, unsafe-key, and patch validation, but does not by itself enforce every possible:
 
-Typical outputs include props JSON, variant identifiers, slot values, and patch operations.
+- network or external-capability restriction;
+- accessibility requirement;
+- review or approval rule;
+- application-specific semantic constraint;
+- design-system rule that is not encoded in the runtime contract.
 
-### Policy validation
+Applications must encode enforceable runtime limits in the personalization schema and component implementation, and add application-level policy checks where required.
 
-Confirms:
+A future runtime policy layer should compose with `PersonalizationEngine` rather than treating schema validation as equivalent to policy enforcement.
 
-- forbidden operations are absent;
-- runtime and network restrictions are respected;
-- overlay paths stay within allowlists;
-- imports and capabilities remain within declared bounds;
-- execution-mode and review requirements are satisfied.
+## Build-Time Validation
 
-Policy is deterministic and external to the model.
+Build or CI generation can apply stronger controls because executable output is reviewable before release. Depending on the workflow, controls may include:
 
-### Accessibility and design validation
-
-May confirm:
-
-- required labels and semantics remain present;
-- runtime output cannot remove critical accessibility behavior;
-- only approved design tokens and variants are used;
-- generated source passes applicable accessibility checks;
-- contrast and interaction constraints remain satisfied.
-
-Some checks require source, rendered output, or platform-specific testing and cannot be proven from schema validation alone.
-
-### Overlay validation
-
-Confirms:
-
-- patch paths and operations are legal;
-- value types satisfy the target schema;
-- component and contract identity are preserved;
-- mutations cannot alter policy, imports, capabilities, or implementation identity;
-- overlays remain bounded and replayable.
-
-Explicit patch contracts are preferred over ambiguous recursive object merging.
-
-### Generated-source validation
-
-Build-time executable output may require:
-
-- import allowlists and sink denylists;
-- formatting, lint, and type checking;
+- ComponentSpec schema and policy validation;
+- import allowlists and dangerous-sink checks;
+- formatting, linting, and type checking;
 - unit, integration, and accessibility tests;
-- package and entrypoint validation;
+- package metadata and entrypoint validation;
 - human diff review;
-- provenance and approval evidence.
+- provenance, SBOM, and approval evidence.
 
-Passing source validation does not make generated behavior inherently correct; it makes the result reviewable through normal engineering controls.
+These controls are separate from device-time personalization and should not be inferred from the runtime schema-validation path.
 
 ## Failure Handling
 
-Validation failures must not silently degrade into unrestricted behavior.
+Validation failures must not silently expand authority.
 
-Preferred behavior is to:
+The implemented runtime behavior is to:
 
-- reject the invalid output or complete overlay;
-- return typed failure details;
-- preserve the authoritative base component;
-- avoid partial application unless the contract explicitly supports atomic subsets;
-- avoid implicit provider or network fallback;
-- record enough evidence for diagnosis without leaking sensitive prompts or context.
+- reject invalid personalization output;
+- preserve or restore base props;
+- expose typed error arrays and diagnostics from `PersonalizationEngine`;
+- optionally report validation events to application telemetry;
+- avoid executing model output as source code.
 
-The runtime should fail closed where policy, identity, or capability boundaries are uncertain.
+Applications remain responsible for retry policy, user-visible fallback, logging, privacy-safe telemetry, and any remote-provider fallback.
 
-## Registry as a Security Boundary
+## Security Properties and Limits
 
-The registry prevents:
+The current registry and runtime path provide useful boundaries:
 
-- arbitrary component injection;
-- runtime implementation replacement;
-- spec and implementation mismatch;
-- unauthorized imports and capabilities;
-- hidden executable generation;
-- silent contract drift.
+- the model cannot introduce a new React implementation at runtime;
+- personalization must satisfy a registered JSON contract;
+- JSON Patch operations are constrained to declared paths;
+- unsafe prototype-related keys are rejected or ignored;
+- registration identity mismatches fail explicitly.
 
-The model may influence rendering only through a contract attached to a known registry entry.
+They do not currently provide:
 
-## Provenance
+- cryptographically signed registry manifests;
+- automatic full-policy evaluation for every runtime personalization call;
+- proof of accessibility or semantic correctness;
+- capability isolation for component implementations;
+- complete replay, audit, or compatibility negotiation.
 
-Useful registry and validation evidence may include:
+## Future Work
 
-- component, spec, contract, and implementation identifiers;
-- hashes and versions;
-- policy and validator versions;
-- model and provider identity;
-- raw and normalized output digests;
-- validation results;
-- review and approval metadata;
-- generated package SBOMs and release attestations.
+Likely next steps include:
 
-Provenance supports attribution and replay. It is not a substitute for policy or correctness checks.
-
-## Current Constraints and Future Work
-
-The repository contains working registry, schema, policy, and personalization primitives, but remains an active `0.1.x` implementation.
-
-Likely future work includes:
-
-- signed registry manifests;
-- stronger spec and contract hashing;
+- compose runtime policy checks with contract validation;
+- signed registry and model manifests;
+- cryptographic identity and provenance evidence;
+- explicit version compatibility and migration rules;
 - overlay replay and diff tooling;
-- validator provenance and compatibility negotiation;
-- explicit migration and replacement workflows;
-- runtime capability negotiation;
-- deterministic render manifests;
-- observability and audit interfaces.
+- runtime observability and audit interfaces;
+- accessibility and design-system validators appropriate to the rendered platform.
 
-The immediate priority is preserving strong identity and validation boundaries before increasing runtime flexibility.
+The immediate priority is to keep implemented guarantees distinct from intended defense-in-depth controls while preserving strong registry and contract boundaries.

--- a/docs/registry-and-validation.md
+++ b/docs/registry-and-validation.md
@@ -1,8 +1,6 @@
 # Registry and Validation
 
-This document explains the registry and validation direction for the `feature/ai-components` branch.
-
-The core architectural principle is:
+The registry and validation pipeline preserve executable ownership when AI participates in component generation or runtime personalization.
 
 ```text
 The registry is authoritative.
@@ -10,206 +8,204 @@ Validation is mandatory.
 Model output is advisory.
 ```
 
-This document focuses on the runtime contract lifecycle rather than generation semantics.
+This document focuses on runtime contract resolution and validation rather than generation prompts or model behavior.
 
----
+## Why Registry-centric Rendering Exists
 
-# Why Registry-Centric Rendering Exists
+Without an authoritative registry, AI-enabled UI can drift toward:
 
-Without an authoritative registry, runtime AI systems tend to drift toward:
+- arbitrary runtime mutation;
+- hidden implementation replacement;
+- unreviewed rendering behavior;
+- inconsistent policy attachment;
+- design-system fragmentation;
+- ambiguous version and contract identity.
 
-- arbitrary runtime mutation
-- hidden implementation changes
-- unreviewed rendering behavior
-- policy inconsistencies
-- design-system fragmentation
+The registry preserves component identity, implementation authority, validation requirements, and rendering stability.
 
-The registry exists to preserve:
+## Registry Responsibilities
 
-- component identity
-- implementation authority
-- policy attachment
-- validation requirements
-- rendering stability
-
----
-
-# Registry Responsibilities
-
-The registry is responsible for mapping:
+A registry entry binds:
 
 ```text
-Component identity
-  -> implementation
-  -> spec
-  -> validation contract
-  -> runtime policy
+component identity
+  -> version
+  -> implementation identity
+  -> ComponentSpec identity
+  -> generation or runtime contract
+  -> validators and policy
 ```
 
 The registry determines:
 
-- what may render
-- which variants are legal
-- which overlays are legal
-- which validators must run
-- which runtime capabilities are allowed
+- what implementation may render;
+- which specification and contract versions apply;
+- which variants, slots, props, and overlays are legal;
+- which validators must run;
+- which runtime capabilities are allowed;
+- how replacement or upgrade semantics work.
 
-The model cannot bypass the registry.
+The model cannot bypass or mutate the registry.
 
----
-
-# Runtime Flow
-
-At a high level:
+## Runtime Flow
 
 ```text
 ComponentSpec
   -> registry lookup
-  -> runtime AI invocation
-  -> structured output
+  -> contract and implementation resolution
+  -> AI invocation
+  -> untrusted structured output
   -> validation pipeline
-  -> overlay construction
+  -> bounded overlay
   -> render
 ```
 
-Validation sits between model output and rendering.
+Validation sits between probabilistic output and authoritative rendering.
 
----
+## Validation Pipeline
 
-# Validation Pipeline
-
-The branch currently leans toward layered validation.
-
-Example:
+Validation is layered so each concern remains explicit and testable.
 
 ```text
-Schema validation
+identity and version checks
+  -> schema validation
   -> policy validation
-  -> accessibility validation
-  -> token validation
+  -> accessibility and design validation
   -> overlay validation
+  -> render eligibility
 ```
 
-Each stage is intentionally explicit.
+Unknown identities, schema versions, operations, or capabilities should fail closed.
 
----
+## Validation Categories
 
-# Validation Categories
-
-## Schema Validation
+### Identity and version validation
 
 Confirms:
 
-- required fields exist
-- types are correct
-- enums are bounded
-- output structure is valid
+- the component is registered;
+- spec, contract, and implementation identities match;
+- versions are compatible;
+- replacement semantics are explicit;
+- the requested runtime mode is supported.
 
-Typical examples:
-
-- props JSON
-- variant identifiers
-- patch operations
-
----
-
-## Policy Validation
+### Schema validation
 
 Confirms:
 
-- forbidden operations are absent
-- runtime restrictions are respected
-- overlays stay within allowed paths
-- execution mode rules are followed
+- required fields exist;
+- types and formats are correct;
+- enums are bounded;
+- output structure matches the declared contract;
+- additional fields are rejected where appropriate.
 
----
+Typical outputs include props JSON, variant identifiers, slot values, and patch operations.
 
-## Accessibility Validation
-
-Confirms:
-
-- required labels exist
-- contrast requirements are preserved
-- slot behavior remains accessible
-- runtime personalization does not remove required semantics
-
----
-
-## Overlay Validation
+### Policy validation
 
 Confirms:
 
-- patch paths are legal
-- component identity is preserved
-- overlays remain bounded
-- mutations do not escape the runtime contract
+- forbidden operations are absent;
+- runtime and network restrictions are respected;
+- overlay paths stay within allowlists;
+- imports and capabilities remain within declared bounds;
+- execution-mode and review requirements are satisfied.
 
----
+Policy is deterministic and external to the model.
 
-# Overlay Philosophy
+### Accessibility and design validation
 
-The branch prefers:
+May confirm:
 
-```text
-bounded overlays
-```
+- required labels and semantics remain present;
+- runtime output cannot remove critical accessibility behavior;
+- only approved design tokens and variants are used;
+- generated source passes applicable accessibility checks;
+- contrast and interaction constraints remain satisfied.
 
-instead of:
+Some checks require source, rendered output, or platform-specific testing and cannot be proven from schema validation alone.
 
-```text
-arbitrary runtime mutation
-```
+### Overlay validation
 
-This keeps:
+Confirms:
 
-- replayability simpler
-- policy enforcement clearer
-- rendering authority explicit
-- validation deterministic
+- patch paths and operations are legal;
+- value types satisfy the target schema;
+- component and contract identity are preserved;
+- mutations cannot alter policy, imports, capabilities, or implementation identity;
+- overlays remain bounded and replayable.
 
----
+Explicit patch contracts are preferred over ambiguous recursive object merging.
 
-# Failure Handling
+### Generated-source validation
 
-Validation failures should not silently degrade into unrestricted behavior.
+Build-time executable output may require:
 
-Preferred failure modes:
+- import allowlists and sink denylists;
+- formatting, lint, and type checking;
+- unit, integration, and accessibility tests;
+- package and entrypoint validation;
+- human diff review;
+- provenance and approval evidence.
 
-- reject overlay
-- log validator failure
-- fall back to authoritative component
-- preserve stable rendering
+Passing source validation does not make generated behavior inherently correct; it makes the result reviewable through normal engineering controls.
 
-The runtime should fail closed where possible.
+## Failure Handling
 
----
+Validation failures must not silently degrade into unrestricted behavior.
 
-# Registry As A Security Boundary
+Preferred behavior is to:
 
-The registry is also a security boundary.
+- reject the invalid output or complete overlay;
+- return typed failure details;
+- preserve the authoritative base component;
+- avoid partial application unless the contract explicitly supports atomic subsets;
+- avoid implicit provider or network fallback;
+- record enough evidence for diagnosis without leaking sensitive prompts or context.
 
-It prevents:
+The runtime should fail closed where policy, identity, or capability boundaries are uncertain.
 
-- arbitrary component injection
-- runtime implementation replacement
-- unauthorized imports
-- hidden executable generation
+## Registry as a Security Boundary
 
-The model may influence rendering only through allowed contracts.
+The registry prevents:
 
----
+- arbitrary component injection;
+- runtime implementation replacement;
+- spec and implementation mismatch;
+- unauthorized imports and capabilities;
+- hidden executable generation;
+- silent contract drift.
 
-# Future Directions
+The model may influence rendering only through a contract attached to a known registry entry.
 
-Likely future registry capabilities include:
+## Provenance
 
-- signed manifests
-- spec hashing
-- overlay replay
-- validator provenance
-- approval workflows
-- policy version negotiation
-- runtime capability negotiation
-- deterministic render manifests
+Useful registry and validation evidence may include:
 
-The current goal is establishing strong architectural constraints before increasing runtime flexibility.
+- component, spec, contract, and implementation identifiers;
+- hashes and versions;
+- policy and validator versions;
+- model and provider identity;
+- raw and normalized output digests;
+- validation results;
+- review and approval metadata;
+- generated package SBOMs and release attestations.
+
+Provenance supports attribution and replay. It is not a substitute for policy or correctness checks.
+
+## Current Constraints and Future Work
+
+The repository contains working registry, schema, policy, and personalization primitives, but remains an active `0.1.x` implementation.
+
+Likely future work includes:
+
+- signed registry manifests;
+- stronger spec and contract hashing;
+- overlay replay and diff tooling;
+- validator provenance and compatibility negotiation;
+- explicit migration and replacement workflows;
+- runtime capability negotiation;
+- deterministic render manifests;
+- observability and audit interfaces.
+
+The immediate priority is preserving strong identity and validation boundaries before increasing runtime flexibility.

--- a/docs/runtime-personalization.md
+++ b/docs/runtime-personalization.md
@@ -2,7 +2,7 @@
 
 Runtime personalization allows AI to influence rendering through bounded structured output without becoming the authoritative source of executable UI.
 
-> The authoritative component remains stable. Model output may only produce a validated overlay within its declared contract.
+> The registered component remains authoritative. Model output may only contribute data that passes its registered personalization contract.
 
 ## Why Runtime Personalization Exists
 
@@ -17,57 +17,59 @@ Adaptive mobile interfaces may need:
 
 Unrestricted runtime source generation creates governance drift, policy bypass, accessibility regressions, reproducibility loss, and arbitrary execution surfaces.
 
-The personalization model preserves adaptive behavior while keeping product authority in deterministic application code.
+The personalization model preserves adaptive behavior while keeping product authority in application code and registered component implementations.
 
-## Lifecycle
+## Implemented Lifecycle
 
 ```text
-ComponentSpec
-  -> registry and runtime contract
+component name
+  -> registry lookup
+  -> registered personalization contract
   -> AI invocation
   -> untrusted structured output
-  -> schema validation
-  -> policy validation
-  -> bounded overlay
-  -> registry-approved render
+  -> JSON Schema and unsafe-key validation
+  -> JSON Patch path, value, and post-patch validation
+  -> bounded prop overlay
+  -> registered component render
 ```
 
-Rendering never occurs directly from raw model output.
+Rendering does not occur directly from raw model output.
+
+The current runtime path validates data against the registered contract. It does not automatically execute the package's full `PolicyEngine` for every personalization call.
 
 ## Overlay Model
 
 ```text
-authoritative component
-  + validated overlay
-  = rendered output
+authoritative base props
+  + contract-validated personalization data
+  = props passed to the registered implementation
 ```
 
-The overlay may affect only dimensions declared by the component contract. The canonical `ComponentSpec`, policy, registry identity, and implementation remain unchanged.
+The canonical `ComponentSpec`, registry entry, contract, and React implementation are not replaced by model output.
 
-## Allowed Runtime Outputs
+## Supported Runtime Data
 
-The current contract model supports bounded forms such as:
+The contract model can represent bounded forms such as:
 
 - props JSON;
 - known variant identifiers;
 - declared slot text;
-- allowlisted JSON patch operations.
+- declared design-token values;
+- JSON Patch operations targeting declared personalization paths.
 
-These forms are easier to validate, audit, replay, and reason about than executable source.
+The exact fields and values accepted at runtime depend on the JSON Schema registered for the component.
 
-## Forbidden Runtime Outputs
+## What the Runtime Does Not Execute
 
-Device-time personalization does not accept:
+Device-time personalization is not interpreted as:
 
-- arbitrary JSX or TSX;
+- JSX or TSX source;
 - executable JavaScript;
-- unrestricted imports;
-- arbitrary native access;
-- unconstrained style or markup injection;
-- implicit network access;
-- changes to specification, policy, identity, or registry fields.
+- module imports;
+- native code;
+- arbitrary markup or style programs.
 
-This is a security and governance boundary, not only an API convenience.
+This prevents model output from directly becoming executable component code. It does not automatically prevent a validated prop value from triggering behavior already implemented by the application. Capability-bearing props, URLs, commands, or identifiers must therefore be constrained by the contract and component implementation.
 
 ## Example Contract
 
@@ -95,58 +97,59 @@ ai:
     output: props-json
 ```
 
-A model might return:
+A corresponding personalization contract might accept data such as:
 
 ```json
 {
-  "summary": "Short local summary",
+  "props": {
+    "title": "Local summary"
+  },
   "variant": "compact"
 }
 ```
 
-The runtime then validates:
+## Current Runtime Validation
 
-- schema shape and types;
-- component and contract identity;
-- allowed variants and slots;
-- patch paths and operations;
-- design-token and capability restrictions;
-- applicable policy rules.
+`PersonalizationEngine.validate` currently performs:
 
-If validation fails, the overlay is rejected and the application falls back to the authoritative component or another explicit safe state.
+- JSON Schema validation through AJV;
+- unsafe object-key detection for `__proto__`, `constructor`, and `prototype`;
+- JSON Patch path checks against declared `props`, `slots`, and `designTokens`, plus `variant`;
+- unsafe patch-value detection;
+- schema validation after patches are applied.
 
-## Registry Interaction
+`PersonalizationEngine.apply` then merges accepted data into base props using a bounded recursive merge that ignores unsafe keys.
 
-The registry remains authoritative over:
+Registry registration separately verifies component name, version, optional hashes, and explicit replacement semantics.
 
-- component identity;
-- implementation identity;
-- spec and contract versions;
-- legal variants and overlays;
-- required validators and policy.
+## Policy Boundary
 
-Runtime model output cannot replace a registry entry or introduce a new implementation. It can only propose data within the approved contract.
+The package's `PolicyEngine` currently participates in build and CLI generation/customization flows. It is not automatically called by `PersonalizedComponent` when a component is registered programmatically.
+
+Runtime applications that require network, capability, accessibility, review, or application-specific semantic policy must:
+
+- encode enforceable limits in the personalization contract;
+- keep sensitive capability decisions in reviewed component code;
+- run additional application-level policy checks before applying personalization;
+- treat schema validity as necessary but not sufficient for semantic safety.
 
 ## Failure Handling
 
-Validation failures should be observable and recoverable.
+When personalization data is invalid, `PersonalizedComponent`:
 
-Preferred behavior includes:
+- rejects the personalization result;
+- restores base props;
+- exposes validation errors and diagnostics through an optional callback;
+- can emit an optional console warning;
+- renders only the already-registered implementation.
 
-- reject the complete invalid overlay;
-- preserve stable base rendering;
-- return typed failure information;
-- avoid silent coercion or capability expansion;
-- prevent implicit remote fallback;
-- record enough evidence to diagnose contract, model, or policy mismatches.
-
-Applications decide whether to retry, use a static fallback, or disable personalization.
+Applications decide whether to retry, show a static fallback, disable personalization, or invoke another provider. Remote fallback is not implicit in this component path.
 
 ## Context and Prompt Inputs
 
 User input, media, retrieved context, and persisted memory are all untrusted. The validity of final output must not depend on the prompt or retrieval source being safe.
 
-The Context Engine may provide attribution and bounded retrieval, but output still passes through the same validation boundary.
+The Context Engine can provide bounded retrieval and attribution, but personalization output still passes through the registered contract.
 
 ## Local Inference
 
@@ -163,30 +166,29 @@ Local execution does not eliminate:
 
 ## CopilotKit and AG-UI
 
-CopilotKit and AG-UI may initiate personalization as frontend actions or render-tool flows, but they do not bypass Amaryllis contracts.
-
-The adapter path remains:
+CopilotKit and AG-UI may initiate personalization as frontend actions or render-tool flows. The adapter path remains:
 
 ```text
 orchestration action
   -> inference function
   -> untrusted structured output
-  -> PersonalizationEngine validation
-  -> validated data for rendering
+  -> PersonalizationEngine contract validation
+  -> validated data for the registered component
 ```
 
-This keeps orchestration optional while preserving local inference, registry, policy, and validation authority.
+Orchestration does not replace the registry or runtime contract. Additional policy enforcement remains an application responsibility unless explicitly composed into the adapter.
 
 ## Current Constraints and Future Work
 
 The project is an active `0.1.x` implementation. Areas still evolving include:
 
+- automatic runtime `PolicyEngine` composition;
 - overlay replay and diff tooling;
 - runtime observability and audit interfaces;
 - rollback and conflict resolution;
 - policy-version negotiation;
 - approval workflows for promoted personalization;
-- stronger model and registry identity evidence;
+- cryptographic model and registry identity evidence;
 - privacy-safe telemetry.
 
-The goal is not maximum generation flexibility. The goal is a stable, explicit, and testable runtime contract.
+The goal is not maximum generation flexibility. The goal is a stable, explicit, and testable runtime contract with accurately documented guarantees.

--- a/docs/runtime-personalization.md
+++ b/docs/runtime-personalization.md
@@ -1,142 +1,93 @@
 # Runtime Personalization
 
-This document describes the runtime personalization model explored by the `feature/ai-components` branch.
+Runtime personalization allows AI to influence rendering through bounded structured output without becoming the authoritative source of executable UI.
 
-The central idea is:
+> The authoritative component remains stable. Model output may only produce a validated overlay within its declared contract.
 
-> Runtime AI may influence rendering through bounded overlays and structured outputs, but it does not become the authoritative source of executable UI.
+## Why Runtime Personalization Exists
 
-This distinction is fundamental to the branch architecture.
+Adaptive mobile interfaces may need:
 
----
+- local summaries;
+- context-aware variants;
+- multimodal reactions;
+- user-specific slot content;
+- bounded layout choices;
+- accessibility-aware presentation changes.
 
-# Why Runtime Personalization Exists
+Unrestricted runtime source generation creates governance drift, policy bypass, accessibility regressions, reproducibility loss, and arbitrary execution surfaces.
 
-Many adaptive interfaces need some degree of runtime intelligence.
+The personalization model preserves adaptive behavior while keeping product authority in deterministic application code.
 
-Examples:
-
-- local summaries
-- adaptive layouts
-- multimodal reactions
-- user-specific slot content
-- context-aware variants
-- accessibility-aware presentation changes
-
-However, unrestricted runtime code generation creates severe problems:
-
-- governance drift
-- runtime trust collapse
-- accessibility regressions
-- policy bypass
-- reproducibility loss
-- arbitrary execution surfaces
-
-The runtime personalization model exists to preserve adaptive behavior while maintaining explicit system boundaries.
-
----
-
-# Personalization Lifecycle
-
-At a high level:
+## Lifecycle
 
 ```text
 ComponentSpec
-  -> runtime contract
+  -> registry and runtime contract
   -> AI invocation
-  -> structured output
-  -> validation
-  -> overlay generation
-  -> render
+  -> untrusted structured output
+  -> schema validation
+  -> policy validation
+  -> bounded overlay
+  -> registry-approved render
 ```
 
-The important detail is that rendering happens through validated overlays, not directly from raw model output.
+Rendering never occurs directly from raw model output.
 
----
-
-# Runtime Overlay Model
-
-The branch currently leans toward overlays rather than arbitrary mutation.
-
-Conceptually:
+## Overlay Model
 
 ```text
-Authoritative component
+authoritative component
   + validated overlay
   = rendered output
 ```
 
-The authoritative component remains stable.
+The overlay may affect only dimensions declared by the component contract. The canonical `ComponentSpec`, policy, registry identity, and implementation remain unchanged.
 
-The overlay is bounded.
+## Allowed Runtime Outputs
 
----
+The current contract model supports bounded forms such as:
 
-# Allowed Runtime Outputs
+- props JSON;
+- known variant identifiers;
+- declared slot text;
+- allowlisted JSON patch operations.
 
-The RFC currently identifies several acceptable runtime output forms:
+These forms are easier to validate, audit, replay, and reason about than executable source.
 
-- props JSON
-- variant selection
-- slot text
-- bounded JSON patch operations
+## Forbidden Runtime Outputs
 
-These outputs are easier to:
+Device-time personalization does not accept:
 
-- validate
-- audit
-- constrain
-- replay
-- reason about
+- arbitrary JSX or TSX;
+- executable JavaScript;
+- unrestricted imports;
+- arbitrary native access;
+- unconstrained style or markup injection;
+- implicit network access;
+- changes to specification, policy, identity, or registry fields.
 
-than arbitrary executable source.
+This is a security and governance boundary, not only an API convenience.
 
----
-
-# Forbidden Runtime Outputs
-
-The runtime model intentionally rejects:
-
-- arbitrary JSX
-- arbitrary TSX
-- executable JavaScript
-- unrestricted imports
-- unrestricted native access
-- arbitrary style injection
-- unrestricted network access
-
-This is not merely a convenience restriction.
-
-It is a core architectural boundary.
-
----
-
-# Example Runtime Flow
-
-## 1. Authoritative Spec
+## Example Contract
 
 ```yaml
 apiVersion: amaryllis/v1alpha1
 kind: ComponentSpec
-
 metadata:
   name: SummaryCard
   version: 0.1.0
-
 target:
   framework: react
   runtime: rn
-
 props:
   type: object
   properties:
     title:
       type: string
-
 ui:
   slots:
     - summary
-
 ai:
   mode: personalize
   execution: device
@@ -144,13 +95,7 @@ ai:
     output: props-json
 ```
 
----
-
-## 2. Runtime Invocation
-
-The runtime asks the local model for structured output.
-
-Conceptually:
+A model might return:
 
 ```json
 {
@@ -159,120 +104,89 @@ Conceptually:
 }
 ```
 
----
+The runtime then validates:
 
-## 3. Validation
+- schema shape and types;
+- component and contract identity;
+- allowed variants and slots;
+- patch paths and operations;
+- design-token and capability restrictions;
+- applicable policy rules.
 
-The runtime validates:
+If validation fails, the overlay is rejected and the application falls back to the authoritative component or another explicit safe state.
 
-- schema shape
-- allowed variants
-- slot boundaries
-- policy restrictions
-- token restrictions
+## Registry Interaction
 
-If validation fails, rendering falls back to the authoritative component.
+The registry remains authoritative over:
 
----
+- component identity;
+- implementation identity;
+- spec and contract versions;
+- legal variants and overlays;
+- required validators and policy.
 
-## 4. Overlay Application
+Runtime model output cannot replace a registry entry or introduce a new implementation. It can only propose data within the approved contract.
 
-A bounded overlay is applied:
+## Failure Handling
+
+Validation failures should be observable and recoverable.
+
+Preferred behavior includes:
+
+- reject the complete invalid overlay;
+- preserve stable base rendering;
+- return typed failure information;
+- avoid silent coercion or capability expansion;
+- prevent implicit remote fallback;
+- record enough evidence to diagnose contract, model, or policy mismatches.
+
+Applications decide whether to retry, use a static fallback, or disable personalization.
+
+## Context and Prompt Inputs
+
+User input, media, retrieved context, and persisted memory are all untrusted. The validity of final output must not depend on the prompt or retrieval source being safe.
+
+The Context Engine may provide attribution and bounded retrieval, but output still passes through the same validation boundary.
+
+## Local Inference
+
+Runtime personalization fits naturally with on-device inference because it can provide low latency, offline behavior, and application-controlled network use.
+
+Local execution does not eliminate:
+
+- client compromise;
+- model or adapter tampering;
+- resource exhaustion;
+- sensitive logging or persistence;
+- privacy leakage through application fallback;
+- probabilistic or adversarial model behavior.
+
+## CopilotKit and AG-UI
+
+CopilotKit and AG-UI may initiate personalization as frontend actions or render-tool flows, but they do not bypass Amaryllis contracts.
+
+The adapter path remains:
 
 ```text
-base component
-  + validated runtime overlay
-  = final render
+orchestration action
+  -> inference function
+  -> untrusted structured output
+  -> PersonalizationEngine validation
+  -> validated data for rendering
 ```
 
-The canonical `ComponentSpec` remains unchanged.
+This keeps orchestration optional while preserving local inference, registry, policy, and validation authority.
 
----
+## Current Constraints and Future Work
 
-# Registry Interaction
+The project is an active `0.1.x` implementation. Areas still evolving include:
 
-The branch architecture assumes the registry remains authoritative.
+- overlay replay and diff tooling;
+- runtime observability and audit interfaces;
+- rollback and conflict resolution;
+- policy-version negotiation;
+- approval workflows for promoted personalization;
+- stronger model and registry identity evidence;
+- privacy-safe telemetry.
 
-Conceptually:
-
-```text
-registry
-  -> approved component implementation
-  -> spec identity
-  -> runtime contract identity
-```
-
-Runtime AI output cannot replace the registry.
-
-It can only provide bounded overlays within the approved contract.
-
----
-
-# Why Structured Output Matters
-
-Structured outputs are easier to govern because:
-
-- schemas are enforceable
-- validation is deterministic
-- replayability improves
-- review tooling becomes possible
-- runtime safety boundaries are clearer
-
-This is one reason the branch strongly prefers:
-
-```text
-props-json
-variant-selection
-json-patch
-```
-
-instead of unrestricted runtime source generation.
-
----
-
-# Relationship To Local AI
-
-The personalization model fits naturally with local inference.
-
-Benefits include:
-
-- lower latency
-- offline adaptation
-- local multimodal context
-- stronger privacy boundaries
-- reduced network dependency
-
-This is especially important for mobile UI flows where interaction timing and responsiveness matter.
-
----
-
-# Relationship To CopilotKit And AG-UI
-
-CopilotKit and AG-UI can initiate personalization as frontend actions or render-tool flows, but they should not bypass Amaryllis validation.
-
-The first adapter surface in `@micrantha/amaryllis-components` keeps that boundary explicit:
-
-- the action receives prompt and context
-- the inference function produces untrusted structured output
-- `PersonalizationEngine` validates output against the registered contract
-- only validated props are returned for rendering
-
-This lets CopilotKit/AG-UI orchestrate user-facing agent interactions while Amaryllis remains the authority for local inference, contracts, and overlays.
-
----
-
-# Future Directions
-
-Several runtime personalization areas remain open:
-
-- replay and observability
-- overlay diff tooling
-- personalization telemetry
-- rollback behavior
-- runtime policy hot reloads
-- conflict resolution
-- approval workflows for promoted overlays
-
-The current goal is not maximum generation flexibility.
-
-The current goal is establishing a strong runtime contract model first.
+The goal is not maximum generation flexibility. The goal is a stable, explicit, and testable runtime contract.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,349 +1,250 @@
 # Security Model
 
-This document describes the security model for the `feature/ai-components` branch.
+This document describes the architectural security model for Amaryllis. It covers the on-device inference runtime, Context Engine, AI-assisted component workflows, and runtime personalization.
 
-The branch combines:
+It is not a compliance claim or a substitute for application-specific threat modeling.
 
-- local multimodal inference
-- AI-assisted component workflows
-- runtime personalization
-- declarative component contracts
-
-Those capabilities create several important trust boundaries that should be explicit rather than implied.
-
-This document is intentionally architectural rather than compliance-oriented.
-
----
-
-# Core Security Principle
-
-The most important principle in this branch is:
+## Core Principle
 
 ```text
 AI output is not authoritative.
 ```
 
-Instead:
+Authority remains in deterministic, application-controlled systems:
 
-- specs are authoritative
-- registries are authoritative
-- policy is authoritative
-- validation is authoritative
+- application code and lifecycle rules;
+- component specifications;
+- registries and implementation identities;
+- schemas and policy;
+- validation and rendering logic;
+- build, review, and release controls.
 
 AI is treated as a bounded capability provider operating inside those constraints.
 
-This principle drives most of the branch’s design decisions.
+## Trust Boundaries
 
----
+### Model output boundary
 
-# Major Trust Boundaries
+Generated source, multimodal responses, props JSON, slot content, variants, and patch operations are untrusted until validated.
 
-## 1. Model Output Boundary
-
-Model output is treated as untrusted until validated.
-
-This applies to:
-
-- generated source
-- personalization overlays
-- props JSON
-- slot content
-- patch operations
-- multimodal responses
-
-The runtime should never assume:
+The runtime must never assume:
 
 ```text
 model output == safe executable UI
 ```
 
----
+### Runtime authority boundary
 
-## 2. Runtime Authority Boundary
+The renderer and application code are authoritative. The model cannot directly:
 
-The runtime renderer is authoritative.
+- control rendering;
+- bypass validation;
+- mutate authoritative specs;
+- replace registry entries;
+- escalate runtime permissions;
+- enable network access or imports.
 
-The model does not:
-
-- directly control rendering
-- bypass validation
-- mutate authoritative specs
-- replace registry entries
-- escalate runtime permissions
-
-Instead, model output flows through:
+The intended path is:
 
 ```text
 structured output
-  -> validation
-  -> overlay
-  -> render
+  -> schema validation
+  -> policy validation
+  -> bounded overlay
+  -> registry-approved render
 ```
 
----
+### Registry boundary
 
-## 3. Registry Boundary
+The registry binds component, specification, runtime contract, version, and implementation identities. Only registered implementations are renderable.
 
-The registry binds:
+Runtime model output cannot introduce a new executable implementation.
 
-- component identity
-- spec identity
-- runtime contract identity
-- implementation identity
+### Policy boundary
 
-The registry determines what implementations are renderable.
+Policy exists outside the model and is enforced deterministically. Policy may constrain:
 
-The model cannot directly introduce new executable implementations at runtime.
+- imports and dependencies;
+- runtime execution modes;
+- overlay paths;
+- slots, variants, and design tokens;
+- network behavior;
+- accessibility requirements;
+- review and approval requirements.
 
----
+### Context boundary
 
-## 4. Policy Boundary
+User input, retrieved content, persisted memory, and media may all contain hostile or misleading instructions. Local provenance does not imply safety.
 
-Policy exists outside the model.
+Context can influence inference but cannot bypass output validation.
 
-The model may attempt to produce outputs that violate policy.
+### Native and model-asset boundary
 
-Validation and enforcement layers are responsible for:
+Model files, media decoders, native bridges, URIs, and platform APIs execute within the mobile client trust boundary. Applications remain responsible for model integrity, licensing, storage, updates, and platform hardening.
 
-- import restrictions
-- runtime restrictions
-- overlay restrictions
-- accessibility requirements
-- generation constraints
-- review requirements
+## Major Threat Surfaces
 
-This prevents the model from becoming the effective policy authority.
+### Prompt injection
 
----
+Potential vectors include user prompts, retrieved context, multimodal inputs, slot content, and persisted personalization data.
 
-# Threat Surfaces
+Controls include:
 
-## Prompt Injection
+- structured output contracts;
+- bounded schemas;
+- independent policy enforcement;
+- strict overlay validation;
+- separation between prompt formatting and rendering authority.
 
-Potential vectors:
+### Arbitrary runtime source generation
 
-- user prompts
-- multimodal inputs
-- retrieved context
-- slot content
-- persisted personalization data
+Unrestricted device-time JSX, TSX, JavaScript, imports, or markup creates arbitrary execution, import injection, review bypass, and accessibility risks.
 
-Potential impacts:
+Runtime personalization therefore prefers:
 
-- unauthorized overlays
-- policy bypass attempts
-- generation manipulation
-- data exfiltration attempts
+- props JSON;
+- known variant identifiers;
+- approved slot text;
+- constrained JSON patch operations.
 
-Mitigations:
+Executable source generation belongs in build or CI workflows with stronger review controls.
 
-- structured output
-- bounded schemas
-- overlay validation
-- policy enforcement
-- explicit runtime contracts
+### Structured-output escalation
 
----
+Structured data can still trigger unsafe behavior through disallowed fields, values, or patch paths.
 
-## Arbitrary Source Generation
+Controls include:
 
-Unrestricted runtime JSX or TSX generation creates:
+- path allowlists;
+- strict enums and token sets;
+- type validation;
+- rejection of changes to policy, identity, implementation, or capability fields;
+- explicit overlay semantics instead of ambiguous deep merges.
 
-- arbitrary execution risk
-- import injection risk
-- policy bypass risk
-- accessibility regressions
-- unreviewed runtime behavior
+### Multimodal input risks
 
-The branch intentionally restricts device-time generation.
+Images and other media introduce malformed-input, resource-exhaustion, hidden-prompt, and data-extraction risks.
 
-Runtime personalization should prefer:
+Applications should constrain:
 
-- props JSON
-- variants
-- slot text
-- bounded patch overlays
+- file size and image count;
+- URI schemes and file locations;
+- preprocessing and decoding;
+- token and session budgets;
+- memory use and cancellation;
+- error and fallback behavior.
 
-rather than executable source.
+### Registry integrity failure
 
----
+A spec or implementation identity mismatch can lead to unauthorized substitution or stale behavior.
 
-## Multimodal Input Risks
+Controls include versioned identities, explicit replacement semantics, mismatch rejection, and reviewable registration.
 
-Image and multimodal systems create additional attack surfaces:
+### Privacy boundary erosion
 
-- malformed media
-- oversized payloads
-- adversarial image content
-- memory pressure attacks
-- hidden prompt content
-- data extraction attempts
+Local inference can still leak data through logs, telemetry, implicit network fallback, generated artifacts, or application-controlled storage.
 
-The runtime therefore constrains:
+Network behavior, logging, persistence, and publication must remain explicit application decisions.
 
-- file handling
-- image sizing
-- URI handling
-- session usage
-- runtime memory behavior
+## Build-Time and Device-Time Security
 
----
+### Build-time or CI generation
 
-## Overlay Escalation
+Build-time generation may produce executable source or larger transformations, but should require:
 
-A personalization overlay should never become an unrestricted mutation surface.
+- schema and policy validation;
+- generated-source analysis;
+- tests and static checks;
+- human review;
+- provenance and artifact tracking;
+- deterministic package validation.
 
-Risks include:
+### Device-time personalization
 
-- modifying policy
-- changing imports
-- replacing layouts
-- introducing executable content
-- bypassing registry controls
-
-The RFC therefore constrains overlay paths and output formats.
-
----
-
-# Build-Time vs Device-Time Security
-
-The branch intentionally distinguishes:
-
-## Build-time / CI generation
-
-Potentially allows:
-
-- TSX generation
-- implementation scaffolding
-- larger transformations
-
-But requires:
-
-- validation
-- review
-- provenance
-- policy enforcement
-- artifact tracking
-
----
-
-## Device-time personalization
-
-Much more constrained.
+Device-time output is more constrained because it executes in the user-facing runtime and may be influenced by untrusted input.
 
 The device-time model assumes:
 
-- runtime AI is probabilistic
-- runtime output is untrusted
-- rendering boundaries must remain stable
-- policy enforcement must remain external
+- model behavior is probabilistic;
+- output is untrusted;
+- rendering boundaries must remain stable;
+- policy enforcement is external;
+- failure must be observable and recoverable.
 
-This is why the branch heavily prefers structured outputs over executable source.
+## Local AI Security Characteristics
 
----
+Local inference can provide:
 
-# Local AI Security Characteristics
+- reduced hosted-data exposure;
+- offline operation;
+- lower latency;
+- application-controlled network behavior;
+- local multimodal processing.
 
-Local inference changes the threat model.
+It also introduces or preserves:
 
-Benefits:
+- client compromise and reverse engineering;
+- malicious or replaced model assets;
+- model licensing and distribution risk;
+- device resource exhaustion;
+- sensitive local storage;
+- platform-specific native attack surfaces.
 
-- reduced network exposure
-- stronger privacy boundaries
-- offline operation
-- local multimodal processing
-- reduced hosted-data dependency
+Local execution changes where trust and exposure exist. It does not make the system automatically secure.
 
-Tradeoffs:
-
-- device resource pressure
-- model distribution concerns
-- local model tampering risk
-- client-side trust assumptions
-- reverse-engineering exposure
-
-Local AI is not automatically “secure.”
-
-It simply shifts where trust and exposure exist.
-
----
-
-# Validation Responsibilities
-
-Validation is one of the most important security mechanisms in the branch.
-
-Validation responsibilities include:
-
-- schema validation
-- patch validation
-- variant validation
-- slot validation
-- import restrictions
-- runtime restrictions
-- policy enforcement
-- accessibility checks
-- design-token enforcement
+## Validation Responsibilities
 
 Validation should remain deterministic even when generation is probabilistic.
 
----
+Responsibilities include:
 
-# Provenance And Replay
+- schema validation;
+- component and contract identity checks;
+- patch-path and value validation;
+- variant and slot validation;
+- import and capability restrictions;
+- runtime-mode restrictions;
+- accessibility and design-token enforcement;
+- generated-source checks;
+- failure reporting and safe fallback.
 
-The branch also moves toward stronger provenance and replay semantics.
+## Provenance and Evidence
 
-Potential provenance artifacts include:
+Useful evidence may include:
 
-- spec hashes
-- contract hashes
-- model identity
-- validator results
-- generation metadata
-- review metadata
+- spec and contract hashes;
+- model identity and version;
+- validator and policy versions;
+- generation inputs and outputs;
+- build and test results;
+- review and approval metadata;
+- package SBOMs and release attestations.
 
-This helps reduce:
+Provenance improves attribution and replayability, but does not prove that an output is safe or correct.
 
-- silent drift
-- untracked generation
-- review ambiguity
-- runtime inconsistency
+## Explicit Non-Goals
 
----
+The current architecture does not aim to provide:
 
-# Explicit Non-Goals
+- unrestricted runtime code generation;
+- autonomous mutation of authoritative UI contracts;
+- implicit model trust;
+- hidden policy enforcement;
+- unrestricted imports or network behavior;
+- security merely because inference is local;
+- a complete mobile sandbox for hostile model assets.
 
-The current direction is intentionally not:
+## Open Security Work
 
-- unrestricted runtime code generation
-- autonomous runtime UI mutation
-- implicit model trust
-- hidden policy enforcement
-- unrestricted runtime imports
-- opaque personalization behavior
+High-value future work includes:
 
-The branch instead prioritizes:
+- signed model and registry manifests;
+- stronger model-delivery integrity;
+- runtime audit and observability interfaces;
+- replayable personalization evidence;
+- policy-version negotiation;
+- capability isolation;
+- multimodal adversarial test corpora;
+- device-specific resource and abuse testing.
 
-- bounded adaptation
-- explicit contracts
-- validation
-- local-first execution
-- runtime governance
-- declarative rendering boundaries
-
----
-
-# Future Security Areas
-
-Several areas remain open for future work:
-
-- overlay replayability
-- runtime observability
-- signed registry manifests
-- attestation of generated artifacts
-- policy version negotiation
-- secure model distribution
-- capability isolation
-- multimodal red-team corpora
-- runtime audit logging
-
-The current focus is establishing stable boundaries before increasing generation flexibility.
+The current priority is to keep trust boundaries stable and explicit before expanding generation flexibility.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -15,17 +15,36 @@ Authority remains in deterministic, application-controlled systems:
 - application code and lifecycle rules;
 - component specifications;
 - registries and implementation identities;
-- schemas and policy;
+- runtime personalization contracts;
 - validation and rendering logic;
 - build, review, and release controls.
 
-AI is treated as a bounded capability provider operating inside those constraints.
+AI is treated as a capability provider operating inside those constraints.
+
+## Implemented Runtime Security Boundary
+
+The current `PersonalizedComponent` path provides these automatic controls:
+
+```text
+registered component lookup
+  -> registered JSON contract
+  -> JSON Schema validation
+  -> unsafe object-key validation
+  -> JSON Patch path and value validation
+  -> post-patch schema validation
+  -> bounded prop merge
+  -> registered implementation render
+```
+
+This path prevents model output from directly becoming JSX, TSX, JavaScript, imports, or a newly registered implementation.
+
+It does **not** automatically invoke the complete package `PolicyEngine` for every programmatic runtime personalization call.
 
 ## Trust Boundaries
 
 ### Model output boundary
 
-Generated source, multimodal responses, props JSON, slot content, variants, and patch operations are untrusted until validated.
+Generated source, multimodal responses, props JSON, slot content, variants, design-token values, and patch operations are untrusted until processed by the controls applicable to their execution path.
 
 The runtime must never assume:
 
@@ -37,50 +56,49 @@ model output == safe executable UI
 
 The renderer and application code are authoritative. The model cannot directly:
 
-- control rendering;
-- bypass validation;
-- mutate authoritative specs;
-- replace registry entries;
-- escalate runtime permissions;
-- enable network access or imports.
+- register or replace a React implementation;
+- mutate the canonical specification or registry entry;
+- introduce executable source or imports through personalization data;
+- bypass the registered JSON contract;
+- decide what implementation is renderable.
 
-The intended path is:
-
-```text
-structured output
-  -> schema validation
-  -> policy validation
-  -> bounded overlay
-  -> registry-approved render
-```
+Validated data can still trigger behavior already implemented by the application. Contracts and component code must therefore constrain capability-bearing values such as URLs, commands, identifiers, or native-operation selectors.
 
 ### Registry boundary
 
-The registry binds component, specification, runtime contract, version, and implementation identities. Only registered implementations are renderable.
+The registry binds component name, version, specification, personalization contract, deterministic hashes, and implementation identity.
 
-Runtime model output cannot introduce a new executable implementation.
+Registration rejects inconsistent names, versions, or supplied hashes, and replacement is explicit.
+
+The current FNV-derived hashes are useful for deterministic identity and drift detection. They are not cryptographic signatures, tamper-proof manifests, or proof that code is trustworthy.
 
 ### Policy boundary
 
-Policy exists outside the model and is enforced deterministically. Policy may constrain:
+Policy exists outside the model and must be enforced deterministically.
 
-- imports and dependencies;
-- runtime execution modes;
-- overlay paths;
-- slots, variants, and design tokens;
-- network behavior;
-- accessibility requirements;
-- review and approval requirements.
+The package currently applies `PolicyEngine` validation in build and CLI generation/customization flows. The programmatic runtime personalization path does not automatically apply every policy rule.
+
+Runtime applications requiring broader policy must explicitly compose checks for concerns such as:
+
+- network and external capabilities;
+- semantic business rules;
+- accessibility behavior dependent on rendered output;
+- design-system rules not encoded in the JSON contract;
+- review, approval, and data-handling requirements.
+
+Schema validity is necessary but not sufficient for semantic safety.
 
 ### Context boundary
 
-User input, retrieved content, persisted memory, and media may all contain hostile or misleading instructions. Local provenance does not imply safety.
+User input, retrieved content, persisted memory, and media may contain hostile or misleading instructions. Local provenance does not imply safety.
 
-Context can influence inference but cannot bypass output validation.
+Context can influence inference but cannot change the registry or bypass the registered personalization contract.
 
 ### Native and model-asset boundary
 
-Model files, media decoders, native bridges, URIs, and platform APIs execute within the mobile client trust boundary. Applications remain responsible for model integrity, licensing, storage, updates, and platform hardening.
+Model files, media decoders, native bridges, URIs, and platform APIs execute within the mobile client trust boundary.
+
+Applications remain responsible for model integrity, licensing, storage, updates, platform hardening, resource budgets, and fallback behavior.
 
 ## Major Threat Surfaces
 
@@ -90,36 +108,38 @@ Potential vectors include user prompts, retrieved context, multimodal inputs, sl
 
 Controls include:
 
-- structured output contracts;
+- structured-output contracts;
 - bounded schemas;
-- independent policy enforcement;
-- strict overlay validation;
-- separation between prompt formatting and rendering authority.
+- separation between prompt formatting and rendering authority;
+- patch-path validation;
+- application-composed semantic and capability policy.
+
+Contract validation reduces the output surface but does not make hostile prompt content harmless.
 
 ### Arbitrary runtime source generation
 
 Unrestricted device-time JSX, TSX, JavaScript, imports, or markup creates arbitrary execution, import injection, review bypass, and accessibility risks.
 
-Runtime personalization therefore prefers:
-
-- props JSON;
-- known variant identifiers;
-- approved slot text;
-- constrained JSON patch operations.
-
-Executable source generation belongs in build or CI workflows with stronger review controls.
+The current personalization path accepts data, not executable source. Executable generation belongs in build or CI workflows with stronger review controls.
 
 ### Structured-output escalation
 
-Structured data can still trigger unsafe behavior through disallowed fields, values, or patch paths.
+Structured data can still trigger unsafe behavior through allowed fields or values.
 
-Controls include:
+Examples include:
 
-- path allowlists;
-- strict enums and token sets;
-- type validation;
-- rejection of changes to policy, identity, implementation, or capability fields;
-- explicit overlay semantics instead of ambiguous deep merges.
+- a validated URL prop that causes a component to contact an unapproved endpoint;
+- an identifier that selects a sensitive application capability;
+- semantically invalid text that still satisfies its JSON type;
+- a permitted design token that produces inaccessible rendered output.
+
+Controls must combine schema restrictions with reviewed component behavior and application policy.
+
+### Prototype and patch abuse
+
+The runtime rejects or ignores `__proto__`, `constructor`, and `prototype` keys. JSON Patch paths are constrained to declared personalization sections, and patched output is schema-validated again.
+
+These controls reduce prototype-pollution and overlay-escape risk. They do not replace application testing of complex contracts.
 
 ### Multimodal input risks
 
@@ -136,9 +156,11 @@ Applications should constrain:
 
 ### Registry integrity failure
 
-A spec or implementation identity mismatch can lead to unauthorized substitution or stale behavior.
+A specification, contract, or implementation identity mismatch can lead to unauthorized substitution or stale behavior.
 
-Controls include versioned identities, explicit replacement semantics, mismatch rejection, and reviewable registration.
+Current controls include deterministic identity construction, registration mismatch rejection, explicit replacement, snapshots, and validated hydration.
+
+Future cryptographic signing is still required for stronger supply-chain integrity claims.
 
 ### Privacy boundary erosion
 
@@ -150,26 +172,31 @@ Network behavior, logging, persistence, and publication must remain explicit app
 
 ### Build-time or CI generation
 
-Build-time generation may produce executable source or larger transformations, but should require:
+Build-time generation may produce executable source or larger transformations. Depending on the workflow, controls may include:
 
-- schema and policy validation;
+- specification schema and package policy validation;
 - generated-source analysis;
 - tests and static checks;
 - human review;
-- provenance and artifact tracking;
-- deterministic package validation.
+- package and entrypoint validation;
+- provenance, SBOM, and artifact tracking.
+
+These controls provide a review window unavailable to device-time personalization.
 
 ### Device-time personalization
 
 Device-time output is more constrained because it executes in the user-facing runtime and may be influenced by untrusted input.
 
-The device-time model assumes:
+The current automatic checks are:
 
-- model behavior is probabilistic;
-- output is untrusted;
-- rendering boundaries must remain stable;
-- policy enforcement is external;
-- failure must be observable and recoverable.
+- registered component and contract lookup;
+- JSON Schema validation;
+- unsafe-key validation;
+- JSON Patch path and value validation;
+- post-patch schema validation;
+- fallback to base props on failure.
+
+Additional semantic, capability, accessibility, privacy, and network policy remains application-controlled unless explicitly composed.
 
 ## Local AI Security Characteristics
 
@@ -194,19 +221,31 @@ Local execution changes where trust and exposure exist. It does not make the sys
 
 ## Validation Responsibilities
 
-Validation should remain deterministic even when generation is probabilistic.
+### Implemented runtime validation
 
-Responsibilities include:
+- JSON Schema contract validation;
+- unsafe object-key detection;
+- patch-path and patch-value validation;
+- post-patch schema validation;
+- safe merge into base props;
+- observable validation errors and diagnostics.
 
-- schema validation;
-- component and contract identity checks;
-- patch-path and value validation;
-- variant and slot validation;
-- import and capability restrictions;
-- runtime-mode restrictions;
-- accessibility and design-token enforcement;
+### Build or CLI validation
+
+- specification schema validation;
+- package policy validation for generation and customization;
 - generated-source checks;
-- failure reporting and safe fallback.
+- package and entrypoint verification.
+
+### Application responsibilities
+
+- semantic business rules;
+- sensitive capability authorization;
+- network and data-handling policy;
+- rendered accessibility and interaction checks;
+- privacy-safe telemetry;
+- model and asset integrity;
+- operational fallback and monitoring.
 
 ## Provenance and Evidence
 
@@ -220,16 +259,16 @@ Useful evidence may include:
 - review and approval metadata;
 - package SBOMs and release attestations.
 
-Provenance improves attribution and replayability, but does not prove that an output is safe or correct.
+Provenance improves attribution and replayability, but does not prove that an output is safe or correct. Non-cryptographic registry hashes must not be presented as attestations.
 
-## Explicit Non-Goals
+## Explicit Non-goals
 
 The current architecture does not aim to provide:
 
 - unrestricted runtime code generation;
 - autonomous mutation of authoritative UI contracts;
 - implicit model trust;
-- hidden policy enforcement;
+- automatic full-policy enforcement for every runtime call;
 - unrestricted imports or network behavior;
 - security merely because inference is local;
 - a complete mobile sandbox for hostile model assets.
@@ -238,8 +277,9 @@ The current architecture does not aim to provide:
 
 High-value future work includes:
 
+- compose `PolicyEngine` into optional runtime enforcement;
 - signed model and registry manifests;
-- stronger model-delivery integrity;
+- cryptographic model-delivery integrity;
 - runtime audit and observability interfaces;
 - replayable personalization evidence;
 - policy-version negotiation;
@@ -247,4 +287,4 @@ High-value future work includes:
 - multimodal adversarial test corpora;
 - device-specific resource and abuse testing.
 
-The current priority is to keep trust boundaries stable and explicit before expanding generation flexibility.
+The current priority is to keep implemented guarantees, application responsibilities, and future controls distinct before expanding generation flexibility.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,362 +1,282 @@
 # Threat Model
 
-This document describes the primary threat surfaces for the `feature/ai-components` branch.
+This document describes the primary threat surfaces for the current Amaryllis architecture:
 
-It covers both:
+- the React Native runtime for local multimodal inference;
+- the application-owned Context Engine;
+- `@micrantha/amaryllis-components` generation and personalization workflows.
 
-- the base Amaryllis runtime for local multimodal inference
-- the `@micrantha/amaryllis-components` companion workspace
-
-The goal is not to be exhaustive. The goal is to establish a clear security model for the current architecture and to make the intended controls explicit.
-
----
+The model is intentionally architectural rather than exhaustive. Applications integrating Amaryllis must extend it for their data, models, devices, deployment paths, and regulatory requirements.
 
 ## Security Posture
 
-The branch is intentionally designed around a conservative rule:
-
 > Model output is not authoritative.
 
-That rule leads to three important consequences:
+This leads to three baseline rules:
 
-1. runtime AI output is treated as untrusted until validated
-2. component specs and registries remain authoritative
-3. device-time AI is bounded to structured outputs rather than unrestricted executable UI generation
-
-This is the core security position of the branch.
-
----
+1. model and retrieved output are untrusted until validated;
+2. application code, component specs, registries, and policy remain authoritative;
+3. device-time AI is bounded to structured output rather than unrestricted executable UI generation.
 
 ## Assets
 
 Important assets include:
 
-- model files on device
-- prompts and context inputs
-- user-provided media
-- component specs
-- runtime personalization outputs
-- generated source artifacts
-- policy definitions
-- registry entries and implementation identities
-- application secrets and network credentials
-
-Not all of these assets have the same sensitivity, but they all participate in the trust model.
-
----
+- model and adapter files;
+- prompts, retrieved context, and persisted memory;
+- user-provided media;
+- component specifications and generation contracts;
+- runtime personalization outputs;
+- generated source and package artifacts;
+- policy definitions;
+- registry entries and implementation identities;
+- application secrets, network credentials, and local storage;
+- build, review, provenance, and release evidence.
 
 ## Trust Boundaries
 
-### Boundary 1: App input -> inference runtime
+### B1: Application input to inference runtime
 
-User text, media, and app context cross into the inference subsystem.
+Text, media, and application context cross into native inference.
 
-Key risks:
+Risks include prompt injection, malformed media, URI abuse, resource exhaustion, and unexpected multimodal behavior.
 
-- prompt injection
-- oversized or malformed media
-- resource exhaustion
-- unexpected multimodal behavior
+### B2: Context store to prompt construction
 
-### Boundary 2: model output -> personalization/runtime layer
+Retrieved or persisted content crosses into model input.
 
-Model output crosses into application-controlled rendering logic.
+Risks include context poisoning, stale data, indirect prompt injection, privacy leakage, and mistaken trust in provenance.
 
-Key risks:
+### B3: Model output to application logic
 
-- invalid structured output
-- policy violations
-- overlay drift
-- hidden capability escalation
+Probabilistic output crosses into application-controlled rendering and behavior.
 
-### Boundary 3: spec/generator -> generated artifact
+Risks include invalid structured output, policy violations, hidden capability escalation, overlay drift, and unsafe fallback.
 
-Build-time generation crosses into source artifacts or derived runtime contracts.
+### B4: Generator to executable artifact
 
-Key risks:
+Build-time generation crosses into source, packages, or derived contracts.
 
-- unsafe imports
-- hidden sinks
-- design-system drift
-- accessibility regressions
-- provenance loss
+Risks include unsafe imports, dynamic execution, hidden network behavior, accessibility regressions, design drift, and provenance loss.
 
-### Boundary 4: registry -> rendered component
+### B5: Registry to rendered implementation
 
-The runtime decides what implementation is actually renderable.
+Registry identity is resolved into executable application code.
 
-Key risks:
+Risks include spec or implementation mismatch, stale identities, unauthorized replacement, and review bypass.
 
-- spec/implementation mismatch
-- stale or replaced identities
-- unauthorized overrides
-- unreviewed component substitutions
+### B6: Model distribution to native runtime
 
----
+Application-selected model files cross into the mobile trust boundary.
+
+Risks include model substitution, tampering, incompatible artifacts, licensing failures, resource abuse, and parser or runtime vulnerabilities.
 
 ## Threat Categories
 
-## T1: Prompt Injection
+### T1: Prompt injection
 
-### Description
+**Description:** User-controlled, retrieved, or multimodal content attempts to override intended inference or personalization boundaries.
 
-User-controlled or retrieved content attempts to alter model behavior outside intended component or inference boundaries.
+**Examples:**
 
-### Examples
+- retrieved memory instructs the model to emit fields outside the schema;
+- image text attempts to override component policy;
+- slot content asks the model to change capability or network settings.
 
-- a slot content source attempts to override the personalization contract
-- retrieved memory tells the model to emit fields outside the schema
-- multimodal input contains text intended to steer behavior away from policy
+**Controls:**
 
-### Controls
+- keep policy and rendering authority outside the model;
+- validate output independently of prompt source;
+- use bounded structured contracts;
+- treat retrieved and multimodal content as untrusted;
+- separate prompt construction from execution authority.
 
-- keep specs authoritative
-- validate runtime output against schemas
-- treat retrieved context as untrusted input
-- separate prompt formatting from rendering authority
-- keep policy enforcement outside the model
+### T2: Arbitrary runtime code generation
 
----
+**Description:** A device-time model produces JSX, TSX, JavaScript, imports, or markup that becomes authoritative UI logic.
 
-## T2: Arbitrary Runtime Code Generation
+**Impact:** Capability escalation, hidden behavior, unreviewed network access, rendering injection, and loss of reproducibility.
 
-### Description
+**Controls:**
 
-A device-time model attempts to produce executable JSX, TSX, JavaScript, imports, or markup that would become authoritative UI logic.
+- prohibit runtime source generation by default;
+- accept structured props, variants, slots, or patches instead;
+- validate before rendering;
+- keep executable implementations registry-controlled.
 
-### Impact
+### T3: Policy bypass through structured output
 
-- capability escalation
-- hidden behavior injection
-- unreviewed network access
-- XSS-like rendering hazards
-- loss of governance and reproducibility
+**Description:** A model uses allowed data structures to trigger disallowed behavior.
 
-### Controls
+**Examples:**
 
-- do not allow runtime source generation as the default path
-- restrict device-time outputs to structured data
-- require validation before rendering
-- keep registry-managed implementations authoritative
+- patching unauthorized paths;
+- selecting values that indirectly enable unsafe behavior;
+- changing identity, policy, or capability fields;
+- exploiting ambiguous deep-merge behavior.
 
----
+**Controls:**
 
-## T3: Policy Bypass Through Structured Output
+- allowlist patch paths and operations;
+- use strict enums and typed values;
+- define overlay semantics explicitly;
+- reject changes to authoritative fields;
+- fail closed on unknown values or schema versions.
 
-### Description
+### T4: Registry integrity failure
 
-Even when output is structured, the model may attempt to smuggle behavior through allowed fields.
+**Description:** The rendered implementation does not match the expected component, specification, version, or runtime contract.
 
-### Examples
+**Impact:** Unauthorized substitution, stale behavior, review bypass, and inconsistent rendering.
 
-- patching disallowed paths
-- setting fields that indirectly trigger unsafe behavior
-- attempting token or slot values outside approved sets
+**Controls:**
 
-### Controls
+- bind registry entries to versioned identities;
+- reject mismatches;
+- require explicit replacement semantics;
+- preserve reviewable registration and provenance;
+- consider signed manifests for higher-assurance deployments.
 
-- allowlist patch paths
-- constrain slot names and variant IDs
-- validate enums and token selections strictly
-- reject overlays that modify authoritative policy or target fields
+### T5: Generated source abuse
 
----
+**Description:** Build-time or CI-time generation produces unsafe executable artifacts.
 
-## T4: Registry Integrity Failure
+**Examples:** Unsafe imports, dynamic execution, raw markup sinks, undeclared capabilities, hidden persistence, or network behavior.
 
-### Description
+**Controls:**
 
-The runtime renders a component whose implementation identity does not match the expected spec or contract.
+- validate source after generation;
+- enforce import allowlists and sink denylists;
+- run lint, type checks, tests, and security analysis;
+- require human review for executable output;
+- record generation and approval evidence.
 
-### Impact
+### T6: Media and native resource exhaustion
 
-- unauthorized substitutions
-- stale implementations
-- review bypass
-- inconsistent runtime behavior
+**Description:** Large, malformed, or adversarial media causes memory pressure, CPU exhaustion, crashes, or inference instability.
 
-### Controls
+**Controls:**
 
-- bind registry entries to spec and contract identities
-- reject mismatched registration attempts
-- require explicit replacement semantics
-- keep authoritative identities versioned
+- bound file size, dimensions, count, tokens, and session duration;
+- restrict URI schemes and file locations;
+- preprocess and validate media;
+- support cancellation and lifecycle cleanup;
+- recover safely without implicit network fallback.
 
----
+### T7: Context poisoning
 
-## T5: Generated Source Abuse
+**Description:** Stored or retrieved context influences output in misleading or hostile ways.
 
-### Description
+**Impact:** Policy drift, invalid personalization, degraded relevance, and indirect prompt injection.
 
-Build-time or CI-time generation produces unsafe source artifacts.
+**Controls:**
 
-### Examples
+- treat context as untrusted;
+- bound retrieval and formatting;
+- validate final output independently;
+- preserve attribution without equating provenance with safety;
+- support deletion, expiration, and source-specific policy.
 
-- unsafe imports
-- dynamic code execution
-- raw markup sinks
-- undeclared capabilities
-- hidden persistence or network behavior
+### T8: Privacy boundary erosion
 
-### Controls
+**Description:** A local-first workflow leaks prompts, media, context, or personalization data through logs, telemetry, fallback, storage, or generated artifacts.
 
-- source validation after generation
-- import allowlists and denylists
-- ban dynamic execution sinks
-- require human review for executable artifacts
-- record provenance and review metadata
+**Controls:**
 
----
+- make network behavior explicit and application-controlled;
+- minimize sensitive logging;
+- document persistence and retention;
+- separate local personalization from publishable artifacts;
+- audit error reporting and fallback paths.
 
-## T6: Media Input Resource Exhaustion
+### T9: Accessibility and design drift
 
-### Description
+**Description:** Generated or personalized output is structurally valid but violates accessibility or design-system rules.
 
-Large or malformed image inputs cause memory pressure, CPU exhaustion, or runtime instability.
+**Controls:**
 
-### Impact
+- encode machine-checkable accessibility and token rules;
+- constrain variants, slots, and design tokens;
+- preserve registry-controlled implementations;
+- include accessibility testing in generated-source review.
 
-- crashes
-- degraded UX
-- denial of service
-- unpredictable inference failures
+### T10: Model or adapter tampering
 
-### Controls
+**Description:** A model asset is replaced, corrupted, or supplied from an untrusted distribution path.
 
-- file size limits
-- URI restrictions
-- resizing and preprocessing
-- bounded image counts
-- graceful failure handling
+**Impact:** Changed behavior, targeted output manipulation, runtime failure, licensing violations, or native exploitation.
 
----
+**Controls:**
 
-## T7: Context Poisoning
+- verify hashes or signatures before activation;
+- bind model identity to configuration and evidence;
+- use application-controlled storage and update paths;
+- reject incompatible or unexpected artifacts;
+- document rollback and revocation behavior.
 
-### Description
+### T11: Unsafe fallback or capability expansion
 
-The Context Engine or retrieval layer returns misleading or hostile data that influences model output in unsafe ways.
+**Description:** Failure of local inference causes an application to silently switch to a remote service or broader capability set.
 
-### Impact
+**Impact:** Privacy violations, policy bypass, inconsistent behavior, and unexpected cost or availability dependencies.
 
-- policy drift
-- invalid personalization
-- degraded relevance
-- indirect prompt injection
+**Controls:**
 
-### Controls
+- require explicit fallback policy;
+- preserve equivalent validation boundaries across providers;
+- surface provider and execution-mode changes;
+- fail closed where privacy or policy requires it.
 
-- treat retrieved context as untrusted
-- bound retrieval and formatting
-- validate runtime outputs independently of context source
-- avoid equating provenance with safety
+### T12: Evidence and provenance confusion
 
----
+**Description:** Generated artifacts, model identities, validator results, or approvals cannot be reliably attributed.
 
-## T8: Privacy Boundary Erosion
+**Impact:** Silent drift, ambiguous review, replay failure, and unverifiable releases.
 
-### Description
+**Controls:**
 
-A local-first system unintentionally leaks prompts, media, or personalization data through logs, network fallbacks, or generated artifacts.
-
-### Impact
-
-- user privacy loss
-- policy violations
-- enterprise data handling failures
-
-### Controls
-
-- keep network behavior application-controlled
-- document local-first assumptions clearly
-- avoid implicit remote execution
-- minimize sensitive logging
-- separate local personalization from publishable artifacts
-
----
-
-## T9: Accessibility and Design Drift
-
-### Description
-
-AI-assisted generation or personalization produces outputs that are technically valid but violate accessibility or design constraints.
-
-### Impact
-
-- inconsistent UX
-- accessibility regressions
-- degraded maintainability
-- weakened product governance
-
-### Controls
-
-- encode accessibility and design rules in policy
-- validate token usage and runtime choices
-- preserve registry-controlled base implementations
-- keep overlays bounded to approved dimensions
-
----
-
-## T10: Deep Merge / Overlay Corruption
-
-### Description
-
-Runtime personalization modifies nested structures in unsafe or unexpected ways.
-
-### Impact
-
-- broken components
-- state corruption
-- policy bypass through structural ambiguity
-
-### Controls
-
-- define overlay semantics precisely
-- prefer explicit patch schemas over ad hoc object merges
-- validate overlay paths and value types
-- treat merge behavior as part of the security boundary
-
----
+- record spec, contract, model, policy, and validator identities;
+- retain build and review metadata;
+- generate SBOMs and release attestations;
+- distinguish provenance from correctness or safety claims.
 
 ## Security Assumptions
 
-This branch currently assumes:
+The current design assumes:
 
-- local inference is available and under application control
-- runtime AI output is untrusted until validated
-- build-time generation is subject to stronger review controls than device-time personalization
-- policy enforcement happens outside the model
-- registry identity and validation remain authoritative
+- the application controls local inference configuration and model distribution;
+- runtime AI output is untrusted until validated;
+- build-time generation receives stronger review than device-time personalization;
+- policy enforcement occurs outside the model;
+- registry identity and validation remain authoritative;
+- the mobile operating system and application sandbox are not perfect isolation boundaries;
+- network fallback is explicit rather than implicit.
 
-If any of these assumptions change, the threat model must be revisited.
-
----
+Changing any of these assumptions requires revisiting the threat model.
 
 ## Near-Term Hardening Priorities
 
-The highest-value hardening work for this branch is:
-
-1. formalize registry identity and replacement rules
-2. define overlay semantics more precisely than shallow object merging
-3. add generated-source validation for build and CI outputs
-4. make runtime validation failures observable and recoverable
-5. document explicit privacy and logging expectations for local-first operation
-6. ensure accessibility and design-token constraints are machine-checkable
-
----
+1. strengthen model and registry integrity verification;
+2. make overlay semantics and failure behavior fully explicit;
+3. expand generated-source and package validation;
+4. improve runtime validation observability and recovery;
+5. define privacy, logging, retention, and fallback expectations;
+6. make accessibility and design constraints machine-checkable;
+7. add adversarial multimodal and resource-exhaustion test coverage;
+8. improve replayable evidence for personalization and generation.
 
 ## Summary
 
-The branch is attempting to support AI-enabled interfaces without collapsing the boundary between:
+The primary security property is the separation between:
 
 ```text
-untrusted model output
+untrusted probabilistic capability
 ```
 
-and
+and:
 
 ```text
-authoritative UI behavior
+authoritative application behavior
 ```
 
-That separation is the primary security property of the architecture.
+Amaryllis is designed to preserve that separation across inference, context retrieval, component generation, personalization, registry resolution, and release workflows.


### PR DESCRIPTION
## Summary

Align the README and core design documentation with the implementation now present on `main`.

The public site no longer describes AI components as feature-branch work, but the repository entry points and technical guides still did. This PR removes that split mental model while preserving historical branch references in completion records where they remain valid evidence.

## Changes

- reframes the README around the current runtime, Context Engine, and governed components architecture
- makes the active `0.1.x` maturity level and application-owned responsibilities explicit
- updates architecture and concepts documentation to repository-level terminology
- aligns the security and threat models with current trust boundaries
- documents model-asset integrity, unsafe fallback, context poisoning, resource exhaustion, and provenance limitations
- updates component, personalization, registry, and validation guides to describe implemented contracts rather than branch direction
- distinguishes build-time executable generation from constrained device-time structured output
- preserves the central rule that model output is untrusted and non-authoritative

## Review fix

An automated review correctly identified that the initial documentation overstated runtime policy enforcement.

The revised documentation now distinguishes:

- **implemented runtime checks:** registry lookup, registered JSON Schema validation, unsafe object-key validation, JSON Patch path/value validation, post-patch schema validation, and base-prop fallback
- **build/CLI checks:** `PolicyEngine` validation for generation and customization workflows
- **application responsibilities:** semantic business rules, sensitive capabilities, network/data policy, rendered accessibility, and any additional runtime policy composition

It also clarifies that deterministic registry hashes are identity and drift-detection values, not cryptographic signatures or attestations.

## Files

- `README.md`
- `docs/architecture.md`
- `docs/concepts.md`
- `docs/security-model.md`
- `docs/threat-model.md`
- `docs/ai-enabled-components.md`
- `docs/runtime-personalization.md`
- `docs/registry-and-validation.md`

## Scope

Documentation only. No package, runtime, native, workflow, or API behavior changes.

## Validation

- CI: passed; documentation-only classifier terminated required jobs successfully and skipped native builds
- Coverage Gate: passed
- Compatibility Matrix: passed on Node.js 20, 22, and 24
- CodeQL: passed

## Review result

The original P1 review thread is outdated after the correction. The final documentation now matches the implemented runtime enforcement boundary and does not claim automatic full-policy validation.