### PR TITLE
verify: define v1alpha1 manifest and evidence contract

### DIFF
--- a/docs/examples/verify/android.evidence.json
+++ b/docs/examples/verify/android.evidence.json
@@ -1,0 +1,303 @@
+{
+  "apiVersion": "amaryllis.dev/verify/v1alpha1",
+  "kind": "VerificationEvidence",
+  "metadata": {
+    "id": "verify-android-20260813-001",
+    "createdAt": "2026-08-13T08:10:00Z"
+  },
+  "execution": {
+    "status": "completed",
+    "startedAt": "2026-08-13T08:08:50Z",
+    "endedAt": "2026-08-13T08:10:00Z",
+    "durationMs": 70000,
+    "repetitions": {
+      "requested": 3,
+      "completed": 3
+    }
+  },
+  "subject": {
+    "application": {
+      "id": "com.example.amaryllis-demo",
+      "version": "1.4.0",
+      "buildId": "10400",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "5ab565d71af467eca99a0a976827b2c4bcf66f3d3b15efe71905b245275cad03"
+      }
+    },
+    "runtime": {
+      "package": "@micrantha/react-native-amaryllis",
+      "version": "0.1.7",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "928595919ebb66303eb5a96c0ea1984413451f77f9c7c630d8a6c0e8525d4d87"
+      }
+    },
+    "model": {
+      "id": "gemma3-1b-it-int4",
+      "version": "1",
+      "format": "mediapipe-task",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "af3346c46870e663db46a85fd5a0ee9e60d85df6ae0b0bea6e6e61147ad10889"
+      }
+    }
+  },
+  "environment": {
+    "platform": "android",
+    "os": {
+      "name": "Android",
+      "version": "15",
+      "build": "AP3A.240905.015"
+    },
+    "device": {
+      "manufacturer": "Google",
+      "model": "Pixel 8",
+      "modelCode": "shiba",
+      "architecture": "arm64-v8a",
+      "memoryClassBytes": 8589934592,
+      "capabilities": [
+        "physical-device"
+      ],
+      "correlation": {
+        "scope": "run",
+        "id": "run-device-1"
+      }
+    }
+  },
+  "provenance": {
+    "runner": {
+      "name": "amaryllis-verify",
+      "version": "0.1.0-alpha.1"
+    },
+    "manifestDigest": {
+      "algorithm": "sha256",
+      "value": "fbaa3f9cba4b0c2254775bfb221e2ab124ce49422c8b8c730602b0d6326fae5f"
+    },
+    "collectors": [
+      {
+        "name": "timing",
+        "version": "v1alpha1"
+      },
+      {
+        "name": "process-memory",
+        "version": "v1alpha1"
+      },
+      {
+        "name": "lifecycle",
+        "version": "v1alpha1"
+      }
+    ],
+    "evaluationSuites": [
+      {
+        "id": "quality.chatSmoke",
+        "version": "1.0.0",
+        "digest": {
+          "algorithm": "sha256",
+          "value": "6e5d639dd3815b6804c2442cc659ef024e5f964c569de001f5ae8bce771ba0f6"
+        }
+      }
+    ]
+  },
+  "measurements": [
+    {
+      "name": "timing.initialization.ms",
+      "unit": "ms",
+      "samples": [
+        {
+          "iteration": 1,
+          "value": 1140
+        },
+        {
+          "iteration": 2,
+          "value": 1088
+        },
+        {
+          "iteration": 3,
+          "value": 1102
+        }
+      ],
+      "summary": {
+        "count": 3,
+        "min": 1088,
+        "max": 1140,
+        "mean": 1110,
+        "p50": 1102,
+        "p95": 1136
+      }
+    },
+    {
+      "name": "timing.ttft.ms",
+      "unit": "ms",
+      "samples": [
+        {
+          "iteration": 1,
+          "value": 520
+        },
+        {
+          "iteration": 2,
+          "value": 505
+        },
+        {
+          "iteration": 3,
+          "value": 535
+        }
+      ],
+      "summary": {
+        "count": 3,
+        "min": 505,
+        "max": 535,
+        "mean": 520,
+        "p50": 520,
+        "p95": 533
+      }
+    },
+    {
+      "name": "memory.peakRssBytes",
+      "unit": "bytes",
+      "samples": [
+        {
+          "iteration": 1,
+          "value": 987654321
+        },
+        {
+          "iteration": 2,
+          "value": 1001000000
+        },
+        {
+          "iteration": 3,
+          "value": 995000000
+        }
+      ],
+      "summary": {
+        "count": 3,
+        "min": 987654321,
+        "max": 1001000000,
+        "mean": 994551440.3333334,
+        "p50": 995000000,
+        "p95": 1000400000
+      }
+    },
+    {
+      "name": "storage.modelBytes",
+      "unit": "bytes",
+      "samples": [
+        {
+          "iteration": 1,
+          "value": 612000000
+        }
+      ],
+      "summary": {
+        "count": 1,
+        "min": 612000000,
+        "max": 612000000,
+        "mean": 612000000
+      }
+    }
+  ],
+  "checks": [
+    {
+      "name": "lifecycle.cancelRestart",
+      "status": "pass",
+      "code": "completed"
+    }
+  ],
+  "evaluations": [
+    {
+      "name": "quality.chatSmoke",
+      "status": "pass",
+      "score": 0.91,
+      "unit": "ratio",
+      "code": "threshold-met"
+    }
+  ],
+  "unavailable": [
+    {
+      "kind": "metric",
+      "name": "thermal.maxState",
+      "reason": "unsupported",
+      "message": "Collector unavailable on this runner."
+    }
+  ],
+  "errors": [],
+  "policy": {
+    "profileId": "mobile-chat-reference",
+    "requirements": [
+      {
+        "id": "startup-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.initialization.ms"
+        },
+        "operator": "lte",
+        "value": 2000,
+        "aggregate": "max",
+        "unit": "ms"
+      },
+      {
+        "id": "ttft-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.ttft.ms"
+        },
+        "operator": "lte",
+        "value": 750,
+        "aggregate": "p95",
+        "unit": "ms"
+      },
+      {
+        "id": "memory-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "memory.peakRssBytes"
+        },
+        "operator": "lte",
+        "value": 1610612736,
+        "aggregate": "max",
+        "unit": "bytes"
+      },
+      {
+        "id": "cancel-restart",
+        "severity": "required",
+        "target": {
+          "kind": "check",
+          "name": "lifecycle.cancelRestart"
+        },
+        "operator": "pass"
+      },
+      {
+        "id": "quality-floor",
+        "severity": "required",
+        "target": {
+          "kind": "evaluation",
+          "name": "quality.chatSmoke"
+        },
+        "operator": "gte",
+        "value": 0.85,
+        "unit": "ratio"
+      },
+      {
+        "id": "thermal-observation",
+        "severity": "advisory",
+        "target": {
+          "kind": "metric",
+          "name": "thermal.maxState"
+        },
+        "operator": "present"
+      }
+    ]
+  },
+  "decision": {
+    "status": "warn",
+    "reasons": [
+      {
+        "requirementId": "thermal-observation",
+        "code": "advisory-evidence-unavailable",
+        "message": "Advisory thermal evidence was unavailable."
+      }
+    ]
+  }
+}

