### PR TITLE
ci: migrate GitHub Actions to Node 24 releases

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: .nvmrc
         registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Wait for required workflows
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TARGET_SHA: ${{ github.sha }}
           REQUIRED_WORKFLOWS: '["CI","Dependency Audit","Security - CodeQL"]'
@@ -103,7 +103,7 @@ jobs:
             }
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -87,6 +87,34 @@ jobs:
 
       - name: Comment coverage result on PR
         if: always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: actions/github-script@v9
         with:
-          path: coverage-comment.md
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- amaryllis-coverage-gate -->';
+            const summary = fs.existsSync('coverage-comment.md')
+              ? fs.readFileSync('coverage-comment.md', 'utf8')
+              : '### Coverage Summary\n\nCoverage execution failed before a summary was generated.';
+            const body = `${marker}\n${summary}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.startsWith(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -31,7 +31,7 @@ jobs:
       changed_count: ${{ steps.classify.outputs.changed_count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -111,7 +111,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -133,7 +133,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_components == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         if: needs.changes.outputs.run_components == 'true'
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload components test log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: components-test-log
           path: components-test.log
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload components lint log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: components-lint-log
           path: components-lint.log
@@ -210,7 +210,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -237,13 +237,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/android
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for Android
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
@@ -260,7 +260,7 @@ jobs:
 
       - name: Install JDK
         if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -275,7 +275,7 @@ jobs:
 
       - name: Cache Gradle
         if: env.turbo_cache_hit != 1
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/wrapper
@@ -300,13 +300,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for iOS
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -254,8 +254,8 @@ jobs:
         run: |
           TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir=\"${{ env.TURBO_CACHE_DIR }}\" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
 
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+          if [[ "$TURBO_CACHE_STATUS" == "HIT" ]]; then
+            echo "turbo_cache_hit=1" >> "$GITHUB_ENV"
           fi
 
       - name: Install JDK
@@ -266,7 +266,7 @@ jobs:
           java-version: '17'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Create local.properties
         run: |
@@ -317,8 +317,8 @@ jobs:
         run: |
           TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:ios --cache-dir=\"${{ env.TURBO_CACHE_DIR }}\" --dry=json)).tasks.find(t => t.task === 'build:ios').cache.status")
 
-          if [[ $TURBO_CACHE_STATUS == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> $GITHUB_ENV
+          if [[ "$TURBO_CACHE_STATUS" == "HIT" ]]; then
+            echo "turbo_cache_hit=1" >> "$GITHUB_ENV"
           fi
 
       - name: Use appropriate Xcode version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     environment: production
     steps:
       - name: Wait for required workflows
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TARGET_SHA: ${{ github.sha }}
           REQUIRED_WORKFLOWS: '["CI","Dependency Audit","Security - CodeQL"]'
@@ -90,7 +90,7 @@ jobs:
             }
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup dependencies
         uses: ./.github/actions/setup
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload SBOM artifacts
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: amaryllis-sbom-cyclonedx
           path: |
@@ -104,7 +104,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup dependencies
         uses: ./.github/actions/setup
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Lint workflow files
         uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Lint workflow files
         uses: reviewdog/action-actionlint@v1
         with:
-          fail_on_error: true
+          fail_level: error

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -109,7 +109,7 @@ test('native jobs remain controlled by the native dimension', () => {
   }
 });
 
-test('first-party JavaScript actions use Node 24-native majors', () => {
+test('workflow actions use Node 24-compatible releases', () => {
   const obsoleteActions = [
     ['actions/checkout', /actions\/checkout@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
     ['actions/setup-node', /actions\/setup-node@v[1-6]\b/],
@@ -118,6 +118,8 @@ test('first-party JavaScript actions use Node 24-native majors', () => {
     ['actions/upload-artifact', /actions\/upload-artifact@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
     ['actions/github-script', /actions\/github-script@v[1-8]\b/],
     ['github/codeql-action', /github\/codeql-action\/(?:init|autobuild|analyze)@v[1-3]\b/],
+    ['android-actions/setup-android', /android-actions\/setup-android@v[1-3]\b/],
+    ['marocchino/sticky-pull-request-comment', /marocchino\/sticky-pull-request-comment@/],
   ];
 
   for (const [path, source] of actionSources) {
@@ -129,6 +131,10 @@ test('first-party JavaScript actions use Node 24-native majors', () => {
   const setup = actionSources.get('.github/actions/setup/action.yml');
   assert.ok(setup, 'missing composite setup action');
   assert.match(setup, /actions\/setup-node@v7\b/);
+
+  const coverage = actionSources.get('.github/workflows/coverage-gate.yml');
+  assert.ok(coverage, 'missing coverage workflow');
+  assert.match(coverage, /actions\/github-script@v9\b/);
 
   const sbom = actionSources.get('.github/workflows/sbom.yml');
   assert.ok(sbom, 'missing SBOM workflow');

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import test from 'node:test';
 
 const workflow = readFileSync('.github/workflows/primary-ci.yml', 'utf8');
@@ -26,6 +27,28 @@ function assertContainsAll(block, snippets) {
     assert.match(block, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 }
+
+function collectYamlFiles(directory) {
+  const files = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectYamlFiles(path));
+    } else if (/\.ya?ml$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+const actionSources = new Map(
+  [
+    ...collectYamlFiles('.github/workflows'),
+    ...collectYamlFiles('.github/actions'),
+  ].map(path => [relative('.', path), readFileSync(path, 'utf8')]),
+);
 
 test('change classifier exposes every CI dimension', () => {
   const changes = jobBlock('changes');
@@ -84,4 +107,37 @@ test('native jobs remain controlled by the native dimension', () => {
       "if: needs.changes.outputs.run_native == 'true'",
     ]);
   }
+});
+
+test('first-party JavaScript actions use Node 24-native majors', () => {
+  const obsoleteActions = [
+    ['actions/checkout', /actions\/checkout@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
+    ['actions/setup-node', /actions\/setup-node@v[1-6]\b/],
+    ['actions/cache', /actions\/cache@v[1-4]\b/],
+    ['actions/setup-java', /actions\/setup-java@v[1-4]\b/],
+    ['actions/upload-artifact', /actions\/upload-artifact@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
+    ['actions/github-script', /actions\/github-script@v[1-8]\b/],
+    ['github/codeql-action', /github\/codeql-action\/(?:init|autobuild|analyze)@v[1-3]\b/],
+  ];
+
+  for (const [path, source] of actionSources) {
+    for (const [action, pattern] of obsoleteActions) {
+      assert.doesNotMatch(source, pattern, `${path} uses an obsolete ${action} release`);
+    }
+  }
+
+  const setup = actionSources.get('.github/actions/setup/action.yml');
+  assert.ok(setup, 'missing composite setup action');
+  assert.match(setup, /actions\/setup-node@v7\b/);
+
+  const sbom = actionSources.get('.github/workflows/sbom.yml');
+  assert.ok(sbom, 'missing SBOM workflow');
+  assert.match(
+    sbom,
+    /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\.0\.1/,
+  );
+  assert.match(
+    sbom,
+    /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/,
+  );
 });


### PR DESCRIPTION
## Summary

Migrates warning-emitting GitHub Actions from Node 20-era releases to Node-24-native equivalents.

- upgrades `actions/checkout` to v7
- upgrades `actions/setup-node` to v7
- upgrades `actions/cache` to v5
- upgrades `actions/setup-java` to v5
- upgrades `actions/upload-artifact` to v7
- upgrades `actions/github-script` to v9
- upgrades `github/codeql-action` to v4
- upgrades `android-actions/setup-android` to v4 after final log review confirmed v3 still targeted Node 20
- replaces `marocchino/sticky-pull-request-comment@v2`, which still targets Node 20, with a request-scoped `actions/github-script@v9` coverage comment updater
- preserves immutable SHA pins in the SBOM workflow using `checkout` v7.0.1 and `upload-artifact` v7.0.1
- replaces deprecated actionlint `fail_on_error` with `fail_level: error`, restoring fail-closed workflow lint behavior
- adds a workflow contract test that scans workflow and composite-action YAML for obsolete or warning-emitting action releases

## Compatibility

All affected workflows use GitHub-hosted runners. Workflow permissions, job names, gating behavior, and event triggers remain stable. The coverage comment keeps one bot-authored marker comment per pull request and updates it on later runs.

`android-actions/setup-android` v4 is the current release line and explicitly migrated its runtime to Node 24.

## Validation

- workflow/action contract tests
- workflow lint with error-level enforcement
- primary CI and native builds
- Node 20/22/24 compatibility matrix
- Coverage Gate and coverage comment update
- CodeQL
- SBOM generation, validation, and artifact upload
- representative log scan confirming upgraded actions no longer emit Node 20 deprecation warnings

Closes #85