### PR TITLE
fix: correlate native asynchronous inference requests

### DIFF
--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -71,15 +71,16 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     activeRequestId = requestId
     try {
       amaryllis.generateAsync(params) { partialResult, done ->
-        if (!ownsRequest(requestId)) {
-          return@generateAsync
-        }
-
         val text = partialResult ?: ""
         if (done) {
-          activeRequestId = null
+          if (!clearRequest(requestId)) {
+            return@generateAsync
+          }
           sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text)
         } else {
+          if (!ownsRequest(requestId)) {
+            return@generateAsync
+          }
           sendTextEvent(EVENT_ON_PARTIAL_RESULT, requestId, text)
         }
       }
@@ -109,12 +110,10 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  @Synchronized
   override fun cancelAsync(requestId: String) {
-    if (!ownsRequest(requestId)) {
+    if (!clearRequest(requestId)) {
       return
     }
-    activeRequestId = null
     amaryllis.cancelAsync()
   }
 
@@ -130,6 +129,15 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
 
   @Synchronized
   private fun ownsRequest(requestId: String): Boolean = activeRequestId == requestId
+
+  @Synchronized
+  private fun clearRequest(requestId: String): Boolean {
+    if (activeRequestId != requestId) {
+      return false
+    }
+    activeRequestId = null
+    return true
+  }
 
   private fun sendTextEvent(event: String, requestId: String, text: String) {
     val data = Arguments.createMap().apply {

--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -1,6 +1,7 @@
 package com.micrantha.amaryllis
 
 import android.util.Log
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
@@ -14,6 +15,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   NativeAmaryllisSpec(reactContext) {
 
   private val amaryllis = Amaryllis()
+  private var activeRequestId: String? = null
 
   override fun getName() = NAME
 
@@ -59,37 +61,60 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  override fun generateAsync(params: ReadableMap, promise: Promise) {
+  @Synchronized
+  override fun generateAsync(params: ReadableMap, requestId: String, promise: Promise) {
+    if (activeRequestId != null) {
+      promise.reject(ERROR_CODE_IN_PROGRESS, "generation already in progress")
+      return
+    }
+
+    activeRequestId = requestId
     try {
       amaryllis.generateAsync(params) { partialResult, done ->
+        if (!ownsRequest(requestId)) {
+          return@generateAsync
+        }
+
+        val text = partialResult ?: ""
         if (done) {
-          sendEvent(EVENT_ON_FINAL_RESULT, partialResult ?: "")
+          activeRequestId = null
+          sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text)
         } else {
-          sendEvent(EVENT_ON_PARTIAL_RESULT, partialResult ?: "")
+          sendTextEvent(EVENT_ON_PARTIAL_RESULT, requestId, text)
         }
       }
       promise.resolve(null)
     } catch (e: Amaryllis.SessionRequiredException) {
+      activeRequestId = null
       Log.e(NAME, "session is required", e)
       promise.reject(ERROR_CODE_SESSION, "session is required", e)
     } catch (e: Amaryllis.NotInitializedException) {
+      activeRequestId = null
       Log.e(NAME, "sdk is not initialized", e)
       promise.reject(ERROR_CODE_INFER, "sdk is not initialized", e)
     } catch (e: Throwable) {
+      activeRequestId = null
       Log.e(NAME, "unable to generate response", e)
-      sendEvent(EVENT_ON_ERROR, "unable to generate response")
+      sendErrorEvent(requestId, "unable to generate response", ERROR_CODE_INFER)
       promise.reject(ERROR_CODE_INFER, "unable to generate response", e)
     }
   }
 
   @ReactMethod
+  @Synchronized
   override fun close() {
     Log.d(NAME, "closing")
+    activeRequestId = null
     amaryllis.close()
   }
 
   @ReactMethod
-  override fun cancelAsync() {
+  @Synchronized
+  override fun cancelAsync(requestId: String) {
+    if (!ownsRequest(requestId)) {
+      return
+    }
+    activeRequestId = null
     amaryllis.cancelAsync()
   }
 
@@ -103,7 +128,27 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     // No-op
   }
 
-  private fun sendEvent(event: String, data: String) {
+  @Synchronized
+  private fun ownsRequest(requestId: String): Boolean = activeRequestId == requestId
+
+  private fun sendTextEvent(event: String, requestId: String, text: String) {
+    val data = Arguments.createMap().apply {
+      putString("requestId", requestId)
+      putString("text", text)
+    }
+    sendEvent(event, data)
+  }
+
+  private fun sendErrorEvent(requestId: String, message: String, code: String) {
+    val data = Arguments.createMap().apply {
+      putString("requestId", requestId)
+      putString("message", message)
+      putString("code", code)
+    }
+    sendEvent(EVENT_ON_ERROR, data)
+  }
+
+  private fun sendEvent(event: String, data: WritableMap) {
     Log.d(NAME, "sending event $event")
     reactApplicationContext
       .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
@@ -111,14 +156,12 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   override fun getConstants() = mapOf(
-    // events
     "EVENT_ON_PARTIAL_RESULT" to EVENT_ON_PARTIAL_RESULT,
     "EVENT_ON_FINAL_RESULT" to EVENT_ON_FINAL_RESULT,
     "EVENT_ON_ERROR" to EVENT_ON_ERROR,
-    // errors
     "ERROR_CODE_INFER" to ERROR_CODE_INFER,
     "ERROR_CODE_SESSION" to ERROR_CODE_SESSION,
-    // params
+    "ERROR_CODE_IN_PROGRESS" to ERROR_CODE_IN_PROGRESS,
     "PARAM_IMAGES" to PARAM_IMAGES,
     "PARAM_PROMPT" to PARAM_PROMPT,
     "PARAM_MAX_TOP_K" to PARAM_MAX_TOP_K,
@@ -138,16 +181,14 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   companion object {
     const val NAME = "Amaryllis"
 
-    // Events
     const val EVENT_ON_PARTIAL_RESULT = "onPartialResult"
     const val EVENT_ON_FINAL_RESULT = "onFinalResult"
     const val EVENT_ON_ERROR = "onError"
 
-    // Errors
     const val ERROR_CODE_INFER = "ERR_INFER"
     const val ERROR_CODE_SESSION = "ERR_SESSION"
+    const val ERROR_CODE_IN_PROGRESS = "GENERATION_IN_PROGRESS"
 
-    // Params
     const val PARAM_IMAGES = "images"
     const val PARAM_PROMPT = "prompt"
     const val PARAM_MAX_TOP_K = "maxTopK"

--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -69,6 +69,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     }
 
     activeRequestId = requestId
+    val accumulatedText = StringBuilder()
     try {
       amaryllis.generateAsync(params) { partialResult, done ->
         val text = partialResult ?: ""
@@ -76,10 +77,16 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
           if (!clearRequest(requestId)) {
             return@generateAsync
           }
-          sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text)
+          val finalText = synchronized(accumulatedText) {
+            accumulatedText.append(text).toString()
+          }
+          sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text, finalText)
         } else {
           if (!ownsRequest(requestId)) {
             return@generateAsync
+          }
+          synchronized(accumulatedText) {
+            accumulatedText.append(text)
           }
           sendTextEvent(EVENT_ON_PARTIAL_RESULT, requestId, text)
         }
@@ -139,10 +146,18 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     return true
   }
 
-  private fun sendTextEvent(event: String, requestId: String, text: String) {
+  private fun sendTextEvent(
+    event: String,
+    requestId: String,
+    text: String,
+    finalText: String? = null
+  ) {
     val data = Arguments.createMap().apply {
       putString("requestId", requestId)
       putString("text", text)
+      if (finalText != null) {
+        putString("finalText", finalText)
+      }
     }
     sendEvent(event, data)
   }

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -115,6 +115,7 @@ RCT_EXPORT_MODULE(Amaryllis)
 
   @try {
     NSError *error = nil;
+    __block NSString *latestPartial = @"";
     __weak AmaryllisModule *weakSelf = self;
 
     PartialResponseHandler progress = ^(NSString *result, NSError *err) {
@@ -134,10 +135,11 @@ RCT_EXPORT_MODULE(Amaryllis)
         return;
       }
 
+      latestPartial = result ?: @"";
       [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
                                body:@{
                                  @"requestId" : requestId,
-                                 @"text" : result ?: @"",
+                                 @"text" : latestPartial,
                                }];
     };
 
@@ -152,6 +154,7 @@ RCT_EXPORT_MODULE(Amaryllis)
                                body:@{
                                  @"requestId" : requestId,
                                  @"text" : @"",
+                                 @"finalText" : latestPartial,
                                }];
     };
 

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -115,7 +115,7 @@ RCT_EXPORT_MODULE(Amaryllis)
 
   @try {
     NSError *error = nil;
-    __block NSString *latestPartial = @"";
+    NSMutableString *accumulatedText = [NSMutableString string];
     __weak AmaryllisModule *weakSelf = self;
 
     PartialResponseHandler progress = ^(NSString *result, NSError *err) {
@@ -135,11 +135,14 @@ RCT_EXPORT_MODULE(Amaryllis)
         return;
       }
 
-      latestPartial = result ?: @"";
+      NSString *partialText = result ?: @"";
+      @synchronized(accumulatedText) {
+        [accumulatedText appendString:partialText];
+      }
       [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
                                body:@{
                                  @"requestId" : requestId,
-                                 @"text" : latestPartial,
+                                 @"text" : partialText,
                                }];
     };
 
@@ -149,12 +152,16 @@ RCT_EXPORT_MODULE(Amaryllis)
         return;
       }
 
+      NSString *finalText;
+      @synchronized(accumulatedText) {
+        finalText = [accumulatedText copy];
+      }
       [strongSelf clearRequest:requestId];
       [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
                                body:@{
                                  @"requestId" : requestId,
                                  @"text" : @"",
-                                 @"finalText" : latestPartial,
+                                 @"finalText" : finalText,
                                }];
     };
 

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -7,10 +7,12 @@ static NSString *const EVENT_ON_FINAL_RESULT = @"onFinalResult";
 static NSString *const EVENT_ON_ERROR = @"onError";
 static NSString *const ERROR_CODE_INFER = @"ERR_INFER";
 static NSString *const ERROR_CODE_SESSION = @"ERR_SESSION";
+static NSString *const ERROR_CODE_IN_PROGRESS = @"GENERATION_IN_PROGRESS";
 
 @interface AmaryllisModule ()
 
 @property(nonatomic, strong) Amaryllis *amaryllis;
+@property(nonatomic, copy, nullable) NSString *activeRequestId;
 
 @end
 
@@ -18,7 +20,7 @@ static NSString *const ERROR_CODE_SESSION = @"ERR_SESSION";
 
 RCT_EXPORT_MODULE(Amaryllis)
 
-- (instancetype) init {
+- (instancetype)init {
   self = [super init];
   self.amaryllis = [[Amaryllis alloc] init];
   return self;
@@ -28,6 +30,7 @@ RCT_EXPORT_MODULE(Amaryllis)
     (const facebook::react::ObjCTurboModule::InitParams &)params {
   return std::make_shared<facebook::react::NativeAmaryllisSpecJSI>(params);
 }
+
 #pragma mark - Event Emitter
 
 - (NSArray *)supportedEvents {
@@ -40,9 +43,8 @@ RCT_EXPORT_MODULE(Amaryllis)
        resolve:(nonnull RCTPromiseResolveBlock)resolve
         reject:(nonnull RCTPromiseRejectBlock)reject {
   NSError *error = nil;
-  
+
   @try {
-   
     [self.amaryllis initWithParams:config error:&error];
 
     if (error) {
@@ -61,11 +63,10 @@ RCT_EXPORT_MODULE(Amaryllis)
            resolve:(nonnull RCTPromiseResolveBlock)resolve
             reject:(nonnull RCTPromiseRejectBlock)reject {
   NSError *error = nil;
-  
+
   @try {
-    
-    [self.amaryllis newSessionWithParams: params error: &error];
-    
+    [self.amaryllis newSessionWithParams:params error:&error];
+
     if (error) {
       reject(ERROR_CODE_INFER, @"unable to initialize inference", error);
       return;
@@ -74,7 +75,6 @@ RCT_EXPORT_MODULE(Amaryllis)
     resolve(nil);
   } @catch (NSException *exception) {
     NSLog(@"Amaryllis: error create new session (%@)", exception.description);
-    [self sendEventWithName:EVENT_ON_ERROR body:nil];
     reject(ERROR_CODE_SESSION, @"unable to create session", nil);
   }
 }
@@ -86,7 +86,7 @@ RCT_EXPORT_MODULE(Amaryllis)
           reject:(nonnull RCTPromiseRejectBlock)reject {
   @try {
     NSError *error = nil;
-    NSString *result = [self.amaryllis generateWithParams: params error:&error];
+    NSString *result = [self.amaryllis generateWithParams:params error:&error];
 
     if (error) {
       reject(ERROR_CODE_INFER, @"unable to generate response", error);
@@ -102,43 +102,115 @@ RCT_EXPORT_MODULE(Amaryllis)
 #pragma mark - Generate Async
 
 - (void)generateAsync:(nonnull NSDictionary *)params
-              resolve:(nonnull RCTPromiseResolveBlock)resolve
-               reject:(nonnull RCTPromiseRejectBlock)reject {
+             requestId:(nonnull NSString *)requestId
+               resolve:(nonnull RCTPromiseResolveBlock)resolve
+                reject:(nonnull RCTPromiseRejectBlock)reject {
+  @synchronized(self) {
+    if (self.activeRequestId != nil) {
+      reject(ERROR_CODE_IN_PROGRESS, @"generation already in progress", nil);
+      return;
+    }
+    self.activeRequestId = requestId;
+  }
+
   @try {
     NSError *error = nil;
-    __block NSString *latestPartial = @"";
+    __weak AmaryllisModule *weakSelf = self;
 
     PartialResponseHandler progress = ^(NSString *result, NSError *err) {
-      if (!err) {
-        latestPartial = result ?: @"";
-        [self sendEventWithName:EVENT_ON_PARTIAL_RESULT body:latestPartial];
-      } else {
-        [self sendEventWithName:EVENT_ON_ERROR body:err.localizedDescription ?: @"unknown error"];
+      AmaryllisModule *strongSelf = weakSelf;
+      if (!strongSelf || ![strongSelf ownsRequest:requestId]) {
+        return;
       }
+
+      if (err) {
+        [strongSelf clearRequest:requestId];
+        [strongSelf sendEventWithName:EVENT_ON_ERROR
+                                 body:@{
+                                   @"requestId" : requestId,
+                                   @"message" : err.localizedDescription ?: @"unknown error",
+                                   @"code" : ERROR_CODE_INFER,
+                                 }];
+        return;
+      }
+
+      [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
+                               body:@{
+                                 @"requestId" : requestId,
+                                 @"text" : result ?: @"",
+                               }];
     };
 
     CompletionHandler completion = ^{
-      [self sendEventWithName:EVENT_ON_FINAL_RESULT body:latestPartial];
+      AmaryllisModule *strongSelf = weakSelf;
+      if (!strongSelf || ![strongSelf ownsRequest:requestId]) {
+        return;
+      }
+
+      [strongSelf clearRequest:requestId];
+      [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
+                               body:@{
+                                 @"requestId" : requestId,
+                                 @"text" : @"",
+                               }];
     };
 
-    [self.amaryllis generateAsyncWithParams:params error:&error response:progress completion:completion];
-    
+    [self.amaryllis generateAsyncWithParams:params
+                                      error:&error
+                                   response:progress
+                                 completion:completion];
+
+    if (error) {
+      [self clearRequest:requestId];
+      reject(ERROR_CODE_INFER, @"unable to generate response", error);
+      return;
+    }
+
     resolve(nil);
   } @catch (NSException *exception) {
+    [self clearRequest:requestId];
     NSLog(@"Amaryllis: error generating inference (%@)", exception.description);
-    [self sendEventWithName:EVENT_ON_ERROR body:nil];
+    [self sendEventWithName:EVENT_ON_ERROR
+                       body:@{
+                         @"requestId" : requestId,
+                         @"message" : @"unable to generate response",
+                         @"code" : ERROR_CODE_INFER,
+                       }];
     reject(ERROR_CODE_INFER, @"unable to generate response", nil);
   }
 }
 
 #pragma mark - Close Engine
 
-- (void) close {
+- (void)close {
+  @synchronized(self) {
+    self.activeRequestId = nil;
+  }
   [self.amaryllis close];
 }
 
-- (void) cancelAsync {
+- (void)cancelAsync:(nonnull NSString *)requestId {
+  @synchronized(self) {
+    if (![self.activeRequestId isEqualToString:requestId]) {
+      return;
+    }
+    self.activeRequestId = nil;
+  }
   [self.amaryllis cancelAsync];
+}
+
+- (BOOL)ownsRequest:(NSString *)requestId {
+  @synchronized(self) {
+    return [self.activeRequestId isEqualToString:requestId];
+  }
+}
+
+- (void)clearRequest:(NSString *)requestId {
+  @synchronized(self) {
+    if ([self.activeRequestId isEqualToString:requestId]) {
+      self.activeRequestId = nil;
+    }
+  }
 }
 
 - (NSDictionary *)constantsToExport {
@@ -146,10 +218,9 @@ RCT_EXPORT_MODULE(Amaryllis)
     @"EVENT_ON_PARTIAL_RESULT" : EVENT_ON_PARTIAL_RESULT,
     @"EVENT_ON_FINAL_RESULT" : EVENT_ON_FINAL_RESULT,
     @"EVENT_ON_ERROR" : EVENT_ON_ERROR,
-    // errors
     @"ERROR_CODE_INFER" : ERROR_CODE_INFER,
     @"ERROR_CODE_SESSION" : ERROR_CODE_SESSION,
-    // params
+    @"ERROR_CODE_IN_PROGRESS" : ERROR_CODE_IN_PROGRESS,
     @"PARAM_IMAGES" : PARAM_IMAGES,
     @"PARAM_PROMPT" : PARAM_PROMPT,
     @"PARAM_MAX_TOP_K" : PARAM_MAX_TOP_K,

--- a/src/Amaryllis.ts
+++ b/src/Amaryllis.ts
@@ -27,6 +27,17 @@ type NativeOperation = {
   owner: LlmPipe;
 };
 
+type NativeTextEvent = {
+  requestId: string;
+  text: string;
+};
+
+type NativeErrorEvent = {
+  requestId: string;
+  message: string;
+  code?: string;
+};
+
 const activeNativeOperations = new WeakMap<LlmNativeEngine, NativeOperation>();
 const closingNativeEngines = new WeakSet<LlmNativeEngine>();
 let nextOperationId = 1;
@@ -91,7 +102,7 @@ export class LlmPipe implements LlmEngine {
     try {
       this.setupAsyncCallbacks(callbacks ?? {}, generationId);
       const nativeParams = toNativeRequestParams(params);
-      await this.llmNative.generateAsync(nativeParams);
+      await this.llmNative.generateAsync(nativeParams, String(generationId));
     } catch (error) {
       this.finishAsyncGeneration(generationId);
       throw error;
@@ -143,21 +154,23 @@ export class LlmPipe implements LlmEngine {
     if (scopedGenerationId === null) {
       return;
     }
+    const requestId = String(scopedGenerationId);
 
     if (callbacks.onPartialResult || callbacks.onEvent) {
       const subscription = this.llmEmitter.addListener(
         EVENT_ON_PARTIAL_RESULT,
-        (result: string) => {
-          if (!this.isActiveGeneration(scopedGenerationId)) {
+        (payload: NativeTextEvent | string) => {
+          const result = this.normalizeTextEvent(payload, requestId);
+          if (!result || !this.isActiveGeneration(scopedGenerationId)) {
             return;
           }
           try {
-            callbacks.onEvent?.({ type: 'partial', text: result });
+            callbacks.onEvent?.({ type: 'partial', text: result.text });
           } catch (error) {
             console.error('Error in onEvent callback:', error);
           }
           try {
-            callbacks.onPartialResult?.(result);
+            callbacks.onPartialResult?.(result.text);
           } catch (error) {
             console.error('Error in onPartialResult callback:', error);
           }
@@ -168,19 +181,20 @@ export class LlmPipe implements LlmEngine {
 
     const finalSubscription = this.llmEmitter.addListener(
       EVENT_ON_FINAL_RESULT,
-      (result: string) => {
-        if (!this.isActiveGeneration(scopedGenerationId)) {
+      (payload: NativeTextEvent | string) => {
+        const result = this.normalizeTextEvent(payload, requestId);
+        if (!result || !this.isActiveGeneration(scopedGenerationId)) {
           return;
         }
 
         this.releaseNativeOperation(scopedGenerationId);
         try {
-          callbacks.onEvent?.({ type: 'final', text: result });
+          callbacks.onEvent?.({ type: 'final', text: result.text });
         } catch (error) {
           console.error('Error in onEvent callback:', error);
         }
         try {
-          callbacks.onFinalResult?.(result);
+          callbacks.onFinalResult?.(result.text);
         } catch (error) {
           console.error('Error in onFinalResult callback:', error);
         }
@@ -190,13 +204,17 @@ export class LlmPipe implements LlmEngine {
 
     const errorSubscription = this.llmEmitter.addListener(
       EVENT_ON_ERROR,
-      (error: string) => {
-        if (!this.isActiveGeneration(scopedGenerationId)) {
+      (payload: NativeErrorEvent | string) => {
+        const result = this.normalizeErrorEvent(payload, requestId);
+        if (!result || !this.isActiveGeneration(scopedGenerationId)) {
           return;
         }
 
         this.releaseNativeOperation(scopedGenerationId);
-        const errorObj = new Error(error);
+        const errorObj = new Error(result.message);
+        if (result.code) {
+          Object.assign(errorObj, { code: result.code });
+        }
         try {
           callbacks.onEvent?.({ type: 'error', error: errorObj });
         } catch (callbackError) {
@@ -210,6 +228,40 @@ export class LlmPipe implements LlmEngine {
       }
     );
     this.subscriptions.push(errorSubscription);
+  }
+
+  private normalizeTextEvent(
+    payload: NativeTextEvent | string,
+    requestId: string
+  ): NativeTextEvent | null {
+    if (typeof payload === 'string') {
+      return { requestId, text: payload };
+    }
+    if (
+      !payload ||
+      payload.requestId !== requestId ||
+      typeof payload.text !== 'string'
+    ) {
+      return null;
+    }
+    return payload;
+  }
+
+  private normalizeErrorEvent(
+    payload: NativeErrorEvent | string,
+    requestId: string
+  ): NativeErrorEvent | null {
+    if (typeof payload === 'string') {
+      return { requestId, message: payload };
+    }
+    if (
+      !payload ||
+      payload.requestId !== requestId ||
+      typeof payload.message !== 'string'
+    ) {
+      return null;
+    }
+    return payload;
   }
 
   private claimNativeOperation(kind: NativeOperation['kind']): number {
@@ -242,7 +294,7 @@ export class LlmPipe implements LlmEngine {
 
     this.releaseNativeOperation(activeOperation.id);
     try {
-      this.llmNative.cancelAsync();
+      this.llmNative.cancelAsync(String(activeOperation.id));
     } finally {
       if (notifyLifecycle) {
         this.notifyAsyncLifecycle({ type: 'cancelled' });

--- a/src/Amaryllis.ts
+++ b/src/Amaryllis.ts
@@ -30,6 +30,7 @@ type NativeOperation = {
 type NativeTextEvent = {
   requestId: string;
   text: string;
+  finalText?: string;
 };
 
 type NativeErrorEvent = {
@@ -194,7 +195,7 @@ export class LlmPipe implements LlmEngine {
           console.error('Error in onEvent callback:', error);
         }
         try {
-          callbacks.onFinalResult?.(result.text);
+          callbacks.onFinalResult?.(result.finalText ?? result.text);
         } catch (error) {
           console.error('Error in onFinalResult callback:', error);
         }
@@ -240,7 +241,9 @@ export class LlmPipe implements LlmEngine {
     if (
       !payload ||
       payload.requestId !== requestId ||
-      typeof payload.text !== 'string'
+      typeof payload.text !== 'string' ||
+      (payload.finalText !== undefined &&
+        typeof payload.finalText !== 'string')
     ) {
       return null;
     }

--- a/src/Amaryllis.ts
+++ b/src/Amaryllis.ts
@@ -242,8 +242,7 @@ export class LlmPipe implements LlmEngine {
       !payload ||
       payload.requestId !== requestId ||
       typeof payload.text !== 'string' ||
-      (payload.finalText !== undefined &&
-        typeof payload.finalText !== 'string')
+      (payload.finalText !== undefined && typeof payload.finalText !== 'string')
     ) {
       return null;
     }

--- a/src/NativeAmaryllis.ts
+++ b/src/NativeAmaryllis.ts
@@ -22,11 +22,14 @@ export interface Spec extends TurboModule {
 
   generate(params: { prompt: string; images?: string[] }): Promise<string>;
 
-  generateAsync(params: { prompt: string; images?: string[] }): Promise<void>;
+  generateAsync(
+    params: { prompt: string; images?: string[] },
+    requestId: string
+  ): Promise<void>;
 
   close(): void;
 
-  cancelAsync(): void;
+  cancelAsync(requestId: string): void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('Amaryllis');

--- a/src/__tests__/Amaryllis.test.tsx
+++ b/src/__tests__/Amaryllis.test.tsx
@@ -11,15 +11,15 @@ import {
   GenerationInProgressError,
 } from '../Errors';
 
-let listeners: Record<string, (result: string) => void> = {};
+let listeners: Record<string, (result: any) => void> = {};
 
 const nativeMock = {
   init: jest.fn(),
   newSession: jest.fn(),
   generate: jest.fn<Promise<string>, [LlmRequestParams]>(),
-  generateAsync: jest.fn<Promise<void>, [LlmRequestParams]>(),
+  generateAsync: jest.fn<Promise<void>, [LlmRequestParams, string]>(),
   close: jest.fn(),
-  cancelAsync: jest.fn(),
+  cancelAsync: jest.fn<void, [string]>(),
   EVENT_ON_PARTIAL_RESULT: 'onPartialResult',
   EVENT_ON_FINAL_RESULT: 'onFinalResult',
   EVENT_ON_ERROR: 'onError',
@@ -46,6 +46,14 @@ const sessionParams: LlmSessionParams = {
   randomSeed: 12345,
 } as LlmSessionParams;
 const requestParams: LlmRequestParams = { prompt: 'baz' } as LlmRequestParams;
+
+const getLastRequestId = (): string => {
+  const call = nativeMock.generateAsync.mock.calls.at(-1);
+  if (!call) {
+    throw new Error('Expected an asynchronous native generation call');
+  }
+  return call[1];
+};
 
 describe('LlmPipe', () => {
   beforeEach(() => {
@@ -83,7 +91,10 @@ describe('LlmPipe', () => {
     const onEvent = jest.fn();
     const callbacks: LlmCallbacks = { onEvent };
     await pipe.generateAsync(requestParams, callbacks);
-    expect(nativeMock.generateAsync).toHaveBeenCalledWith(requestParams);
+    expect(nativeMock.generateAsync).toHaveBeenCalledWith(
+      requestParams,
+      expect.any(String)
+    );
     expect(listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]).toBeDefined();
     expect(listeners[nativeMock.EVENT_ON_FINAL_RESULT]).toBeDefined();
     expect(listeners[nativeMock.EVENT_ON_ERROR]).toBeDefined();
@@ -95,6 +106,52 @@ describe('LlmPipe', () => {
     listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.('final');
     expect(onEvent).toHaveBeenCalledWith({ type: 'final', text: 'final' });
     expect(nativeMock.cancelAsync).not.toHaveBeenCalled();
+    expect(listeners).toEqual({});
+  });
+
+  it('routes structured native events only to their request', async () => {
+    const onEvent = jest.fn();
+    await pipe.generateAsync(requestParams, { onEvent });
+    const requestId = getLastRequestId();
+
+    listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]?.({
+      requestId: 'another-request',
+      text: 'stale',
+    });
+    listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]?.({
+      requestId,
+      text: 'partial',
+    });
+    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.({
+      requestId,
+      text: '',
+    });
+
+    expect(onEvent).toHaveBeenNthCalledWith(1, {
+      type: 'partial',
+      text: 'partial',
+    });
+    expect(onEvent).toHaveBeenNthCalledWith(2, {
+      type: 'final',
+      text: '',
+    });
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(listeners).toEqual({});
+  });
+
+  it('preserves a final snapshot for final-only callbacks', async () => {
+    const onFinalResult = jest.fn();
+    await pipe.generateAsync(requestParams, { onFinalResult });
+    const requestId = getLastRequestId();
+
+    expect(listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]).toBeUndefined();
+    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.({
+      requestId,
+      text: '',
+      finalText: 'complete result',
+    });
+
+    expect(onFinalResult).toHaveBeenCalledWith('complete result');
     expect(listeners).toEqual({});
   });
 
@@ -241,10 +298,11 @@ describe('LlmPipe', () => {
     const lifecycleListener = jest.fn();
     pipe.subscribeAsyncLifecycle(lifecycleListener);
     await pipe.generateAsync(requestParams, { onEvent: jest.fn() });
+    const requestId = getLastRequestId();
 
     pipe.cancelAsync();
 
-    expect(nativeMock.cancelAsync).toHaveBeenCalledTimes(1);
+    expect(nativeMock.cancelAsync).toHaveBeenCalledWith(requestId);
     expect(lifecycleListener).toHaveBeenCalledWith({ type: 'cancelled' });
   });
 
@@ -253,11 +311,12 @@ describe('LlmPipe', () => {
     const secondOnEvent = jest.fn();
 
     await pipe.generateAsync(requestParams, { onEvent: firstOnEvent });
+    const firstRequestId = getLastRequestId();
     const staleFinalListener = listeners[nativeMock.EVENT_ON_FINAL_RESULT];
 
     pipe.cancelAsync();
 
-    expect(nativeMock.cancelAsync).toHaveBeenCalledTimes(1);
+    expect(nativeMock.cancelAsync).toHaveBeenCalledWith(firstRequestId);
     expect(listeners).toEqual({});
 
     await pipe.generateAsync({ prompt: 'second' }, { onEvent: secondOnEvent });


### PR DESCRIPTION
## Summary

Implements the native request-correlation slice of #62.

- adds an explicit request ID to the TurboModule `generateAsync` and `cancelAsync` contracts
- passes the JavaScript operation identity into Android and iOS
- emits structured partial, final, and error payloads containing the request ID
- ignores events whose request ID does not match the active JavaScript generation
- enforces one active asynchronous request in each native module
- makes cancellation request-targeted rather than globally unconditional
- clears native request ownership on final, error, cancellation, close, and startup failure
- preserves legacy string-event compatibility for custom engines while built-in native modules use correlated payloads
- keeps public `onEvent` streaming values as deltas while providing accumulated final output to `onFinalResult`

## Concurrency contract

The runtime remains single-flight. A second native asynchronous generation is rejected with `GENERATION_IN_PROGRESS`; it is not queued and does not cancel the active request.

## Review fixes

Two review findings were addressed:

- Android now performs the request ownership check and conditional clear atomically, preventing a late callback from clearing a newer request during a cancel/final race.
- Android and iOS accumulate native chunks for final-only callback users while continuing to emit terminal deltas without duplicating `onEvent` output.

Regression coverage now verifies request ID propagation, stale-event rejection, targeted cancellation, and final-only output preservation.

## Scope

This PR advances issue #62 across the JavaScript/native boundary. It does not add parallel generation or redesign the public hook API.

## Validation

All checks pass on head `f4b2787020c2e9d387e8da0fdf48830b154b4ed1`:

- CI unit tests, lint, typecheck, and package validation
- Android example build and TurboModule codegen
- iOS example build and TurboModule codegen
- Coverage Gate
- Node.js 20, 22, and 24 Compatibility Matrix
- CodeQL
- SBOM workflow

All inline review threads are resolved.

Refs #62