### PR TITLE
docs: define asynchronous inference lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ const generate = useInferenceAsync({
 const cancel = await generate({ prompt, images });
 ```
 
-`await generate(...)` waits for validation and native startup, not for model completion. Use `onComplete` or the final `onResult(..., true)` callback as the terminal boundary. The returned cancellation function targets only that request and is idempotent.
+`await generate(...)` waits for validation and native startup, not for model completion. The final `onResult(..., true)` callback delivers the complete output, while `onComplete` is the safe boundary for immediately starting another request. The returned cancellation function targets only that request and is idempotent.
 
 Asynchronous generation is single-flight per native module. An overlapping synchronous or asynchronous request is rejected with `GenerationInProgressError` and code `GENERATION_IN_PROGRESS`; it is not queued and does not cancel the active request.
 

--- a/README.md
+++ b/README.md
@@ -127,17 +127,23 @@ Use `useInferenceAsync` for streaming generation:
 import { useInferenceAsync } from '@micrantha/react-native-amaryllis';
 
 const generate = useInferenceAsync({
-  onResult: (chunk, isFinal) => {
-    append(chunk);
+  onResult: (text, isFinal) => {
+    // Hook results are cumulative snapshots. Replace displayed text.
+    setOutput(text);
     if (isFinal) finish();
   },
   onError: handleError,
+  onComplete: handleComplete,
 });
 
-await generate({ prompt, images });
+const cancel = await generate({ prompt, images });
 ```
 
-Applications should cancel active work during lifecycle cleanup and bound image count, image size, and token budgets for predictable resource use.
+`await generate(...)` waits for validation and native startup, not for model completion. Use `onComplete` or the final `onResult(..., true)` callback as the terminal boundary. The returned cancellation function targets only that request and is idempotent.
+
+Asynchronous generation is single-flight per native module. An overlapping synchronous or asynchronous request is rejected with `GenerationInProgressError` and code `GENERATION_IN_PROGRESS`; it is not queued and does not cancel the active request.
+
+Applications should cancel active work during lifecycle cleanup and bound image count, image size, and token budgets for predictable resource use. See [Asynchronous inference lifecycle](docs/async-inference.md) and the [sequential generation example](docs/examples/sequential-async-inference.md).
 
 ## Context Engine
 
@@ -241,6 +247,7 @@ These controls improve reviewability and traceability; they do not replace appli
 - [Architecture](docs/architecture.md)
 - [Concepts](docs/concepts.md)
 - [Local AI and MediaPipe](docs/local-ai.md)
+- [Asynchronous inference lifecycle](docs/async-inference.md)
 - [Context Engine](docs/context-engine.md)
 - [AI-enabled components](docs/ai-enabled-components.md)
 - [Runtime personalization](docs/runtime-personalization.md)

--- a/docs/async-inference.md
+++ b/docs/async-inference.md
@@ -1,0 +1,131 @@
+# Asynchronous inference lifecycle
+
+Amaryllis asynchronous inference is request-scoped and single-flight. This document defines the current `0.1.x` behavior of `useInferenceAsync`, `LlmPipe.generateAsync`, native request correlation, cancellation, and streamed output.
+
+## Recommended entry point
+
+Use `useInferenceAsync` for React components. It creates a fresh stream and output buffer for every accepted generation while preserving one hook instance across sequential calls.
+
+```tsx
+const generate = useInferenceAsync({
+  onResult: (text, isFinal) => {
+    setOutput(text);
+    if (isFinal) {
+      setStatus('complete');
+    }
+  },
+  onError: handleError,
+  onComplete: handleComplete,
+});
+
+const cancel = await generate({ prompt, images });
+```
+
+`await generate(...)` waits for validation and native startup. It does **not** wait for the model to finish. Use `onComplete`, the final `onResult(..., true)` callback, or an application wrapper to await terminal completion.
+
+The returned function cancels only the generation started by that call. Calling it more than once, or after settlement, is a no-op.
+
+## Single-flight contract
+
+One synchronous or asynchronous generation may own a native module at a time. This applies across `LlmPipe` instances that share the same native module.
+
+An overlapping call:
+
+- is rejected immediately;
+- reports `GenerationInProgressError` with code `GENERATION_IN_PROGRESS`;
+- is not queued;
+- does not cancel or otherwise disturb the active generation.
+
+Starting a generation while the native engine is closing is rejected by the same contract.
+
+Sequential calls are supported after the prior operation reaches a terminal state and releases ownership.
+
+## Request isolation
+
+Every accepted asynchronous generation receives an internal request ID. Android and iOS include that ID in structured partial, final, and error events. JavaScript ignores events that do not match the active request.
+
+This prevents:
+
+- a new generation receiving stale output from an earlier request;
+- completion or error from one request settling another;
+- cancellation of one request cancelling an unrelated request;
+- a late native callback clearing ownership of a newer request.
+
+Custom engines remain single-flight through `LlmPipe`. They should use the structured event contract when they bridge through the built-in native event emitter.
+
+## Stream semantics
+
+Amaryllis exposes two stream layers with different text semantics.
+
+| Layer | Callback | Text contract |
+| --- | --- | --- |
+| React hook | `useInferenceAsync({ onResult })` | `text` is the complete accumulated output produced so far. Replace displayed text; do not append it. `isFinal: true` contains the complete final output. |
+| Low-level engine | `LlmCallbacks.onEvent` partial event | `event.text` is the next delta from the native stream. Accumulate it when using this interface directly. |
+| Low-level engine | `LlmCallbacks.onEvent` final event | `event.text` is the terminal delta and may be empty. It marks completion and should be accumulated once. |
+| Legacy callback | `onPartialResult` | Incremental delta. Deprecated in favor of `onEvent`. |
+| Legacy callback | `onFinalResult` | Complete accumulated final output. Deprecated in favor of `onEvent` or the hook adapter. |
+
+The hook adapter accumulates low-level deltas before invoking `onResult`. Therefore this is correct:
+
+```tsx
+onResult: (text) => setOutput(text)
+```
+
+This duplicates output and is incorrect:
+
+```tsx
+onResult: (text) => setOutput((current) => current + text)
+```
+
+A configured protocol sanitizes the accumulated hook output before `onResult` is invoked.
+
+## Terminal behavior
+
+### Successful completion
+
+- the final result is delivered exactly once;
+- listeners are removed;
+- native and JavaScript ownership are released;
+- `onComplete` is invoked once;
+- the hook can start a later generation.
+
+### Generation error
+
+- the matching request receives `onError`;
+- listeners and ownership are released;
+- `onComplete` follows as a terminal lifecycle notification;
+- late events are ignored.
+
+### Explicit cancellation
+
+Calling the cancellation function returned by `generate(...)`:
+
+- targets only that generation;
+- releases listeners and ownership;
+- invokes `onComplete` by default;
+- does not emit a final result;
+- is idempotent.
+
+`onComplete` means that the operation ended; it does not mean that generation succeeded. Applications that distinguish success, error, and cancellation should track that state explicitly.
+
+### Component unmount
+
+Unmount cancels only the generation owned by that hook instance. Cleanup is silent: it does not invoke `onComplete` after the component has unmounted.
+
+### Engine close
+
+`close()` owns the engine lifecycle. It may cancel active work, removes listeners, and releases native resources. Generation startup and close are serialized on Android and iOS so a new request cannot enter MediaPipe during teardown.
+
+## Sequential generations
+
+Do not use only `await generate(...)` as the sequencing boundary because that promise resolves after startup. Wait for terminal completion before starting the next request.
+
+See [Sequential asynchronous inference](examples/sequential-async-inference.md) for a complete React example that converts the callback lifecycle into an awaitable application helper and runs two requests from the same mounted hook.
+
+## Resource and security guidance
+
+- Bound token counts, image counts, and image sizes.
+- Cancel work that is no longer visible or relevant.
+- Treat model output as untrusted input.
+- Do not log prompts, generated output, model paths, or image paths unless the application has an explicit safe logging policy.
+- Use `close()` when the application owns the complete engine lifecycle, not as a substitute for request cancellation.

--- a/docs/async-inference.md
+++ b/docs/async-inference.md
@@ -36,6 +36,8 @@ An overlapping call:
 - is not queued;
 - does not cancel or otherwise disturb the active generation.
 
+At the low-level `LlmPipe` API, the overlapping call rejects with `GenerationInProgressError`. `useInferenceAsync` reports the same error through `onError` and returns a no-op cancellation function for the rejected attempt. It does not invoke `onComplete` for that rejected attempt; the already-active generation continues with its original callbacks.
+
 Starting a generation while the native engine is closing is rejected by the same contract.
 
 Sequential calls are supported after the prior operation reaches a terminal state and releases ownership.

--- a/docs/async-inference.md
+++ b/docs/async-inference.md
@@ -21,7 +21,7 @@ const generate = useInferenceAsync({
 const cancel = await generate({ prompt, images });
 ```
 
-`await generate(...)` waits for validation and native startup. It does **not** wait for the model to finish. Use `onComplete`, the final `onResult(..., true)` callback, or an application wrapper to await terminal completion.
+`await generate(...)` waits for validation and native startup. It does **not** wait for the model to finish. The final `onResult(..., true)` callback delivers the complete output, while `onComplete` is the safe boundary for immediately starting another request. Do not start the next request synchronously from inside the final `onResult` callback; hook ownership is released immediately after that callback returns.
 
 The returned function cancels only the generation started by that call. Calling it more than once, or after settlement, is a no-op.
 
@@ -86,10 +86,9 @@ A configured protocol sanitizes the accumulated hook output before `onResult` is
 ### Successful completion
 
 - the final result is delivered exactly once;
-- listeners are removed;
-- native and JavaScript ownership are released;
+- after the final callback returns, listeners are removed and ownership is released;
 - `onComplete` is invoked once;
-- the hook can start a later generation.
+- the hook can start a later generation from `onComplete` or afterward.
 
 ### Generation error
 
@@ -120,7 +119,7 @@ Unmount cancels only the generation owned by that hook instance. Cleanup is sile
 
 ## Sequential generations
 
-Do not use only `await generate(...)` as the sequencing boundary because that promise resolves after startup. Wait for terminal completion before starting the next request.
+Do not use only `await generate(...)` as the sequencing boundary because that promise resolves after startup. Use `onComplete`, or an application promise resolved by the terminal callbacks, before starting the next request. Avoid directly re-entering `generate` from inside the final `onResult` callback.
 
 See [Sequential asynchronous inference](examples/sequential-async-inference.md) for a complete React example that converts the callback lifecycle into an awaitable application helper and runs two requests from the same mounted hook.
 

--- a/docs/examples/sequential-async-inference.md
+++ b/docs/examples/sequential-async-inference.md
@@ -1,0 +1,131 @@
+# Sequential asynchronous inference
+
+`useInferenceAsync` supports repeated calls from the same mounted hook, but `await generate(...)` resolves after native startup rather than model completion. This example wraps the callback lifecycle in an application-level promise and runs two requests sequentially.
+
+```tsx
+import React, { useCallback, useRef, useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import {
+  GenerationInProgressError,
+  useInferenceAsync,
+} from '@micrantha/react-native-amaryllis';
+
+type PendingGeneration = {
+  latestText: string;
+  resolve: (text: string) => void;
+  reject: (error: Error) => void;
+};
+
+export function SequentialInferenceExample() {
+  const [currentText, setCurrentText] = useState('');
+  const [responses, setResponses] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const pendingRef = useRef<PendingGeneration | null>(null);
+
+  const generate = useInferenceAsync({
+    onResult: (text) => {
+      // Hook results are cumulative snapshots. Replace the displayed text.
+      setCurrentText(text);
+      if (pendingRef.current) {
+        pendingRef.current.latestText = text;
+      }
+    },
+    onError: (generationError) => {
+      const pending = pendingRef.current;
+      pendingRef.current = null;
+      pending?.reject(generationError);
+    },
+    onComplete: () => {
+      const pending = pendingRef.current;
+      pendingRef.current = null;
+      pending?.resolve(pending.latestText);
+    },
+  });
+
+  const runOne = useCallback(
+    (prompt: string) =>
+      new Promise<string>((resolve, reject) => {
+        if (pendingRef.current) {
+          reject(new GenerationInProgressError());
+          return;
+        }
+
+        pendingRef.current = {
+          latestText: '',
+          resolve,
+          reject,
+        };
+        setCurrentText('');
+
+        // This promise resolves after validation and native startup. The
+        // outer application promise resolves from onComplete instead.
+        void generate({ prompt }).catch((unknownError: unknown) => {
+          const pending = pendingRef.current;
+          pendingRef.current = null;
+          pending?.reject(
+            unknownError instanceof Error
+              ? unknownError
+              : new Error('Unknown generation error')
+          );
+        });
+      }),
+    [generate]
+  );
+
+  const runSequentially = useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    setResponses([]);
+
+    try {
+      const first = await runOne('Name one benefit of on-device inference.');
+      setResponses([first]);
+
+      // The first request has reached a terminal state and released the
+      // single-flight lock before the second request starts.
+      const second = await runOne('Name one risk that local inference does not remove.');
+      setResponses([first, second]);
+    } catch (generationError) {
+      setError(
+        generationError instanceof Error
+          ? generationError.message
+          : 'Unknown generation error'
+      );
+    } finally {
+      setRunning(false);
+    }
+  }, [runOne]);
+
+  return (
+    <View>
+      <Button
+        title={running ? 'Generating…' : 'Run two requests'}
+        disabled={running}
+        onPress={() => void runSequentially()}
+      />
+
+      <Text>Current stream: {currentText}</Text>
+      {responses.map((response, index) => (
+        <Text key={index}>Response {index + 1}: {response}</Text>
+      ))}
+      {error ? <Text>Generation failed: {error}</Text> : null}
+    </View>
+  );
+}
+```
+
+## Why the wrapper is necessary
+
+The hook's returned `generate` function starts one request and returns its cancellation function. Completion is reported through callbacks. The `runOne` helper turns those callbacks into a promise without changing Amaryllis ownership rules.
+
+The example also demonstrates these requirements:
+
+- one mounted hook performs multiple sequential generations;
+- each request starts with an empty output buffer;
+- displayed text is replaced with each cumulative hook result;
+- the second request starts only after `onComplete` releases the first;
+- an accidental overlapping application call receives `GenerationInProgressError`;
+- errors reject the application wrapper rather than being treated as successful completion.
+
+For cancellation, retain the function returned by `generate(...)` and track a separate cancelled state. An explicit cancellation terminates the operation and invokes `onComplete`, but it does not produce a final result.

--- a/docs/examples/sequential-async-inference.md
+++ b/docs/examples/sequential-async-inference.md
@@ -119,6 +119,8 @@ export function SequentialInferenceExample() {
 
 The hook's returned `generate` function starts one request and returns its cancellation function. Completion is reported through callbacks. The `runOne` helper turns those callbacks into a promise without changing Amaryllis ownership rules.
 
+The wrapper resolves from `onComplete`, not directly from the final `onResult`, because `onComplete` runs after the hook releases its local active-generation guard. The final result callback supplies the complete text, but synchronous re-entry from inside that callback would still be rejected.
+
 The example also demonstrates these requirements:
 
 - one mounted hook performs multiple sequential generations;

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,16 +265,24 @@
             <pre><code>import { useInferenceAsync } from '@micrantha/react-native-amaryllis';
 
 const generate = useInferenceAsync({
-  onResult: (chunk, isFinal) =&gt; {
-    append(chunk);
+  onResult: (text, isFinal) =&gt; {
+    setOutput(text);
     if (isFinal) finish();
   },
   onError: handleError,
+  onComplete: handleComplete,
 });
 
-await generate({ prompt, images });</code></pre>
+const cancel = await generate({ prompt, images });</code></pre>
           </div>
         </div>
+        <p>
+          Hook results are cumulative snapshots, so replace displayed text rather than
+          appending it. Awaiting <code>generate</code> waits for startup, not final model
+          output. Review the
+          <a href="https://github.com/hackelia-micrantha/amaryllis/blob/main/docs/async-inference.md">asynchronous inference lifecycle</a>
+          for completion, cancellation, and single-flight semantics.
+        </p>
       </section>
 
       <section class="section callout">

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -151,13 +151,16 @@ export type InferenceProps = {
   /**
    * Receives the complete accumulated output produced so far. Replace displayed
    * text rather than appending this value. `isFinal` is true exactly once for a
-   * successful generation and that result contains the complete final output.
+   * successful asynchronous generation and that result contains the complete
+   * final output.
    */
   onResult?: (result: string, isFinal: boolean) => void;
   onError?: (error: Error) => void;
   /**
-   * Terminal lifecycle notification for success, error, or explicit
-   * cancellation. Completion does not by itself imply successful generation.
+   * `useInferenceAsync` invokes this after success, error, or explicit
+   * cancellation. It is a terminal lifecycle notification and does not by
+   * itself imply successful generation. Other hooks may use it only from their
+   * documented cleanup paths.
    */
   onComplete?: () => void;
 };

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -3,17 +3,30 @@ import type { Observable } from 'rxjs';
 
 export type LlmNativeEngine = Spec;
 
+/**
+ * Low-level asynchronous engine event.
+ *
+ * Partial and final text values are incremental deltas. Consumers that use
+ * `onEvent` directly must accumulate them. `useInferenceAsync` performs that
+ * accumulation and exposes cumulative snapshots through `onResult`.
+ */
 export type LlmEvent =
   | { type: 'partial'; text: string }
   | { type: 'final'; text: string }
   | { type: 'error'; error: Error };
 
 export type LlmCallbacks = {
-  // Async streaming callbacks
+  /**
+   * Low-level request-scoped event callback. Partial and final text values are
+   * deltas; the final delta may be empty.
+   */
   onEvent?: (event: LlmEvent) => void;
-  /** @deprecated Use onEvent instead. */
+  /** @deprecated Use onEvent instead. Receives an incremental text delta. */
   onPartialResult?: (result: string) => void;
-  /** @deprecated Use onEvent instead. */
+  /**
+   * @deprecated Use onEvent or useInferenceAsync instead. Receives the complete
+   * accumulated final output.
+   */
   onFinalResult?: (result: string) => void;
   /** @deprecated Use onEvent instead. */
   onError?: (err: Error) => void;
@@ -73,7 +86,12 @@ export type LlmEngine = {
   generate(params: LlmRequestParams): Promise<string>;
 
   /**
-   * Generate a response asynchronously (streaming).
+   * Start an asynchronous request-scoped generation.
+   *
+   * The promise resolves after validation and native startup, not after the
+   * model reaches a terminal state. Observe callbacks for results and
+   * completion. Only one synchronous or asynchronous generation may own a
+   * native module at a time.
    */
   generateAsync(
     params: LlmRequestParams,
@@ -81,10 +99,15 @@ export type LlmEngine = {
   ): Promise<void>;
 
   /**
-   * Clean up resources.
+   * Clean up resources. Closing may cancel active work owned by this engine.
    */
   close(): void;
 
+  /**
+   * Cancel the asynchronous generation owned by this engine. The operation is
+   * request-scoped and is a no-op after settlement or when no owned request is
+   * active.
+   */
   cancelAsync(): void;
 
   /**
@@ -125,12 +148,22 @@ export interface LLMProviderProps {
 
 export type InferenceProps = {
   onGenerate?: () => void;
+  /**
+   * Receives the complete accumulated output produced so far. Replace displayed
+   * text rather than appending this value. `isFinal` is true exactly once for a
+   * successful generation and that result contains the complete final output.
+   */
   onResult?: (result: string, isFinal: boolean) => void;
   onError?: (error: Error) => void;
+  /**
+   * Terminal lifecycle notification for success, error, or explicit
+   * cancellation. Completion does not by itself imply successful generation.
+   */
   onComplete?: () => void;
 };
 
 export interface LLMResult {
+  /** Complete accumulated output produced so far. */
   text: string;
   isFinal: boolean;
 }


### PR DESCRIPTION
## Summary

Completes issue #62 slice 4 by documenting the request-scoped asynchronous inference contract now implemented across JavaScript, Android, and iOS.

- defines single-flight ownership and `GenerationInProgressError`
- documents internal request correlation and stale-event rejection
- distinguishes low-level delta events from cumulative `useInferenceAsync.onResult` snapshots
- defines success, error, cancellation, unmount, and engine-close behavior
- clarifies that `await generate(...)` waits for startup rather than terminal model output
- adds a complete example that performs two sequential requests from one mounted hook
- aligns exported type comments, the README quickstart, and the public-site snippet

## Important API clarification

`useInferenceAsync.onResult` receives the complete accumulated output produced so far. Consumers should replace displayed text rather than append it.

`LlmCallbacks.onEvent` remains the low-level delta interface. Direct consumers must accumulate partial and final deltas themselves; the final delta may be empty.

## Review fix

Manual review identified a re-entrancy boundary that needed clearer wording. The final `onResult(..., true)` callback delivers complete output before the hook clears its local active-generation guard. Documentation now states that `onComplete` is the safe boundary for immediately starting another request and warns against synchronously re-entering `generate` from the final result callback.

Earlier iOS attempts were cancelled by the workflow's expected `cancel-in-progress` behavior when this branch received newer commits. The final-head iOS run completed successfully; the cancelled attempts contained no compiler or test failure.

## Files

- `docs/async-inference.md`
- `docs/examples/sequential-async-inference.md`
- `src/Types.ts`
- `README.md`
- `docs/index.html`

## Validation

All applicable checks pass on head `d645ce17ba36396cf71a5a3c44d570bab16a5045`:

- CI run `30803170678`
  - change-classifier contract tests
  - root lint and typecheck
  - JavaScript unit tests
  - main package build, metadata validation, and archive dry-run
  - Android native lifecycle tests and example build
  - iOS native lifecycle tests and example build
  - stable components acknowledgement path
- Compatibility Matrix run `30803170664`
- Coverage Gate run `30803171068`
- Security - CodeQL run `30803171261`

No inline review threads remain unresolved. Automated Codex review was unavailable because its review quota was exhausted; the final diff was reviewed manually and validated by the full applicable CI matrix.

Refs #62