--- a/docs/examples/verify/android.evidence.json
+++ b/docs/examples/verify/android.evidence.json
@@ -70,6 +70,10 @@
       "name": "amaryllis-verify",
       "version": "0.1.0-alpha.1"
     },
+    "scenario": {
+      "id": "chat-smoke",
+      "version": "1.0.0"
+    },
     "manifestDigest": {
       "algorithm": "sha256",
       "value": "fbaa3f9cba4b0c2254775bfb221e2ab124ce49422c8b8c730602b0d6326fae5f"

--- a/docs/examples/verify/android.manifest.json
+++ b/docs/examples/verify/android.manifest.json
@@ -1,0 +1,155 @@
+{
+  "apiVersion": "amaryllis.dev/verify/v1alpha1",
+  "kind": "VerificationManifest",
+  "metadata": {
+    "name": "android-chat-reference",
+    "labels": {
+      "profile": "reference"
+    }
+  },
+  "subject": {
+    "application": {
+      "id": "com.example.amaryllis-demo",
+      "version": "1.4.0",
+      "buildId": "10400",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "5ab565d71af467eca99a0a976827b2c4bcf66f3d3b15efe71905b245275cad03"
+      }
+    },
+    "runtime": {
+      "package": "@micrantha/react-native-amaryllis",
+      "version": "0.1.7",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "928595919ebb66303eb5a96c0ea1984413451f77f9c7c630d8a6c0e8525d4d87"
+      }
+    },
+    "model": {
+      "id": "gemma3-1b-it-int4",
+      "version": "1",
+      "format": "mediapipe-task",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "af3346c46870e663db46a85fd5a0ee9e60d85df6ae0b0bea6e6e61147ad10889"
+      }
+    }
+  },
+  "target": {
+    "platform": "android",
+    "minOsVersion": "14",
+    "architectures": [
+      "arm64-v8a"
+    ],
+    "requiredCapabilities": [
+      "physical-device"
+    ]
+  },
+  "scenario": {
+    "id": "chat-smoke",
+    "version": "1.0.0",
+    "timeoutMs": 60000,
+    "warmupRuns": 1,
+    "repetitions": 3,
+    "fixtureRefs": [
+      {
+        "id": "chat-basic",
+        "ref": "fixtures/chat-basic.json",
+        "digest": {
+          "algorithm": "sha256",
+          "value": "178ae36531c4999dcdb1a3a349bf2c88e7ed79e32cd76df1cb4f2e098215ae31"
+        },
+        "evidencePolicy": "exclude-content"
+      }
+    ]
+  },
+  "collect": {
+    "metrics": [
+      "timing.initialization.ms",
+      "timing.ttft.ms",
+      "memory.peakRssBytes",
+      "storage.modelBytes",
+      "thermal.maxState"
+    ],
+    "checks": [
+      "lifecycle.cancelRestart"
+    ],
+    "evaluations": [
+      "quality.chatSmoke"
+    ]
+  },
+  "policy": {
+    "profileId": "mobile-chat-reference",
+    "requirements": [
+      {
+        "id": "startup-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.initialization.ms"
+        },
+        "operator": "lte",
+        "value": 2000,
+        "aggregate": "max",
+        "unit": "ms"
+      },
+      {
+        "id": "ttft-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.ttft.ms"
+        },
+        "operator": "lte",
+        "value": 750,
+        "aggregate": "p95",
+        "unit": "ms"
+      },
+      {
+        "id": "memory-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "memory.peakRssBytes"
+        },
+        "operator": "lte",
+        "value": 1610612736,
+        "aggregate": "max",
+        "unit": "bytes"
+      },
+      {
+        "id": "cancel-restart",
+        "severity": "required",
+        "target": {
+          "kind": "check",
+          "name": "lifecycle.cancelRestart"
+        },
+        "operator": "pass"
+      },
+      {
+        "id": "quality-floor",
+        "severity": "required",
+        "target": {
+          "kind": "evaluation",
+          "name": "quality.chatSmoke"
+        },
+        "operator": "gte",
+        "value": 0.85,
+        "unit": "ratio"
+      },
+      {
+        "id": "thermal-observation",
+        "severity": "advisory",
+        "target": {
+          "kind": "metric",
+          "name": "thermal.maxState"
+        },
+        "operator": "present"
+      }
+    ]
+  },
+  "output": {
+    "path": "artifacts/verify/android-chat-reference.json",
+    "humanSummary": true
+  }
+}

