### PR TITLE
test: cover native async lifecycle races

### DIFF
--- a/Amaryllis.podspec
+++ b/Amaryllis.podspec
@@ -14,8 +14,9 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/hackelia-micrantha/react-native-amaryllis.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
+  s.exclude_files = "ios/tests/**/*"
   s.private_header_files = "ios/**/*.h"
-   
+
   s.dependency "MediaPipeTasksGenAI"
 
   install_modules_dependencies(s)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,10 +17,8 @@ buildscript {
   }
 }
 
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-
 apply plugin: "com.facebook.react"
 
 def getExtOrIntegerDefault(name) {
@@ -29,7 +27,6 @@ def getExtOrIntegerDefault(name) {
 
 android {
   namespace "com.micrantha.amaryllis"
-
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
@@ -78,4 +75,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.google.mediapipe:tasks-core:latest.release'
   implementation 'com.google.mediapipe:tasks-genai:latest.release'
+
+  testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -15,7 +15,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   NativeAmaryllisSpec(reactContext) {
 
   private val amaryllis = Amaryllis()
-  private var activeRequestId: String? = null
+  private val requestTracker = NativeRequestTracker()
 
   override fun getName() = NAME
 
@@ -61,20 +61,18 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  @Synchronized
   override fun generateAsync(params: ReadableMap, requestId: String, promise: Promise) {
-    if (activeRequestId != null) {
+    if (!requestTracker.tryStart(requestId)) {
       promise.reject(ERROR_CODE_IN_PROGRESS, "generation already in progress")
       return
     }
 
-    activeRequestId = requestId
     val accumulatedText = StringBuilder()
     try {
       amaryllis.generateAsync(params) { partialResult, done ->
         val text = partialResult ?: ""
         if (done) {
-          if (!clearRequest(requestId)) {
+          if (!requestTracker.clear(requestId)) {
             return@generateAsync
           }
           val finalText = synchronized(accumulatedText) {
@@ -82,7 +80,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
           }
           sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text, finalText)
         } else {
-          if (!ownsRequest(requestId)) {
+          if (!requestTracker.owns(requestId)) {
             return@generateAsync
           }
           synchronized(accumulatedText) {
@@ -93,15 +91,15 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
       }
       promise.resolve(null)
     } catch (e: Amaryllis.SessionRequiredException) {
-      activeRequestId = null
+      requestTracker.clear(requestId)
       Log.e(NAME, "session is required", e)
       promise.reject(ERROR_CODE_SESSION, "session is required", e)
     } catch (e: Amaryllis.NotInitializedException) {
-      activeRequestId = null
+      requestTracker.clear(requestId)
       Log.e(NAME, "sdk is not initialized", e)
       promise.reject(ERROR_CODE_INFER, "sdk is not initialized", e)
     } catch (e: Throwable) {
-      activeRequestId = null
+      requestTracker.clear(requestId)
       Log.e(NAME, "unable to generate response", e)
       sendErrorEvent(requestId, "unable to generate response", ERROR_CODE_INFER)
       promise.reject(ERROR_CODE_INFER, "unable to generate response", e)
@@ -109,16 +107,15 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  @Synchronized
   override fun close() {
     Log.d(NAME, "closing")
-    activeRequestId = null
+    requestTracker.clearAll()
     amaryllis.close()
   }
 
   @ReactMethod
   override fun cancelAsync(requestId: String) {
-    if (!clearRequest(requestId)) {
+    if (!requestTracker.clear(requestId)) {
       return
     }
     amaryllis.cancelAsync()
@@ -132,18 +129,6 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   @Override
   fun removeListeners(count: Int) {
     // No-op
-  }
-
-  @Synchronized
-  private fun ownsRequest(requestId: String): Boolean = activeRequestId == requestId
-
-  @Synchronized
-  private fun clearRequest(requestId: String): Boolean {
-    if (activeRequestId != requestId) {
-      return false
-    }
-    activeRequestId = null
-    return true
   }
 
   private fun sendTextEvent(

--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -61,6 +61,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  @Synchronized
   override fun generateAsync(params: ReadableMap, requestId: String, promise: Promise) {
     if (!requestTracker.tryStart(requestId)) {
       promise.reject(ERROR_CODE_IN_PROGRESS, "generation already in progress")
@@ -107,6 +108,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  @Synchronized
   override fun close() {
     Log.d(NAME, "closing")
     requestTracker.clearAll()

--- a/android/src/main/java/com/micrantha/amaryllis/NativeRequestTracker.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/NativeRequestTracker.kt
@@ -1,0 +1,31 @@
+package com.micrantha.amaryllis
+
+internal class NativeRequestTracker {
+  private var activeRequestId: String? = null
+
+  @Synchronized
+  fun tryStart(requestId: String): Boolean {
+    if (activeRequestId != null) {
+      return false
+    }
+    activeRequestId = requestId
+    return true
+  }
+
+  @Synchronized
+  fun owns(requestId: String): Boolean = activeRequestId == requestId
+
+  @Synchronized
+  fun clear(requestId: String): Boolean {
+    if (activeRequestId != requestId) {
+      return false
+    }
+    activeRequestId = null
+    return true
+  }
+
+  @Synchronized
+  fun clearAll() {
+    activeRequestId = null
+  }
+}

--- a/android/src/test/java/com/micrantha/amaryllis/NativeRequestTrackerTest.kt
+++ b/android/src/test/java/com/micrantha/amaryllis/NativeRequestTrackerTest.kt
@@ -1,0 +1,74 @@
+package com.micrantha.amaryllis
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NativeRequestTrackerTest {
+  @Test
+  fun rejectsOverlapAndAllowsRestartAfterCompletion() {
+    val tracker = NativeRequestTracker()
+
+    assertTrue(tracker.tryStart("first"))
+    assertFalse(tracker.tryStart("second"))
+    assertTrue(tracker.clear("first"))
+    assertTrue(tracker.tryStart("second"))
+  }
+
+  @Test
+  fun cancellationIsRequestScopedAndLateCallbacksAreIgnored() {
+    val tracker = NativeRequestTracker()
+
+    assertTrue(tracker.tryStart("first"))
+    assertFalse(tracker.clear("other"))
+    assertTrue(tracker.owns("first"))
+    assertTrue(tracker.clear("first"))
+    assertFalse(tracker.owns("first"))
+    assertFalse(tracker.clear("first"))
+  }
+
+  @Test
+  fun closeClearsActiveRequestAndAllowsImmediateRestart() {
+    val tracker = NativeRequestTracker()
+
+    assertTrue(tracker.tryStart("first"))
+    tracker.clearAll()
+    assertFalse(tracker.owns("first"))
+    assertTrue(tracker.tryStart("second"))
+  }
+
+  @Test
+  fun staleCompletionCannotClearANewerRequest() {
+    val tracker = NativeRequestTracker()
+
+    assertTrue(tracker.tryStart("first"))
+    assertTrue(tracker.clear("first"))
+    assertTrue(tracker.tryStart("second"))
+    assertFalse(tracker.clear("first"))
+    assertTrue(tracker.owns("second"))
+  }
+
+  @Test
+  fun concurrentStartsHaveExactlyOneWinner() {
+    val tracker = NativeRequestTracker()
+    val ready = CountDownLatch(2)
+    val start = CountDownLatch(1)
+    val executor = Executors.newFixedThreadPool(2)
+
+    val results = listOf("first", "second").map { requestId ->
+      executor.submit<Boolean> {
+        ready.countDown()
+        start.await()
+        tracker.tryStart(requestId)
+      }
+    }
+
+    ready.await()
+    start.countDown()
+
+    assertTrue(results.count { it.get() } == 1)
+    executor.shutdownNow()
+  }
+}

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,10 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "build:android": "react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
-    "build:ios": "react-native build-ios --mode Debug"
+    "test:native:android": "cd android && ./gradlew testDebugUnitTest --no-daemon --console=plain",
+    "test:native:ios": "xcrun clang -fobjc-arc -fblocks -framework Foundation -I ../ios ../ios/AMRequestTracker.m ../ios/tests/AMRequestTrackerTests.m -o /tmp/amaryllis-request-tracker-tests && /tmp/amaryllis-request-tracker-tests",
+    "build:android": "yarn test:native:android && react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
+    "build:ios": "yarn test:native:ios && react-native build-ios --mode Debug"
   },
   "dependencies": {
     "@micrantha/amaryllis-components": "workspace:*",

--- a/ios/AMRequestTracker.h
+++ b/ios/AMRequestTracker.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AMRequestTracker : NSObject
+
+- (BOOL)tryStart:(NSString *)requestId;
+- (BOOL)owns:(NSString *)requestId;
+- (BOOL)clear:(NSString *)requestId;
+- (void)clearAll;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/AMRequestTracker.m
+++ b/ios/AMRequestTracker.m
@@ -1,0 +1,41 @@
+#import "AMRequestTracker.h"
+
+@interface AMRequestTracker ()
+@property(nonatomic, copy, nullable) NSString *activeRequestId;
+@end
+
+@implementation AMRequestTracker
+
+- (BOOL)tryStart:(NSString *)requestId {
+  @synchronized(self) {
+    if (self.activeRequestId != nil) {
+      return NO;
+    }
+    self.activeRequestId = requestId;
+    return YES;
+  }
+}
+
+- (BOOL)owns:(NSString *)requestId {
+  @synchronized(self) {
+    return [self.activeRequestId isEqualToString:requestId];
+  }
+}
+
+- (BOOL)clear:(NSString *)requestId {
+  @synchronized(self) {
+    if (![self.activeRequestId isEqualToString:requestId]) {
+      return NO;
+    }
+    self.activeRequestId = nil;
+    return YES;
+  }
+}
+
+- (void)clearAll {
+  @synchronized(self) {
+    self.activeRequestId = nil;
+  }
+}
+
+@end

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -107,92 +107,96 @@ RCT_EXPORT_MODULE(Amaryllis)
              requestId:(nonnull NSString *)requestId
                resolve:(nonnull RCTPromiseResolveBlock)resolve
                 reject:(nonnull RCTPromiseRejectBlock)reject {
-  if (![self.requestTracker tryStart:requestId]) {
-    reject(ERROR_CODE_IN_PROGRESS, @"generation already in progress", nil);
-    return;
-  }
-
-  @try {
-    NSError *error = nil;
-    NSMutableString *accumulatedText = [NSMutableString string];
-    __weak AmaryllisModule *weakSelf = self;
-
-    PartialResponseHandler progress = ^(NSString *result, NSError *err) {
-      AmaryllisModule *strongSelf = weakSelf;
-      if (!strongSelf || ![strongSelf.requestTracker owns:requestId]) {
-        return;
-      }
-
-      if (err) {
-        [strongSelf.requestTracker clear:requestId];
-        [strongSelf sendEventWithName:EVENT_ON_ERROR
-                                 body:@{
-                                   @"requestId" : requestId,
-                                   @"message" : err.localizedDescription ?: @"unknown error",
-                                   @"code" : ERROR_CODE_INFER,
-                                 }];
-        return;
-      }
-
-      NSString *partialText = result ?: @"";
-      @synchronized(accumulatedText) {
-        [accumulatedText appendString:partialText];
-      }
-      [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
-                               body:@{
-                                 @"requestId" : requestId,
-                                 @"text" : partialText,
-                               }];
-    };
-
-    CompletionHandler completion = ^{
-      AmaryllisModule *strongSelf = weakSelf;
-      if (!strongSelf || ![strongSelf.requestTracker clear:requestId]) {
-        return;
-      }
-
-      NSString *finalText;
-      @synchronized(accumulatedText) {
-        finalText = [accumulatedText copy];
-      }
-      [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
-                               body:@{
-                                 @"requestId" : requestId,
-                                 @"text" : @"",
-                                 @"finalText" : finalText,
-                               }];
-    };
-
-    [self.amaryllis generateAsyncWithParams:params
-                                      error:&error
-                                   response:progress
-                                 completion:completion];
-
-    if (error) {
-      [self.requestTracker clear:requestId];
-      reject(ERROR_CODE_INFER, @"unable to generate response", error);
+  @synchronized(self) {
+    if (![self.requestTracker tryStart:requestId]) {
+      reject(ERROR_CODE_IN_PROGRESS, @"generation already in progress", nil);
       return;
     }
 
-    resolve(nil);
-  } @catch (NSException *exception) {
-    [self.requestTracker clear:requestId];
-    NSLog(@"Amaryllis: error generating inference (%@)", exception.description);
-    [self sendEventWithName:EVENT_ON_ERROR
-                       body:@{
-                         @"requestId" : requestId,
-                         @"message" : @"unable to generate response",
-                         @"code" : ERROR_CODE_INFER,
-                       }];
-    reject(ERROR_CODE_INFER, @"unable to generate response", nil);
+    @try {
+      NSError *error = nil;
+      NSMutableString *accumulatedText = [NSMutableString string];
+      __weak AmaryllisModule *weakSelf = self;
+
+      PartialResponseHandler progress = ^(NSString *result, NSError *err) {
+        AmaryllisModule *strongSelf = weakSelf;
+        if (!strongSelf || ![strongSelf.requestTracker owns:requestId]) {
+          return;
+        }
+
+        if (err) {
+          [strongSelf.requestTracker clear:requestId];
+          [strongSelf sendEventWithName:EVENT_ON_ERROR
+                                   body:@{
+                                     @"requestId" : requestId,
+                                     @"message" : err.localizedDescription ?: @"unknown error",
+                                     @"code" : ERROR_CODE_INFER,
+                                   }];
+          return;
+        }
+
+        NSString *partialText = result ?: @"";
+        @synchronized(accumulatedText) {
+          [accumulatedText appendString:partialText];
+        }
+        [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
+                                 body:@{
+                                   @"requestId" : requestId,
+                                   @"text" : partialText,
+                                 }];
+      };
+
+      CompletionHandler completion = ^{
+        AmaryllisModule *strongSelf = weakSelf;
+        if (!strongSelf || ![strongSelf.requestTracker clear:requestId]) {
+          return;
+        }
+
+        NSString *finalText;
+        @synchronized(accumulatedText) {
+          finalText = [accumulatedText copy];
+        }
+        [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
+                                 body:@{
+                                   @"requestId" : requestId,
+                                   @"text" : @"",
+                                   @"finalText" : finalText,
+                                 }];
+      };
+
+      [self.amaryllis generateAsyncWithParams:params
+                                        error:&error
+                                     response:progress
+                                   completion:completion];
+
+      if (error) {
+        [self.requestTracker clear:requestId];
+        reject(ERROR_CODE_INFER, @"unable to generate response", error);
+        return;
+      }
+
+      resolve(nil);
+    } @catch (NSException *exception) {
+      [self.requestTracker clear:requestId];
+      NSLog(@"Amaryllis: error generating inference (%@)", exception.description);
+      [self sendEventWithName:EVENT_ON_ERROR
+                         body:@{
+                           @"requestId" : requestId,
+                           @"message" : @"unable to generate response",
+                           @"code" : ERROR_CODE_INFER,
+                         }];
+      reject(ERROR_CODE_INFER, @"unable to generate response", nil);
+    }
   }
 }
 
 #pragma mark - Close Engine
 
 - (void)close {
-  [self.requestTracker clearAll];
-  [self.amaryllis close];
+  @synchronized(self) {
+    [self.requestTracker clearAll];
+    [self.amaryllis close];
+  }
 }
 
 - (void)cancelAsync:(nonnull NSString *)requestId {

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -1,4 +1,5 @@
 #import "AmaryllisModule.h"
+#import "AMRequestTracker.h"
 #import "Amaryllis.h"
 #import <ReactCommon/RCTTurboModule.h>
 
@@ -12,7 +13,7 @@ static NSString *const ERROR_CODE_IN_PROGRESS = @"GENERATION_IN_PROGRESS";
 @interface AmaryllisModule ()
 
 @property(nonatomic, strong) Amaryllis *amaryllis;
-@property(nonatomic, copy, nullable) NSString *activeRequestId;
+@property(nonatomic, strong) AMRequestTracker *requestTracker;
 
 @end
 
@@ -23,6 +24,7 @@ RCT_EXPORT_MODULE(Amaryllis)
 - (instancetype)init {
   self = [super init];
   self.amaryllis = [[Amaryllis alloc] init];
+  self.requestTracker = [[AMRequestTracker alloc] init];
   return self;
 }
 
@@ -105,12 +107,9 @@ RCT_EXPORT_MODULE(Amaryllis)
              requestId:(nonnull NSString *)requestId
                resolve:(nonnull RCTPromiseResolveBlock)resolve
                 reject:(nonnull RCTPromiseRejectBlock)reject {
-  @synchronized(self) {
-    if (self.activeRequestId != nil) {
-      reject(ERROR_CODE_IN_PROGRESS, @"generation already in progress", nil);
-      return;
-    }
-    self.activeRequestId = requestId;
+  if (![self.requestTracker tryStart:requestId]) {
+    reject(ERROR_CODE_IN_PROGRESS, @"generation already in progress", nil);
+    return;
   }
 
   @try {
@@ -120,12 +119,12 @@ RCT_EXPORT_MODULE(Amaryllis)
 
     PartialResponseHandler progress = ^(NSString *result, NSError *err) {
       AmaryllisModule *strongSelf = weakSelf;
-      if (!strongSelf || ![strongSelf ownsRequest:requestId]) {
+      if (!strongSelf || ![strongSelf.requestTracker owns:requestId]) {
         return;
       }
 
       if (err) {
-        [strongSelf clearRequest:requestId];
+        [strongSelf.requestTracker clear:requestId];
         [strongSelf sendEventWithName:EVENT_ON_ERROR
                                  body:@{
                                    @"requestId" : requestId,
@@ -148,7 +147,7 @@ RCT_EXPORT_MODULE(Amaryllis)
 
     CompletionHandler completion = ^{
       AmaryllisModule *strongSelf = weakSelf;
-      if (!strongSelf || ![strongSelf ownsRequest:requestId]) {
+      if (!strongSelf || ![strongSelf.requestTracker clear:requestId]) {
         return;
       }
 
@@ -156,7 +155,6 @@ RCT_EXPORT_MODULE(Amaryllis)
       @synchronized(accumulatedText) {
         finalText = [accumulatedText copy];
       }
-      [strongSelf clearRequest:requestId];
       [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
                                body:@{
                                  @"requestId" : requestId,
@@ -171,14 +169,14 @@ RCT_EXPORT_MODULE(Amaryllis)
                                  completion:completion];
 
     if (error) {
-      [self clearRequest:requestId];
+      [self.requestTracker clear:requestId];
       reject(ERROR_CODE_INFER, @"unable to generate response", error);
       return;
     }
 
     resolve(nil);
   } @catch (NSException *exception) {
-    [self clearRequest:requestId];
+    [self.requestTracker clear:requestId];
     NSLog(@"Amaryllis: error generating inference (%@)", exception.description);
     [self sendEventWithName:EVENT_ON_ERROR
                        body:@{
@@ -193,34 +191,15 @@ RCT_EXPORT_MODULE(Amaryllis)
 #pragma mark - Close Engine
 
 - (void)close {
-  @synchronized(self) {
-    self.activeRequestId = nil;
-  }
+  [self.requestTracker clearAll];
   [self.amaryllis close];
 }
 
 - (void)cancelAsync:(nonnull NSString *)requestId {
-  @synchronized(self) {
-    if (![self.activeRequestId isEqualToString:requestId]) {
-      return;
-    }
-    self.activeRequestId = nil;
+  if (![self.requestTracker clear:requestId]) {
+    return;
   }
   [self.amaryllis cancelAsync];
-}
-
-- (BOOL)ownsRequest:(NSString *)requestId {
-  @synchronized(self) {
-    return [self.activeRequestId isEqualToString:requestId];
-  }
-}
-
-- (void)clearRequest:(NSString *)requestId {
-  @synchronized(self) {
-    if ([self.activeRequestId isEqualToString:requestId]) {
-      self.activeRequestId = nil;
-    }
-  }
 }
 
 - (NSDictionary *)constantsToExport {

--- a/ios/tests/AMRequestTrackerTests.m
+++ b/ios/tests/AMRequestTrackerTests.m
@@ -1,0 +1,50 @@
+#import <Foundation/Foundation.h>
+#import "../AMRequestTracker.h"
+
+static void Assert(BOOL condition, NSString *message) {
+  if (!condition) {
+    NSLog(@"FAILED: %@", message);
+    exit(1);
+  }
+}
+
+int main(void) {
+  @autoreleasepool {
+    AMRequestTracker *tracker = [[AMRequestTracker alloc] init];
+
+    Assert([tracker tryStart:@"first"], @"first request should start");
+    Assert(![tracker tryStart:@"second"], @"overlap should be rejected");
+    Assert(![tracker clear:@"other"], @"unrelated cancellation should be ignored");
+    Assert([tracker owns:@"first"], @"first request should remain active");
+    Assert([tracker clear:@"first"], @"owner should clear request");
+    Assert(![tracker clear:@"first"], @"late completion should be ignored");
+    Assert([tracker tryStart:@"second"], @"restart after completion should succeed");
+    Assert(![tracker clear:@"first"], @"stale completion must not clear newer request");
+    Assert([tracker owns:@"second"], @"second request should remain active");
+
+    [tracker clearAll];
+    Assert(![tracker owns:@"second"], @"close should clear active request");
+    Assert([tracker tryStart:@"third"], @"restart after close should succeed");
+    [tracker clearAll];
+
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    NSLock *lock = [[NSLock alloc] init];
+    __block NSInteger winners = 0;
+
+    for (NSString *requestId in @[ @"a", @"b" ]) {
+      dispatch_group_async(group, queue, ^{
+        if ([tracker tryStart:requestId]) {
+          [lock lock];
+          winners += 1;
+          [lock unlock];
+        }
+      });
+    }
+
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    Assert(winners == 1, @"concurrent starts should have exactly one winner");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements issue #62 slice 3 with deterministic native lifecycle tests that do not load MediaPipe models or require devices.

- extracts Android request ownership into a synchronized `NativeRequestTracker`
- adds JVM tests for overlap rejection, targeted cancellation, close, immediate restart, stale completion, and concurrent starts
- extracts equivalent iOS request ownership into a Foundation-only `AMRequestTracker`
- adds a standalone Objective-C lifecycle test executable covering the same state transitions and races
- runs both native lifecycle harnesses before their existing example builds
- excludes the iOS test executable sources from the published CocoaPod

## Review fix

Review identified that tracker extraction had removed Android module-level serialization between asynchronous generation startup and engine shutdown. The final implementation:

- restores `@Synchronized` on Android `generateAsync()` and `close()`;
- serializes the equivalent iOS startup and close operations with `@synchronized(self)`;
- keeps request ownership inside the extracted trackers while protecting the broader native-engine transition at the module boundary.

This prevents a new request from entering MediaPipe while `close()` is still tearing down the session or inference engine.

## Scope

This PR tests the native ownership state machines introduced by PR #80. It does not add emulator/device inference tests or parallel generation.

## Validation

All checks pass on head `329495d85528d22d3d29e9348917436c13538d2f`:

- Android JVM lifecycle tests
- Android example build and TurboModule codegen
- iOS Foundation lifecycle test executable
- iOS example build and TurboModule codegen
- JavaScript unit tests
- lint and typecheck
- components and main package validation
- Node.js compatibility matrix
- Coverage Gate
- CodeQL
- SBOM workflow

All inline review threads are resolved.

Refs #62