--- a/docs/examples/verify/ios.evidence.json
+++ b/docs/examples/verify/ios.evidence.json
@@ -1,0 +1,176 @@
+{
+  "apiVersion": "amaryllis.dev/verify/v1alpha1",
+  "kind": "VerificationEvidence",
+  "metadata": {
+    "id": "verify-ios-20260813-001",
+    "createdAt": "2026-08-13T08:12:00Z"
+  },
+  "execution": {
+    "status": "completed",
+    "startedAt": "2026-08-13T08:11:00Z",
+    "endedAt": "2026-08-13T08:12:00Z",
+    "durationMs": 60000,
+    "repetitions": {
+      "requested": 2,
+      "completed": 2
+    }
+  },
+  "subject": {
+    "application": {
+      "id": "com.example.amaryllis-demo",
+      "version": "1.4.0",
+      "buildId": "10400",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "a04ac7d67177712aab81e8fb0ad5d128b684652be36bf8ca686239ead4bcc20d"
+      }
+    },
+    "runtime": {
+      "package": "@micrantha/react-native-amaryllis",
+      "version": "0.1.7",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "928595919ebb66303eb5a96c0ea1984413451f77f9c7c630d8a6c0e8525d4d87"
+      }
+    },
+    "model": {
+      "id": "gemma3-1b-it-int4",
+      "version": "1",
+      "format": "mediapipe-task",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "af3346c46870e663db46a85fd5a0ee9e60d85df6ae0b0bea6e6e61147ad10889"
+      }
+    }
+  },
+  "environment": {
+    "platform": "ios",
+    "os": {
+      "name": "iOS",
+      "version": "18.6",
+      "build": "22G86"
+    },
+    "device": {
+      "manufacturer": "Apple",
+      "model": "iPhone 15 Pro",
+      "modelCode": "iPhone16,1",
+      "architecture": "arm64",
+      "capabilities": [
+        "physical-device"
+      ],
+      "correlation": {
+        "scope": "run",
+        "id": "run-device-1"
+      }
+    }
+  },
+  "provenance": {
+    "runner": {
+      "name": "amaryllis-verify",
+      "version": "0.1.0-alpha.1"
+    },
+    "manifestDigest": {
+      "algorithm": "sha256",
+      "value": "9d906bd096aef41411ae25f5158ecb3014b9124b964f8a1b65501ef259ff8ac8"
+    },
+    "collectors": [
+      {
+        "name": "timing",
+        "version": "v1alpha1"
+      },
+      {
+        "name": "lifecycle",
+        "version": "v1alpha1"
+      }
+    ]
+  },
+  "measurements": [
+    {
+      "name": "timing.initialization.ms",
+      "unit": "ms",
+      "samples": [
+        {
+          "iteration": 1,
+          "value": 1260
+        },
+        {
+          "iteration": 2,
+          "value": 1225
+        }
+      ],
+      "summary": {
+        "count": 2,
+        "min": 1225,
+        "max": 1260,
+        "mean": 1242.5,
+        "p50": 1242.5,
+        "p95": 1258.25
+      }
+    }
+  ],
+  "checks": [
+    {
+      "name": "lifecycle.cancelRestart",
+      "status": "pass",
+      "code": "completed"
+    }
+  ],
+  "evaluations": [],
+  "unavailable": [
+    {
+      "kind": "metric",
+      "name": "energy.averageMilliwatts",
+      "reason": "unsupported",
+      "message": "No calibrated energy collector is available for this runner."
+    }
+  ],
+  "errors": [],
+  "policy": {
+    "profileId": "ios-reference",
+    "requirements": [
+      {
+        "id": "startup-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.initialization.ms"
+        },
+        "operator": "lte",
+        "value": 2200,
+        "aggregate": "max",
+        "unit": "ms"
+      },
+      {
+        "id": "energy-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "energy.averageMilliwatts"
+        },
+        "operator": "lte",
+        "value": 2500,
+        "aggregate": "mean",
+        "unit": "mW"
+      },
+      {
+        "id": "cancel-restart",
+        "severity": "required",
+        "target": {
+          "kind": "check",
+          "name": "lifecycle.cancelRestart"
+        },
+        "operator": "pass"
+      }
+    ]
+  },
+  "decision": {
+    "status": "unknown",
+    "reasons": [
+      {
+        "requirementId": "energy-budget",
+        "code": "required-evidence-unavailable",
+        "message": "Required energy evidence was unavailable."
+      }
+    ]
+  }
+}

--- a/docs/examples/verify/ios.evidence.json
+++ b/docs/examples/verify/ios.evidence.json
@@ -69,6 +69,10 @@
       "name": "amaryllis-verify",
       "version": "0.1.0-alpha.1"
     },
+    "scenario": {
+      "id": "chat-smoke",
+      "version": "1.0.0"
+    },
     "manifestDigest": {
       "algorithm": "sha256",
       "value": "9d906bd096aef41411ae25f5158ecb3014b9124b964f8a1b65501ef259ff8ac8"

--- a/docs/examples/verify/ios.manifest.json
+++ b/docs/examples/verify/ios.manifest.json
@@ -1,0 +1,104 @@
+{
+  "apiVersion": "amaryllis.dev/verify/v1alpha1",
+  "kind": "VerificationManifest",
+  "metadata": {
+    "name": "ios-chat-reference"
+  },
+  "subject": {
+    "application": {
+      "id": "com.example.amaryllis-demo",
+      "version": "1.4.0",
+      "buildId": "10400",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "a04ac7d67177712aab81e8fb0ad5d128b684652be36bf8ca686239ead4bcc20d"
+      }
+    },
+    "runtime": {
+      "package": "@micrantha/react-native-amaryllis",
+      "version": "0.1.7",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "928595919ebb66303eb5a96c0ea1984413451f77f9c7c630d8a6c0e8525d4d87"
+      }
+    },
+    "model": {
+      "id": "gemma3-1b-it-int4",
+      "version": "1",
+      "format": "mediapipe-task",
+      "digest": {
+        "algorithm": "sha256",
+        "value": "af3346c46870e663db46a85fd5a0ee9e60d85df6ae0b0bea6e6e61147ad10889"
+      }
+    }
+  },
+  "target": {
+    "platform": "ios",
+    "minOsVersion": "18.0",
+    "architectures": [
+      "arm64"
+    ],
+    "requiredCapabilities": [
+      "physical-device"
+    ]
+  },
+  "scenario": {
+    "id": "chat-smoke",
+    "version": "1.0.0",
+    "timeoutMs": 60000,
+    "warmupRuns": 1,
+    "repetitions": 2
+  },
+  "collect": {
+    "metrics": [
+      "timing.initialization.ms",
+      "energy.averageMilliwatts"
+    ],
+    "checks": [
+      "lifecycle.cancelRestart"
+    ],
+    "evaluations": []
+  },
+  "policy": {
+    "profileId": "ios-reference",
+    "requirements": [
+      {
+        "id": "startup-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "timing.initialization.ms"
+        },
+        "operator": "lte",
+        "value": 2200,
+        "aggregate": "max",
+        "unit": "ms"
+      },
+      {
+        "id": "energy-budget",
+        "severity": "required",
+        "target": {
+          "kind": "metric",
+          "name": "energy.averageMilliwatts"
+        },
+        "operator": "lte",
+        "value": 2500,
+        "aggregate": "mean",
+        "unit": "mW"
+      },
+      {
+        "id": "cancel-restart",
+        "severity": "required",
+        "target": {
+          "kind": "check",
+          "name": "lifecycle.cancelRestart"
+        },
+        "operator": "pass"
+      }
+    ]
+  },
+  "output": {
+    "path": "artifacts/verify/ios-chat-reference.json",
+    "humanSummary": true
+  }
+}

--- a/docs/verify-v1alpha1.md
+++ b/docs/verify-v1alpha1.md
@@ -1,0 +1,617 @@
+# Amaryllis Verify v1alpha1 Contract
+
+## Status
+
+Draft implementation design for #98.
+
+Parent architecture: [Production Verification and Compatibility Evidence](./production_verification_rfc.md).
+
+Related security boundary: #99.
+
+Future model-artifact lifecycle alignment: #101.
+
+## Purpose
+
+This document turns the production-verification RFC into a concrete `v1alpha1` contract without introducing hosted infrastructure, a device farm, or a model registry.
+
+The contract answers one question:
+
+> Can this exact application/runtime/model configuration run on this target environment within application-defined operational and quality requirements?
+
+The primary output is a portable `VerificationEvidence` document. A human-readable report, CI gate, future hosted orchestrator, or governance consumer is a view or consumer of that same evidence.
+
+## Decisions
+
+### Canonical interchange format
+
+The canonical contract is **JSON Schema 2020-12**, stored under:
+
+```text
+schemas/verify/v1alpha1/
+  common.schema.json
+  manifest.schema.json
+  evidence.schema.json
+```
+
+JSON Schema is preferred over a TypeScript- or Zod-only source of truth because Verify crosses Node tooling, React Native, Android, iOS, customer-owned runners, and possible future non-JavaScript consumers.
+
+TypeScript types and validators may be generated or wrapped from these schemas, but they must not become a second divergent contract.
+
+### Strict schema by default
+
+`v1alpha1` rejects unknown fields with `additionalProperties: false` on contract objects.
+
+There is intentionally no generic `extensions` or arbitrary metadata bag in evidence. This is both a compatibility and privacy decision: a collector must not be able to silently add prompts, model output, raw logs, or new telemetry fields to an otherwise valid evidence document.
+
+New evidence fields require an explicit schema revision.
+
+### Package boundary
+
+When implementation begins, Verify should remain outside the production mobile bundle:
+
+```text
+@micrantha/amaryllis-verify
+  - schema validation
+  - runner orchestration
+  - policy evaluation
+  - evidence generation
+  - CLI
+
+@micrantha/react-native-amaryllis
+  - application/runtime under test
+  - Android/iOS harness or platform adapter integration
+  - native lifecycle behavior
+```
+
+A future `@micrantha/amaryllis-verify` package is preferable to adding a Node-oriented verification CLI to either the React Native runtime or `amaryllis-components` package.
+
+The schemas remain repository-level public artifacts so other implementations do not need the Node package to interpret evidence.
+
+This package split is a design target, not a requirement to create the package in this PR.
+
+## Execution model
+
+The runner has one bounded lifecycle:
+
+```text
+manifest
+  -> schema + semantic validation
+  -> resolve exact subject identities/digests
+  -> discover adapter capabilities
+  -> prepare target
+  -> warmup
+  -> run repetitions
+  -> collect measurements/checks
+  -> execute local evaluation suites
+  -> derive summaries
+  -> evaluate application policy
+  -> cleanup
+  -> validate evidence
+  -> write evidence
+```
+
+A future remote service may schedule this runner, but it should not replace the runner contract or produce a hosted-only evidence format.
+
+## Runner boundary
+
+The implementation should preserve a narrow orchestration/adapter split equivalent to:
+
+```ts
+interface VerifyRunner {
+  run(
+    manifest: VerificationManifest,
+    adapter: PlatformAdapter,
+    signal?: AbortSignal
+  ): Promise<VerificationEvidence>;
+}
+
+interface PlatformAdapter {
+  capabilities(): Promise<AdapterCapabilities>;
+  prepare(context: RunContext): Promise<void>;
+  warmup(context: RunContext, iteration: number): Promise<void>;
+  execute(context: RunContext, iteration: number): Promise<IterationResult>;
+  cleanup(context: RunContext): Promise<void>;
+}
+```
+
+The exact TypeScript names are not normative. The required separation is:
+
+- the **runner** owns orchestration, timeouts, repetitions, aggregation, policy, evidence assembly, and cancellation;
+- the **adapter** owns platform/device launch and collection mechanisms;
+- collectors expose capability support explicitly rather than fabricating unavailable metrics;
+- semantic/model-quality evaluators return bounded status/score evidence, not raw model content.
+
+## Cancellation and cleanup
+
+Runner cancellation must be fail-explicit:
+
+1. stop starting new iterations;
+2. attempt bounded cancellation of active target work;
+3. run bounded cleanup;
+4. emit `execution.status: cancelled` when a valid evidence artifact can still be assembled;
+5. mark required facts that were not established as unavailable/cancelled;
+6. derive `unknown` unless independent positive failure evidence already establishes `fail`.
+
+A runner/tool crash that prevents a structurally and semantically valid evidence document from being produced is a tool failure, not a compatibility decision.
+
+## Verification manifest
+
+A `VerificationManifest` declares the requested verification work. It includes:
+
+- exact application identity;
+- exact Amaryllis/runtime identity;
+- exact model digest;
+- Android or iOS target constraints;
+- scenario identity and version;
+- timeout, warmup, and repetition policy;
+- fixture references rather than embedded fixture content;
+- requested metrics, checks, and evaluations;
+- application-owned compatibility requirements;
+- optional local output settings.
+
+See:
+
+- `schemas/verify/v1alpha1/manifest.schema.json`
+- `docs/examples/verify/android.manifest.json`
+- `docs/examples/verify/ios.manifest.json`
+
+### Fixture references
+
+Fixture content may contain prompts, images, context, or other application data needed to execute a scenario. The manifest therefore references fixtures rather than embedding them into evidence.
+
+Rules:
+
+- fixture references must not embed credentials or bearer tokens;
+- a digest should be supplied when reproducibility requires exact fixture identity;
+- `evidencePolicy: exclude-content` is the only `v1alpha1` evidence policy;
+- the runner may read fixture content locally but must not copy it into ordinary evidence;
+- evaluation suites may consume local output and reduce it to bounded score/status evidence.
+
+## Evidence envelope
+
+A `VerificationEvidence` document contains these independent concerns:
+
+```text
+metadata       evidence identity
+execution      runner completion/partial/failure/cancellation state
+subject        application + runtime + model identity
+environment    actual OS/device environment
+provenance     runner + scenario + manifest + collector/evaluator identity
+measurements   numeric samples + summaries
+checks         deterministic behavioral outcomes
+evaluations    bounded semantic/application-quality outcomes
+unavailable    facts that could not be established
+errors         bounded sanitized operational errors
+policy         application requirements used for the decision
+decision       pass | warn | fail | unknown
+integrity      optional detached-attestation preparation
+```
+
+A valid JSON document does not imply a successful run or a passing decision.
+
+## Subject identity
+
+The subject is compound:
+
+```text
+application/build + Amaryllis runtime + model artifact
+```
+
+The model requires a SHA-256 digest in `v1alpha1`. A filename, URL, model name, or mutable tag is insufficient as the authoritative artifact identity.
+
+Application/runtime digests are optional when an immutable build/package digest is not available, but their explicit version/build identities remain required as defined by the schemas.
+
+#101 should reuse or supersede this model identity when the model-artifact manifest is defined. Verify must not invent a separate model identity namespace.
+
+## Environment identity
+
+Evidence records the actual environment, not just the requested target:
+
+- platform;
+- OS version/build;
+- manufacturer;
+- model/model code;
+- architecture;
+- relevant capability metadata;
+- optional bounded correlation identity.
+
+### Device correlation privacy
+
+The schema intentionally has no serial number, IMEI, advertising identifier, or platform-global device identifier.
+
+If correlation is required, `environment.device.correlation` supports only:
+
+- `run` scope; or
+- `project` scope.
+
+An implementation should generate the narrowest-scoped pseudonymous identity that satisfies the comparison requirement.
+
+## Measurements
+
+`measurements` are numeric series. Each metric contains:
+
+- stable metric name;
+- canonical unit;
+- raw per-iteration numeric samples;
+- derived summary.
+
+Raw samples are retained because an aggregate alone can hide failures and make later statistical changes impossible to reproduce.
+
+Initial metric identifiers should remain small and high-signal. Candidate reserved identifiers include:
+
+```text
+timing.initialization.ms
+timing.ttft.ms
+timing.generation.ms
+throughput.tokensPerSecond
+memory.peakRssBytes
+storage.modelBytes
+```
+
+Additional battery/energy/thermal/accelerator metrics should be introduced only when the platform collector has defensible semantics.
+
+A reserved metric identifier must define one canonical unit. Semantic validation must reject a reserved metric paired with a conflicting unit.
+
+## Checks
+
+`checks` represent deterministic or categorical runtime invariants that do not naturally reduce to a scalar metric.
+
+Initial examples include:
+
+```text
+lifecycle.cancelRestart
+lifecycle.closeDuringGeneration
+lifecycle.reinitializeAfterFailure
+runtime.requestCompletes
+runtime.noCrash
+runtime.noOom
+```
+
+A check status is:
+
+```text
+pass | fail | unknown
+```
+
+The evidence message is optional, bounded, and sanitized. Raw logs are not part of the canonical evidence artifact.
+
+## Evaluations
+
+`evaluations` represent application/model-quality assessments.
+
+An evaluation may contain:
+
+- stable evaluation name;
+- `pass | fail | unknown` status;
+- bounded numeric score;
+- unit such as `ratio`;
+- machine-readable code.
+
+Evaluation-suite identity/version/digest belongs in provenance.
+
+The evidence does not contain the prompt, generated response, retrieved context, or user content used to compute the score.
+
+This separation allows a quality suite to run locally over sensitive content while retaining only the minimum result needed for a compatibility decision.
+
+## Unavailable evidence
+
+Unsupported or failed collection is first-class evidence:
+
+```json
+{
+  "kind": "metric",
+  "name": "energy.averageMilliwatts",
+  "reason": "unsupported"
+}
+```
+
+Supported reasons are intentionally bounded:
+
+```text
+unsupported
+collector-failed
+not-run
+cancelled
+insufficient-samples
+```
+
+A required target must never disappear silently. It must either have evidence or an explicit unavailable record.
+
+## Execution status vs compatibility decision
+
+These are separate state machines.
+
+### Execution status
+
+```text
+completed | partial | failed | cancelled
+```
+
+Execution status describes the verification operation.
+
+### Compatibility decision
+
+```text
+pass | warn | fail | unknown
+```
+
+Compatibility status describes application policy against the available evidence.
+
+Examples:
+
+- a completed run can be `fail` because latency exceeded budget;
+- a completed run can be `unknown` because a required collector was unsupported;
+- a partial run can be `fail` if a crash definitively violated a required check;
+- a cancelled run will normally be `unknown` because required evidence is incomplete.
+
+## Decision precedence
+
+The policy evaluator should use this precedence:
+
+```text
+known required violation  -> fail
+required evidence missing -> unknown
+advisory violation/missing -> warn
+otherwise                  -> pass
+```
+
+If both a known required violation and an unknown required fact exist, `fail` wins because a blocking violation is already established. Reasons should still include the unknown requirement.
+
+This gives the stable ordering:
+
+```text
+fail > unknown > warn > pass
+```
+
+All `fail` and `unknown` states block a normal compatibility promotion workflow. `warn` remains application policy; a caller may choose to fail CI on warnings separately.
+
+## Requirement semantics
+
+The JSON Schema validates the shape of requirements. A semantic validator must additionally enforce operator/type rules.
+
+### Numeric comparisons
+
+For `lte`, `lt`, `gte`, and `gt`:
+
+- `value` must be numeric;
+- metric targets must specify a compatible `aggregate` and canonical unit;
+- evaluation targets may compare a bounded numeric score;
+- check targets are invalid.
+
+### Equality
+
+`eq` and `neq` compare a scalar result whose type is defined by the target contract.
+
+### Presence
+
+`present` requires evidence to exist and be valid. It does not compare a value.
+
+### Pass
+
+`pass` is valid for check/evaluation status and requires status `pass`.
+
+### Severity
+
+`required` affects `fail`/`unknown` decisions. `advisory` affects `warn` only.
+
+## Evidence semantic validation
+
+JSON Schema validation is necessary but not sufficient. The Verify implementation must also check at least these invariants:
+
+- requirement IDs are unique;
+- requested metric/check/evaluation IDs are unique;
+- every requirement target is declared for collection/evaluation;
+- every required target has either a result or an explicit unavailable record;
+- no target appears simultaneously as available and unavailable;
+- measurement names are unique;
+- check names are unique;
+- evaluation names are unique;
+- sample iteration numbers are valid for the completed execution;
+- summary `count` matches the samples used;
+- summary values are recomputable from samples under the defined aggregation algorithm;
+- completed repetitions do not exceed requested repetitions;
+- reserved metric IDs use their canonical unit;
+- policy operator/value/aggregate combinations are valid;
+- decision reasons reference declared requirements when `requirementId` is present;
+- the derived decision matches the evidence and policy.
+
+Evidence that fails these invariants is invalid evidence; it must not be repaired by silently converting the result to `unknown`.
+
+## Statistical summaries
+
+`v1alpha1` retains raw samples and permits:
+
+```text
+min
+max
+mean
+p50
+p95
+```
+
+Percentile interpolation must be defined by the implementation and versioned with the runner/collector semantics. CI comparison tools must not assume two differently versioned collectors calculate percentiles identically unless their contract says so.
+
+Historical baseline comparison is intentionally **not embedded** in `v1alpha1` evidence. A comparison tool may compare two independently valid evidence documents. This keeps a single-run artifact self-contained and prevents a mutable baseline pointer from changing the meaning of historical evidence.
+
+## Privacy invariants
+
+The #99 threat-model boundary applies directly to this schema.
+
+`v1alpha1` has no fields for:
+
+- prompts;
+- generated output;
+- retrieved context;
+- embeddings;
+- user media/documents;
+- arbitrary application payloads;
+- credentials/secrets;
+- raw logs.
+
+Because contract objects reject additional properties, these cannot be inserted into a valid evidence document without an explicit schema change.
+
+Bounded `message` fields are for sanitized machine/operator context only. Implementations must treat model/application-originated text as untrusted and must not copy it verbatim into these messages.
+
+## Integrity and attestations
+
+`integrity` is optional in `v1alpha1`.
+
+When present:
+
+- canonicalization is RFC 8785 JSON Canonicalization Scheme;
+- `payloadDigest` is SHA-256 over the canonicalized evidence document **with the `integrity` property omitted**;
+- signatures remain detached;
+- `attestationRefs` may point to an external attestation/signature artifact and optionally identify its digest.
+
+This avoids defining a new signing system inside Verify and leaves room for GitHub artifact attestations, Sigstore-style evidence, or organization-specific signing without changing the core measurement model.
+
+The final trust/signing relationship should align with #101 rather than creating separate model and evidence trust roots unnecessarily.
+
+## Schema evolution
+
+Every artifact identifies:
+
+```text
+apiVersion: amaryllis.dev/verify/v1alpha1
+kind: VerificationManifest | VerificationEvidence
+```
+
+Rules:
+
+- unknown fields are rejected;
+- a change that alters required fields or semantics requires a new API version;
+- platform-specific data must be normalized into shared fields or added in a new schema revision rather than creating separate Android/iOS top-level schemas;
+- old evidence remains interpretable according to its declared API version;
+- hosted tooling must accept/produce the same public schema used by local tooling for a supported API version;
+- no hosted-only evidence fields may become required for local compatibility decisions.
+
+## CLI shape
+
+The first implementation should use a dedicated thin binary rather than adding Node tooling to the production React Native package:
+
+```bash
+amaryllis-verify run \
+  --manifest verify.json \
+  --output evidence.json
+
+amaryllis-verify validate --evidence evidence.json
+
+amaryllis-verify check --evidence evidence.json
+```
+
+### `run`
+
+- validates the manifest;
+- executes the runner locally;
+- writes one evidence document;
+- may print a human-readable summary generated from that evidence;
+- does not require network access.
+
+`run` should return exit code `0` whenever a structurally and semantically valid evidence document was produced, even if its decision is `fail` or `unknown`. This separates runner/tool health from compatibility policy.
+
+### `validate`
+
+Validates schema plus semantic invariants. It does not rerun the target and does not reinterpret compatibility policy.
+
+### `check`
+
+Evaluates the embedded policy/evidence decision for CI gating.
+
+Recommended initial exit codes:
+
+```text
+0   pass or warn
+2   fail
+3   unknown
+64  invalid manifest/evidence/usage
+70  runner/internal failure with no valid evidence artifact
+```
+
+A later `--fail-on-warn` option may be added without changing the evidence schema.
+
+## Human-readable output
+
+Console and Markdown summaries are presentation layers over `VerificationEvidence`.
+
+They must not become a second source of truth and should not attach raw runtime logs by default.
+
+A report should be reproducible from the evidence document alone.
+
+## Android example
+
+The Android example demonstrates:
+
+- exact application/runtime/model identity;
+- numeric timing/memory/storage measurements;
+- a lifecycle check;
+- a local quality evaluation;
+- unavailable advisory thermal evidence;
+- final decision `warn`.
+
+Files:
+
+```text
+docs/examples/verify/android.manifest.json
+docs/examples/verify/android.evidence.json
+```
+
+## iOS example
+
+The iOS example demonstrates fail-safe unavailable evidence:
+
+- initialization evidence is present;
+- cancellation/restart passes;
+- a required energy collector is unsupported;
+- the runner completes;
+- the compatibility decision is `unknown`, not `pass`.
+
+Files:
+
+```text
+docs/examples/verify/ios.manifest.json
+docs/examples/verify/ios.evidence.json
+```
+
+## Initial implementation sequence
+
+After this design is accepted:
+
+1. add schema/meta-schema and example validation to CI;
+2. add negative privacy tests from #99, including rejection of prompt/output/context fields;
+3. implement semantic manifest/evidence validation;
+4. implement policy decision derivation and test precedence;
+5. create the smallest local `amaryllis-verify` runner package/CLI;
+6. add one deterministic fake/platform adapter for runner lifecycle tests;
+7. add one Android and one iOS attached-device execution path;
+8. retain evidence as a CI artifact without requiring hosted infrastructure;
+9. only then evaluate remote orchestration or a managed reference device fleet.
+
+## Non-goals for v1alpha1
+
+- hosted execution;
+- accounts or billing;
+- web dashboard;
+- broad physical-device inventory;
+- fleet telemetry ingestion;
+- remote model deployment;
+- model registry implementation;
+- general mobile-device management;
+- universal model-quality benchmark;
+- automatic safety/compliance certification;
+- raw prompt/output retention;
+- Anthesis dependency.
+
+## Completion criteria for #98
+
+This design satisfies #98 when review confirms:
+
+- one manifest/evidence model represents Android and iOS;
+- exact model identity uses an immutable digest;
+- local execution requires no Amaryllis-hosted service;
+- runner and platform-adapter responsibilities are separated;
+- `pass`, `warn`, `fail`, and `unknown` are unambiguous;
+- required unavailable evidence cannot become `pass`;
+- raw samples remain available for later comparison;
+- privacy-sensitive content is excluded structurally from normal evidence;
+- CLI/tool failure is distinct from compatibility failure;
+- versioning allows future orchestration without a hosted-only contract.

--- a/schemas/verify/v1alpha1/common.schema.json
+++ b/schemas/verify/v1alpha1/common.schema.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Amaryllis Verify v1alpha1 common definitions",
+  "$defs": {
+    "digest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "properties": {
+        "algorithm": {
+          "const": "sha256"
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        }
+      }
+    },
+    "applicationIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "buildId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "runtimeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "package",
+        "version"
+      ],
+      "properties": {
+        "package": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        }
+      }
+    },
+    "modelIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "format",
+        "digest"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "format": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "digest": {
+          "$ref": "#/$defs/digest"
+        },
+        "auxiliaryArtifacts": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "role",
+              "digest"
+            ],
+            "properties": {
+              "role": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "digest": {
+                "$ref": "#/$defs/digest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "application",
+        "runtime",
+        "model"
+      ],
+      "properties": {
+        "application": {
+          "$ref": "#/$defs/applicationIdentity"
+        },
+        "runtime": {
+          "$ref": "#/$defs/runtimeIdentity"
+        },
+        "model": {
+          "$ref": "#/$defs/modelIdentity"
+        }
+      }
+    },
+    "platformTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform"
+      ],
+      "properties": {
+        "platform": {
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "minOsVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "deviceModels": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120
+          }
+        },
+        "architectures": {
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+          }
+        },
+        "requiredCapabilities": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "severity",
+        "target",
+        "operator"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "severity": {
+          "enum": [
+            "required",
+            "advisory"
+          ]
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "name"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "metric",
+                "check",
+                "evaluation"
+              ]
+            },
+            "name": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+            }
+          }
+        },
+        "operator": {
+          "enum": [
+            "lte",
+            "lt",
+            "gte",
+            "gt",
+            "eq",
+            "neq",
+            "present",
+            "pass"
+          ]
+        },
+        "value": {
+          "type": [
+            "number",
+            "integer",
+            "string",
+            "boolean"
+          ]
+        },
+        "aggregate": {
+          "enum": [
+            "min",
+            "max",
+            "mean",
+            "p50",
+            "p95",
+            "all",
+            "any",
+            "last"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 32
+        }
+      }
+    },
+    "sanitizedMessage": {
+      "type": "string",
+      "maxLength": 512
+    }
+  }
+}

--- a/schemas/verify/v1alpha1/evidence.schema.json
+++ b/schemas/verify/v1alpha1/evidence.schema.json
@@ -212,6 +212,7 @@
       "additionalProperties": false,
       "required": [
         "runner",
+        "scenario",
         "manifestDigest",
         "collectors"
       ],
@@ -287,6 +288,25 @@
               "digest": {
                 "$ref": "common.schema.json#/$defs/digest"
               }
+            }
+          }
+        },
+        "scenario": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "version"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
             }
           }
         }
@@ -566,6 +586,49 @@
               },
               "message": {
                 "$ref": "common.schema.json#/$defs/sanitizedMessage"
+              }
+            }
+          }
+        }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonicalization",
+        "payloadDigest"
+      ],
+      "properties": {
+        "canonicalization": {
+          "const": "RFC8785"
+        },
+        "payloadDigest": {
+          "$ref": "common.schema.json#/$defs/digest"
+        },
+        "attestationRefs": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "ref"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "ref": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 500
+              },
+              "digest": {
+                "$ref": "common.schema.json#/$defs/digest"
               }
             }
           }

--- a/schemas/verify/v1alpha1/evidence.schema.json
+++ b/schemas/verify/v1alpha1/evidence.schema.json
@@ -1,0 +1,576 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Amaryllis Verification Evidence v1alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "execution",
+    "subject",
+    "environment",
+    "provenance",
+    "measurements",
+    "checks",
+    "evaluations",
+    "unavailable",
+    "errors",
+    "policy",
+    "decision"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "amaryllis.dev/verify/v1alpha1"
+    },
+    "kind": {
+      "const": "VerificationEvidence"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "createdAt"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "startedAt",
+        "endedAt",
+        "durationMs",
+        "repetitions"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "completed",
+            "partial",
+            "failed",
+            "cancelled"
+          ]
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "endedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "repetitions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "requested",
+            "completed"
+          ],
+          "properties": {
+            "requested": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "completed": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "subject": {
+      "$ref": "common.schema.json#/$defs/subject"
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "os",
+        "device"
+      ],
+      "properties": {
+        "platform": {
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "os": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "version"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "build": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        },
+        "device": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "manufacturer",
+            "model",
+            "architecture"
+          ],
+          "properties": {
+            "manufacturer": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "model": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            },
+            "modelCode": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 120
+            },
+            "architecture": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 50
+            },
+            "memoryClassBytes": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "capabilities": {
+              "type": "array",
+              "uniqueItems": true,
+              "maxItems": 64,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              }
+            },
+            "correlation": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "scope",
+                "id"
+              ],
+              "properties": {
+                "scope": {
+                  "enum": [
+                    "run",
+                    "project"
+                  ]
+                },
+                "id": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner",
+        "manifestDigest",
+        "collectors"
+      ],
+      "properties": {
+        "runner": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name",
+            "version"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          }
+        },
+        "manifestDigest": {
+          "$ref": "common.schema.json#/$defs/digest"
+        },
+        "collectors": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "version"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              }
+            }
+          }
+        },
+        "evaluationSuites": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "version"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "digest": {
+                "$ref": "common.schema.json#/$defs/digest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "measurements": {
+      "type": "array",
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "unit",
+          "samples",
+          "summary"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "unit": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "samples": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1000,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "iteration",
+                "value"
+              ],
+              "properties": {
+                "iteration": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "value": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "summary": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "count",
+              "min",
+              "max",
+              "mean"
+            ],
+            "properties": {
+              "count": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              },
+              "mean": {
+                "type": "number"
+              },
+              "p50": {
+                "type": "number"
+              },
+              "p95": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "status"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "fail",
+              "unknown"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "message": {
+            "$ref": "common.schema.json#/$defs/sanitizedMessage"
+          }
+        }
+      }
+    },
+    "evaluations": {
+      "type": "array",
+      "maxItems": 64,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "status"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "status": {
+            "enum": [
+              "pass",
+              "fail",
+              "unknown"
+            ]
+          },
+          "score": {
+            "type": "number"
+          },
+          "unit": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        }
+      }
+    },
+    "unavailable": {
+      "type": "array",
+      "maxItems": 256,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "name",
+          "reason"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "metric",
+              "check",
+              "evaluation"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "reason": {
+            "enum": [
+              "unsupported",
+              "collector-failed",
+              "not-run",
+              "cancelled",
+              "insufficient-samples"
+            ]
+          },
+          "message": {
+            "$ref": "common.schema.json#/$defs/sanitizedMessage"
+          }
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "phase",
+          "code"
+        ],
+        "properties": {
+          "phase": {
+            "enum": [
+              "setup",
+              "launch",
+              "warmup",
+              "execute",
+              "collect",
+              "evaluate",
+              "cleanup"
+            ]
+          },
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          },
+          "message": {
+            "$ref": "common.schema.json#/$defs/sanitizedMessage"
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requirements"
+      ],
+      "properties": {
+        "profileId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "requirements": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "common.schema.json#/$defs/requirement"
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "reasons"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "pass",
+            "warn",
+            "fail",
+            "unknown"
+          ]
+        },
+        "reasons": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "requirementId": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+              },
+              "code": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+              },
+              "message": {
+                "$ref": "common.schema.json#/$defs/sanitizedMessage"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/verify/v1alpha1/manifest.schema.json
+++ b/schemas/verify/v1alpha1/manifest.schema.json
@@ -164,6 +164,7 @@
         },
         "requirements": {
           "type": "array",
+          "minItems": 1,
           "maxItems": 256,
           "items": {
             "$ref": "common.schema.json#/$defs/requirement"

--- a/schemas/verify/v1alpha1/manifest.schema.json
+++ b/schemas/verify/v1alpha1/manifest.schema.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Amaryllis Verify Manifest v1alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "subject",
+    "target",
+    "scenario",
+    "collect",
+    "policy"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "amaryllis.dev/verify/v1alpha1"
+    },
+    "kind": {
+      "const": "VerificationManifest"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9.-]{0,127}$"
+        },
+        "labels": {
+          "type": "object",
+          "maxProperties": 32,
+          "additionalProperties": {
+            "type": "string",
+            "maxLength": 120
+          }
+        }
+      }
+    },
+    "subject": {
+      "$ref": "common.schema.json#/$defs/subject"
+    },
+    "target": {
+      "$ref": "common.schema.json#/$defs/platformTarget"
+    },
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version",
+        "timeoutMs",
+        "repetitions"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3600000
+        },
+        "warmupRuns": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "default": 0
+        },
+        "repetitions": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "fixtureRefs": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "ref"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+              },
+              "ref": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 500
+              },
+              "digest": {
+                "$ref": "common.schema.json#/$defs/digest"
+              },
+              "evidencePolicy": {
+                "const": "exclude-content"
+              }
+            }
+          }
+        }
+      }
+    },
+    "collect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metrics",
+        "checks"
+      ],
+      "properties": {
+        "metrics": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        },
+        "checks": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 128,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        },
+        "evaluations": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 64,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+          }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requirements"
+      ],
+      "properties": {
+        "profileId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "requirements": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "common.schema.json#/$defs/requirement"
+          }
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "humanSummary": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the design scope of #98 on top of the accepted production-verification RFC (#97) and merged operational-evidence threat boundary (#99/#109).

Adds:

- canonical JSON Schema 2020-12 contracts for Verify `v1alpha1`;
- a shared subject/policy schema plus `VerificationManifest` and `VerificationEvidence` schemas;
- a concrete runner/platform-adapter lifecycle and cancellation boundary;
- explicit execution vs compatibility decision state machines;
- deterministic `pass` / `warn` / `fail` / `unknown` precedence;
- semantic validation requirements beyond JSON Schema shape validation;
- strict privacy invariants with unknown evidence fields rejected;
- optional detached integrity/attestation hooks without inventing a new signing system;
- proposed local CLI/package boundary and exit-code semantics;
- Android and iOS manifest/evidence examples.

## Important examples

The fixtures intentionally demonstrate fail-safe missing evidence:

- Android: an **advisory** thermal measurement is unsupported, so the compatibility result is `warn`.
- iOS: a **required** energy measurement is unsupported, so the compatibility result is `unknown`, never `pass`.

## Contract decisions

- JSON Schema is the language-neutral source of truth rather than a TypeScript/Zod-only schema.
- `v1alpha1` contract objects use `additionalProperties: false`; there is no generic extension/telemetry bag.
- model subject identity requires an immutable SHA-256 digest.
- raw numeric samples remain in evidence alongside summaries.
- fixture content, prompts, generated output, retrieved context, user media, secrets, and raw logs are structurally outside ordinary evidence.
- tool/runner failure is distinct from a valid compatibility `fail` or `unknown` result.
- historical baseline comparison remains outside a single-run evidence artifact.
- signatures remain detached; an optional integrity block uses RFC 8785 canonicalization and SHA-256 references.

## Scope

This remains contract/design work. It does **not** add:

- a Verify runtime/CLI package;
- platform collectors or device adapters;
- hosted execution/device farm;
- model registry/deployment services;
- telemetry ingestion;
- billing/accounts.

## Validation

- schemas were checked as JSON Schema Draft 2020-12 documents;
- Android/iOS manifest and evidence examples were validated against the proposed schemas during design review;
- cross-file review checked required-vs-advisory unavailable semantics and privacy boundaries;
- branch contains only schemas, design documentation, and examples.

## Follow-up

After this contract is accepted, implementation should be split into validation/policy foundations, local runner/CLI, and later attached-device adapters. #99 remains open until schema-level privacy negative tests are implemented.

Closes #98 when merged.