### PR TITLE
verify: validate v1alpha1 contract and privacy invariants

### DIFF
--- a/packages/amaryllis-components/package.json
+++ b/packages/amaryllis-components/package.json
@@ -15,8 +15,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "jest && node --test tools/verify/validator.test.mjs",
     "verify:examples": "node ../../scripts/verify-component-examples.mjs",
+    "verify:contract": "node --test tools/verify/validator.test.mjs",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "prepare": "npm run build"
   },

--- a/packages/amaryllis-components/tools/verify/validator.mjs
+++ b/packages/amaryllis-components/tools/verify/validator.mjs
@@ -1,0 +1,593 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const NUMERIC_OPERATORS = new Set(['lte', 'lt', 'gte', 'gt']);
+const NUMERIC_AGGREGATES = new Set(['min', 'max', 'mean', 'p50', 'p95', 'last']);
+const CHECK_STATUSES = new Set(['pass', 'fail', 'unknown']);
+
+const RESERVED_METRIC_UNITS = new Map([
+  ['timing.initialization.ms', 'ms'],
+  ['timing.ttft.ms', 'ms'],
+  ['timing.generation.ms', 'ms'],
+  ['throughput.tokensPerSecond', 'tokens/s'],
+  ['memory.peakRssBytes', 'bytes'],
+  ['storage.modelBytes', 'bytes'],
+]);
+
+const RFC3339_DATE_TIME =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isRfc3339DateTime(value) {
+  return RFC3339_DATE_TIME.test(value) && Number.isFinite(Date.parse(value));
+}
+
+function readJsonSchema(filePath) {
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`expected JSON object schema in ${filePath}`);
+  }
+  return parsed;
+}
+
+export function loadVerifySchemaBundle(directory) {
+  const absolute = path.resolve(directory);
+  return {
+    common: readJsonSchema(path.join(absolute, 'common.schema.json')),
+    manifest: readJsonSchema(path.join(absolute, 'manifest.schema.json')),
+    evidence: readJsonSchema(path.join(absolute, 'evidence.schema.json')),
+  };
+}
+
+function schemaIssues(errors) {
+  return (errors ?? []).map((error) => ({
+    code: `schema.${error.keyword}`,
+    path: error.instancePath || '/',
+    message: error.message ?? 'schema validation failed',
+  }));
+}
+
+function addIssue(issues, code, issuePath, message) {
+  issues.push({ code, path: issuePath, message });
+}
+
+function hasDuplicates(values) {
+  return new Set(values).size !== values.length;
+}
+
+function targetKey(kind, name) {
+  return `${kind}:${name}`;
+}
+
+export function isLocalPathReference(value) {
+  // Windows drive paths contain a colon but are still local filesystem paths.
+  if (/^[A-Za-z]:[\\/]/.test(value)) {
+    return true;
+  }
+
+  // v1alpha1 references are paths, never URI fetch instructions.
+  return !/^[A-Za-z][A-Za-z0-9+.-]*:/.test(value);
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function approximatelyEqual(left, right) {
+  const tolerance = Math.max(1e-9, Math.abs(right) * 1e-12);
+  return Math.abs(left - right) <= tolerance;
+}
+
+function validateRequirementSemantics(requirement, issuePath, issues) {
+  const { kind } = requirement.target;
+  const { operator } = requirement;
+
+  if (operator === 'present') {
+    if (requirement.value !== undefined) {
+      addIssue(
+        issues,
+        'requirement.present-value',
+        issuePath,
+        '`present` must not define a comparison value'
+      );
+    }
+    if (requirement.aggregate !== undefined) {
+      addIssue(
+        issues,
+        'requirement.present-aggregate',
+        issuePath,
+        '`present` must not define an aggregate'
+      );
+    }
+    return;
+  }
+
+  if (operator === 'pass') {
+    if (kind === 'metric') {
+      addIssue(
+        issues,
+        'requirement.pass-metric',
+        issuePath,
+        '`pass` is only valid for check or evaluation targets'
+      );
+    }
+    if (requirement.value !== undefined || requirement.aggregate !== undefined) {
+      addIssue(
+        issues,
+        'requirement.pass-comparison',
+        issuePath,
+        '`pass` must not define value or aggregate comparison data'
+      );
+    }
+    return;
+  }
+
+  if (NUMERIC_OPERATORS.has(operator)) {
+    if (kind === 'check') {
+      addIssue(
+        issues,
+        'requirement.numeric-check',
+        issuePath,
+        `numeric operator ${operator} is invalid for check targets`
+      );
+      return;
+    }
+
+    if (!isFiniteNumber(requirement.value)) {
+      addIssue(
+        issues,
+        'requirement.numeric-value',
+        issuePath,
+        `numeric operator ${operator} requires a finite numeric value`
+      );
+    }
+
+    if (!requirement.unit) {
+      addIssue(
+        issues,
+        'requirement.numeric-unit',
+        issuePath,
+        `numeric operator ${operator} requires an explicit unit`
+      );
+    }
+
+    if (kind === 'metric') {
+      if (
+        requirement.aggregate === undefined ||
+        !NUMERIC_AGGREGATES.has(requirement.aggregate)
+      ) {
+        addIssue(
+          issues,
+          'requirement.metric-aggregate',
+          issuePath,
+          'numeric metric comparisons require min/max/mean/p50/p95/last aggregation'
+        );
+      }
+    } else if (requirement.aggregate !== undefined) {
+      addIssue(
+        issues,
+        'requirement.evaluation-aggregate',
+        issuePath,
+        'evaluation scores are scalar and must not define an aggregate'
+      );
+    }
+    return;
+  }
+
+  if (operator === 'eq' || operator === 'neq') {
+    if (requirement.value === undefined) {
+      addIssue(
+        issues,
+        'requirement.equality-value',
+        issuePath,
+        `${operator} requires a comparison value`
+      );
+    }
+
+    if (kind === 'metric') {
+      if (!isFiniteNumber(requirement.value)) {
+        addIssue(
+          issues,
+          'requirement.metric-equality-value',
+          issuePath,
+          'metric equality comparisons require a finite numeric value'
+        );
+      }
+      if (
+        requirement.aggregate === undefined ||
+        !NUMERIC_AGGREGATES.has(requirement.aggregate)
+      ) {
+        addIssue(
+          issues,
+          'requirement.metric-aggregate',
+          issuePath,
+          'metric equality comparisons require min/max/mean/p50/p95/last aggregation'
+        );
+      }
+      if (!requirement.unit) {
+        addIssue(
+          issues,
+          'requirement.metric-unit',
+          issuePath,
+          'metric equality comparisons require an explicit unit'
+        );
+      }
+    } else if (kind === 'check') {
+      if (
+        typeof requirement.value !== 'string' ||
+        !CHECK_STATUSES.has(requirement.value)
+      ) {
+        addIssue(
+          issues,
+          'requirement.check-equality-value',
+          issuePath,
+          'check equality comparisons must use pass/fail/unknown status values'
+        );
+      }
+      if (requirement.aggregate !== undefined || requirement.unit !== undefined) {
+        addIssue(
+          issues,
+          'requirement.check-comparison-shape',
+          issuePath,
+          'check equality comparisons must not define aggregate or unit'
+        );
+      }
+    } else if (requirement.aggregate !== undefined) {
+      addIssue(
+        issues,
+        'requirement.evaluation-aggregate',
+        issuePath,
+        'evaluation equality comparisons must not define an aggregate'
+      );
+    }
+  }
+}
+
+function validateManifestSemantics(manifest) {
+  const issues = [];
+  const requirements = manifest.policy.requirements;
+
+  if (requirements.length === 0) {
+    addIssue(
+      issues,
+      'policy.empty',
+      '/policy/requirements',
+      'compatibility policy must contain at least one requirement'
+    );
+  }
+
+  const requirementIds = requirements.map((requirement) => requirement.id);
+  if (hasDuplicates(requirementIds)) {
+    addIssue(
+      issues,
+      'policy.duplicate-requirement-id',
+      '/policy/requirements',
+      'requirement IDs must be unique'
+    );
+  }
+
+  const requested = {
+    metric: new Set(manifest.collect.metrics),
+    check: new Set(manifest.collect.checks),
+    evaluation: new Set(manifest.collect.evaluations ?? []),
+  };
+
+  requirements.forEach((requirement, index) => {
+    const requirementPath = `/policy/requirements/${index}`;
+    validateRequirementSemantics(requirement, requirementPath, issues);
+
+    if (!requested[requirement.target.kind].has(requirement.target.name)) {
+      addIssue(
+        issues,
+        'policy.undeclared-target',
+        `${requirementPath}/target`,
+        `requirement target ${requirement.target.kind}:${requirement.target.name} is not declared for collection/evaluation`
+      );
+    }
+  });
+
+  for (const [index, fixture] of (manifest.scenario.fixtureRefs ?? []).entries()) {
+    if (!isLocalPathReference(fixture.ref)) {
+      addIssue(
+        issues,
+        'manifest.remote-fixture-ref',
+        `/scenario/fixtureRefs/${index}/ref`,
+        'v1alpha1 fixture references must be local filesystem paths; URI/network fetch schemes are not supported'
+      );
+    }
+  }
+
+  if (manifest.output?.path && !isLocalPathReference(manifest.output.path)) {
+    addIssue(
+      issues,
+      'manifest.remote-output-path',
+      '/output/path',
+      'v1alpha1 output path must be a local filesystem path'
+    );
+  }
+
+  return issues;
+}
+
+function validateMeasurementSummary(measurement, index, completedRepetitions, issues) {
+  const measurementPath = `/measurements/${index}`;
+  const values = measurement.samples.map((sample) => sample.value);
+  const iterations = measurement.samples.map((sample) => sample.iteration);
+
+  if (hasDuplicates(iterations.map(String))) {
+    addIssue(
+      issues,
+      'measurement.duplicate-iteration',
+      `${measurementPath}/samples`,
+      'a metric may retain at most one sample for each iteration'
+    );
+  }
+
+  for (const [sampleIndex, sample] of measurement.samples.entries()) {
+    if (sample.iteration < 1 || sample.iteration > completedRepetitions) {
+      addIssue(
+        issues,
+        'measurement.iteration-range',
+        `${measurementPath}/samples/${sampleIndex}/iteration`,
+        `sample iteration must be within completed repetitions 1..${completedRepetitions}`
+      );
+    }
+  }
+
+  if (measurement.summary.count !== values.length) {
+    addIssue(
+      issues,
+      'measurement.summary-count',
+      `${measurementPath}/summary/count`,
+      'summary count must match the number of retained samples'
+    );
+  }
+
+  if (values.length > 0) {
+    const expectedMin = Math.min(...values);
+    const expectedMax = Math.max(...values);
+    const expectedMean = values.reduce((sum, value) => sum + value, 0) / values.length;
+
+    if (!approximatelyEqual(measurement.summary.min, expectedMin)) {
+      addIssue(
+        issues,
+        'measurement.summary-min',
+        `${measurementPath}/summary/min`,
+        'summary min is not reproducible from retained samples'
+      );
+    }
+    if (!approximatelyEqual(measurement.summary.max, expectedMax)) {
+      addIssue(
+        issues,
+        'measurement.summary-max',
+        `${measurementPath}/summary/max`,
+        'summary max is not reproducible from retained samples'
+      );
+    }
+    if (!approximatelyEqual(measurement.summary.mean, expectedMean)) {
+      addIssue(
+        issues,
+        'measurement.summary-mean',
+        `${measurementPath}/summary/mean`,
+        'summary mean is not reproducible from retained samples'
+      );
+    }
+  }
+
+  const reservedUnit = RESERVED_METRIC_UNITS.get(measurement.name);
+  if (reservedUnit && measurement.unit !== reservedUnit) {
+    addIssue(
+      issues,
+      'measurement.canonical-unit',
+      `${measurementPath}/unit`,
+      `reserved metric ${measurement.name} must use canonical unit ${reservedUnit}`
+    );
+  }
+}
+
+function validateEvidenceSemantics(evidence) {
+  const issues = [];
+  const requirements = evidence.policy.requirements;
+
+  if (requirements.length === 0) {
+    addIssue(
+      issues,
+      'policy.empty',
+      '/policy/requirements',
+      'compatibility policy must contain at least one requirement'
+    );
+  }
+
+  const requirementIds = requirements.map((requirement) => requirement.id);
+  if (hasDuplicates(requirementIds)) {
+    addIssue(
+      issues,
+      'policy.duplicate-requirement-id',
+      '/policy/requirements',
+      'requirement IDs must be unique'
+    );
+  }
+
+  if (evidence.execution.repetitions.completed > evidence.execution.repetitions.requested) {
+    addIssue(
+      issues,
+      'execution.repetition-count',
+      '/execution/repetitions/completed',
+      'completed repetitions must not exceed requested repetitions'
+    );
+  }
+
+  const measurementNames = evidence.measurements.map((measurement) => measurement.name);
+  const checkNames = evidence.checks.map((check) => check.name);
+  const evaluationNames = evidence.evaluations.map((evaluation) => evaluation.name);
+
+  if (hasDuplicates(measurementNames)) {
+    addIssue(issues, 'evidence.duplicate-measurement', '/measurements', 'measurement names must be unique');
+  }
+  if (hasDuplicates(checkNames)) {
+    addIssue(issues, 'evidence.duplicate-check', '/checks', 'check names must be unique');
+  }
+  if (hasDuplicates(evaluationNames)) {
+    addIssue(issues, 'evidence.duplicate-evaluation', '/evaluations', 'evaluation names must be unique');
+  }
+
+  evidence.measurements.forEach((measurement, index) =>
+    validateMeasurementSummary(
+      measurement,
+      index,
+      evidence.execution.repetitions.completed,
+      issues
+    )
+  );
+
+  const available = new Set([
+    ...measurementNames.map((name) => targetKey('metric', name)),
+    ...checkNames.map((name) => targetKey('check', name)),
+    ...evaluationNames.map((name) => targetKey('evaluation', name)),
+  ]);
+
+  const unavailableKeys = evidence.unavailable.map((entry) => targetKey(entry.kind, entry.name));
+  const unavailable = new Set(unavailableKeys);
+
+  if (hasDuplicates(unavailableKeys)) {
+    addIssue(
+      issues,
+      'evidence.duplicate-unavailable',
+      '/unavailable',
+      'unavailable target entries must be unique'
+    );
+  }
+
+  for (const key of unavailable) {
+    if (available.has(key)) {
+      addIssue(
+        issues,
+        'evidence.available-and-unavailable',
+        '/unavailable',
+        `target ${key} cannot be both available and unavailable`
+      );
+    }
+  }
+
+  const measurementByName = new Map(
+    evidence.measurements.map((measurement) => [measurement.name, measurement])
+  );
+  const evaluationByName = new Map(
+    evidence.evaluations.map((evaluation) => [evaluation.name, evaluation])
+  );
+
+  requirements.forEach((requirement, index) => {
+    const requirementPath = `/policy/requirements/${index}`;
+    validateRequirementSemantics(requirement, requirementPath, issues);
+
+    const key = targetKey(requirement.target.kind, requirement.target.name);
+    if (requirement.severity === 'required' && !available.has(key) && !unavailable.has(key)) {
+      addIssue(
+        issues,
+        'policy.required-evidence-missing',
+        `${requirementPath}/target`,
+        `required target ${key} has neither evidence nor an explicit unavailable entry`
+      );
+    }
+
+    if (requirement.target.kind === 'metric') {
+      const measurement = measurementByName.get(requirement.target.name);
+      if (measurement && requirement.unit !== undefined && requirement.unit !== measurement.unit) {
+        addIssue(
+          issues,
+          'policy.metric-unit-mismatch',
+          `${requirementPath}/unit`,
+          `requirement unit ${requirement.unit} does not match evidence unit ${measurement.unit}`
+        );
+      }
+
+      const reservedUnit = RESERVED_METRIC_UNITS.get(requirement.target.name);
+      if (reservedUnit && requirement.unit !== undefined && requirement.unit !== reservedUnit) {
+        addIssue(
+          issues,
+          'policy.canonical-unit',
+          `${requirementPath}/unit`,
+          `reserved metric ${requirement.target.name} must use canonical unit ${reservedUnit}`
+        );
+      }
+    }
+
+    if (requirement.target.kind === 'evaluation') {
+      const evaluation = evaluationByName.get(requirement.target.name);
+      if (
+        evaluation?.unit !== undefined &&
+        requirement.unit !== undefined &&
+        evaluation.unit !== requirement.unit
+      ) {
+        addIssue(
+          issues,
+          'policy.evaluation-unit-mismatch',
+          `${requirementPath}/unit`,
+          `requirement unit ${requirement.unit} does not match evaluation unit ${evaluation.unit}`
+        );
+      }
+    }
+  });
+
+  const knownRequirementIds = new Set(requirementIds);
+  evidence.decision.reasons.forEach((reason, index) => {
+    if (reason.requirementId && !knownRequirementIds.has(reason.requirementId)) {
+      addIssue(
+        issues,
+        'decision.unknown-requirement',
+        `/decision/reasons/${index}/requirementId`,
+        `decision reason references unknown requirement ${reason.requirementId}`
+      );
+    }
+  });
+
+  return issues;
+}
+
+export class VerifyValidator {
+  constructor(bundle) {
+    const ajv = new Ajv2020({
+      allErrors: true,
+      allowUnionTypes: true,
+      strict: true,
+      validateSchema: true,
+    });
+
+    ajv.addFormat('date-time', {
+      type: 'string',
+      validate: isRfc3339DateTime,
+    });
+
+    for (const [name, schema] of Object.entries(bundle)) {
+      if (!ajv.validateSchema(schema)) {
+        const details = schemaIssues(ajv.errors)
+          .map((issue) => `${issue.path}: ${issue.message}`)
+          .join('; ');
+        throw new Error(`invalid Verify schema ${name}: ${details}`);
+      }
+    }
+
+    ajv.addSchema(bundle.common, 'common.schema.json');
+    this.manifestValidator = ajv.compile(bundle.manifest);
+    this.evidenceValidator = ajv.compile(bundle.evidence);
+  }
+
+  validateManifest(value) {
+    if (!this.manifestValidator(value)) {
+      return { valid: false, issues: schemaIssues(this.manifestValidator.errors) };
+    }
+
+    const issues = validateManifestSemantics(value);
+    return { valid: issues.length === 0, issues };
+  }
+
+  validateEvidence(value) {
+    if (!this.evidenceValidator(value)) {
+      return { valid: false, issues: schemaIssues(this.evidenceValidator.errors) };
+    }
+
+    const issues = validateEvidenceSemantics(value);
+    return { valid: issues.length === 0, issues };
+  }
+}

--- a/packages/amaryllis-components/tools/verify/validator.test.mjs
+++ b/packages/amaryllis-components/tools/verify/validator.test.mjs
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { loadVerifySchemaBundle, VerifyValidator } from './validator.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const schemaDirectory = path.join(repositoryRoot, 'schemas/verify/v1alpha1');
+const exampleDirectory = path.join(repositoryRoot, 'docs/examples/verify');
+const validator = new VerifyValidator(loadVerifySchemaBundle(schemaDirectory));
+
+function readExample(name) {
+  return JSON.parse(fs.readFileSync(path.join(exampleDirectory, name), 'utf8'));
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function assertIssue(result, code) {
+  assert.equal(result.valid, false, `expected validation failure containing ${code}`);
+  assert.ok(
+    result.issues.some((issue) => issue.code === code),
+    `expected issue ${code}; got ${JSON.stringify(result.issues)}`
+  );
+}
+
+const androidManifest = readExample('android.manifest.json');
+const androidEvidence = readExample('android.evidence.json');
+const iosManifest = readExample('ios.manifest.json');
+const iosEvidence = readExample('ios.evidence.json');
+
+test('committed Android and iOS examples validate', () => {
+  assert.deepEqual(validator.validateManifest(androidManifest), { valid: true, issues: [] });
+  assert.deepEqual(validator.validateEvidence(androidEvidence), { valid: true, issues: [] });
+  assert.deepEqual(validator.validateManifest(iosManifest), { valid: true, issues: [] });
+  assert.deepEqual(validator.validateEvidence(iosEvidence), { valid: true, issues: [] });
+});
+
+for (const field of [
+  'prompt',
+  'generatedOutput',
+  'retrievedContext',
+  'embeddings',
+  'rawLogs',
+  'telemetry',
+  'accessToken',
+]) {
+  test(`rejects privacy-sensitive top-level field ${field}`, () => {
+    const evidence = clone(androidEvidence);
+    evidence[field] = 'sensitive';
+    assertIssue(validator.validateEvidence(evidence), 'schema.additionalProperties');
+  });
+}
+
+for (const field of ['serialNumber', 'imei', 'advertisingId']) {
+  test(`rejects persistent device identifier ${field}`, () => {
+    const evidence = clone(androidEvidence);
+    evidence.environment.device[field] = 'persistent-id';
+    assertIssue(validator.validateEvidence(evidence), 'schema.additionalProperties');
+  });
+}
+
+test('rejects oversized diagnostic messages', () => {
+  const evidence = clone(androidEvidence);
+  evidence.unavailable[0].message = 'x'.repeat(513);
+  assertIssue(validator.validateEvidence(evidence), 'schema.maxLength');
+});
+
+for (const ref of [
+  'https://example.invalid/fixture.json',
+  's3:bucket/fixture.json',
+  'file:/tmp/fixture.json',
+]) {
+  test(`rejects URI fixture reference ${ref}`, () => {
+    const manifest = clone(androidManifest);
+    manifest.scenario.fixtureRefs[0].ref = ref;
+    assertIssue(validator.validateManifest(manifest), 'manifest.remote-fixture-ref');
+  });
+}
+
+test('allows Windows local fixture paths', () => {
+  const manifest = clone(androidManifest);
+  manifest.scenario.fixtureRefs[0].ref = 'C:\\fixtures\\chat-basic.json';
+  assert.deepEqual(validator.validateManifest(manifest), { valid: true, issues: [] });
+});
+
+test('rejects remote output paths', () => {
+  const manifest = clone(androidManifest);
+  manifest.output.path = 'https://example.invalid/evidence.json';
+  assertIssue(validator.validateManifest(manifest), 'manifest.remote-output-path');
+});
+
+test('rejects an empty manifest compatibility policy', () => {
+  const manifest = clone(androidManifest);
+  manifest.policy.requirements = [];
+  assertIssue(validator.validateManifest(manifest), 'schema.minItems');
+});
+
+test('rejects an empty evidence compatibility policy', () => {
+  const evidence = clone(androidEvidence);
+  evidence.policy.requirements = [];
+  assertIssue(validator.validateEvidence(evidence), 'policy.empty');
+});
+
+test('rejects duplicate requirement identifiers', () => {
+  const manifest = clone(androidManifest);
+  manifest.policy.requirements[1].id = manifest.policy.requirements[0].id;
+  assertIssue(validator.validateManifest(manifest), 'policy.duplicate-requirement-id');
+});
+
+test('rejects requirements for undeclared collection targets', () => {
+  const manifest = clone(androidManifest);
+  manifest.policy.requirements[0].target.name = 'timing.notRequested.ms';
+  assertIssue(validator.validateManifest(manifest), 'policy.undeclared-target');
+});
+
+test('rejects numeric comparisons against check targets', () => {
+  const manifest = clone(androidManifest);
+  const requirement = manifest.policy.requirements.find(({ id }) => id === 'cancel-restart');
+  requirement.operator = 'lte';
+  requirement.value = 1;
+  requirement.unit = 'count';
+  assertIssue(validator.validateManifest(manifest), 'requirement.numeric-check');
+});
+
+test('rejects available evidence also marked unavailable', () => {
+  const evidence = clone(androidEvidence);
+  evidence.unavailable[0].name = 'timing.ttft.ms';
+  assertIssue(validator.validateEvidence(evidence), 'evidence.available-and-unavailable');
+});
+
+test('rejects duplicate unavailable entries', () => {
+  const evidence = clone(androidEvidence);
+  evidence.unavailable.push(clone(evidence.unavailable[0]));
+  assertIssue(validator.validateEvidence(evidence), 'evidence.duplicate-unavailable');
+});
+
+test('rejects required targets with neither evidence nor explicit unavailable state', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements = evidence.measurements.filter(
+    ({ name }) => name !== 'timing.ttft.ms'
+  );
+  assertIssue(validator.validateEvidence(evidence), 'policy.required-evidence-missing');
+});
+
+test('allows required evidence to be explicitly unavailable', () => {
+  const evidence = clone(iosEvidence);
+  assert.deepEqual(validator.validateEvidence(evidence), { valid: true, issues: [] });
+});
+
+test('rejects completed repetitions greater than requested', () => {
+  const evidence = clone(androidEvidence);
+  evidence.execution.repetitions.completed = 4;
+  assertIssue(validator.validateEvidence(evidence), 'execution.repetition-count');
+});
+
+test('rejects samples outside the completed repetition range', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements[0].samples[0].iteration = 4;
+  assertIssue(validator.validateEvidence(evidence), 'measurement.iteration-range');
+});
+
+test('rejects duplicate sample iterations for one metric', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements[0].samples[1].iteration = 1;
+  assertIssue(validator.validateEvidence(evidence), 'measurement.duplicate-iteration');
+});
+
+test('rejects inconsistent summary count and mean', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements[0].summary.count = 2;
+  evidence.measurements[0].summary.mean = 999999;
+  const result = validator.validateEvidence(evidence);
+  assertIssue(result, 'measurement.summary-count');
+  assert.ok(result.issues.some(({ code }) => code === 'measurement.summary-mean'));
+});
+
+test('rejects non-canonical units for reserved metrics', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements[0].unit = 'seconds';
+  assertIssue(validator.validateEvidence(evidence), 'measurement.canonical-unit');
+});
+
+test('rejects requirement/evidence metric unit mismatch', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = evidence.policy.requirements.find(({ id }) => id === 'startup-budget');
+  requirement.unit = 'seconds';
+  assertIssue(validator.validateEvidence(evidence), 'policy.metric-unit-mismatch');
+});
+
+test('rejects decision reasons referencing unknown requirements', () => {
+  const evidence = clone(androidEvidence);
+  evidence.decision.reasons[0].requirementId = 'does-not-exist';
+  assertIssue(validator.validateEvidence(evidence), 'decision.unknown-requirement');
+});


### PR DESCRIPTION
## Summary

Implements #113 as the first executable Verify slice after the v1alpha1 contract landed in #112.

Adds one reusable repository validator for:

- JSON Schema Draft 2020-12 validation;
- cross-file Verify schema compilation;
- manifest semantic validation;
- evidence semantic validation;
- local-only fixture/output reference policy;
- privacy-negative schema tests;
- committed Android/iOS reference validation.

## Packaging decision

This PR intentionally does **not** create a new Yarn workspace/package yet.

The repository uses Yarn 3 immutable installs, so adding `@micrantha/amaryllis-verify` now would require a generated workspace lockfile update. Instead, the validator temporarily lives under:

```text
packages/amaryllis-components/tools/verify/
```

solely to reuse the repository's existing Ajv 8 dependency. The `tools/` directory is not part of the Components package `files` list and the validator is not exported from Components.

#116 owns promotion into a dedicated Verify tooling package when the CLI/runner packaging boundary is implemented intentionally.

## Validation behavior

The validator fails closed on, among other cases:

- malformed/unknown schema fields;
- empty/vacuous manifest/evidence policies;
- duplicate requirement IDs;
- requirements targeting undeclared manifest collection targets;
- invalid operator/target combinations;
- remote URI fixture/output references;
- required evidence that is neither present nor explicitly unavailable;
- a target being both present and unavailable;
- duplicate measurement/check/evaluation/unavailable identities;
- invalid repetition/sample iteration relationships;
- non-reproducible count/min/max/mean summaries;
- reserved metric unit drift;
- policy/evidence unit mismatch;
- decision reasons referencing undeclared requirements.

Percentile derivation is intentionally not introduced here; #114 owns the deterministic aggregation/policy semantics required to evaluate p50/p95 requirements.

## Privacy tests

Negative tests prove ordinary v1alpha1 evidence rejects:

- prompts;
- generated output;
- retrieved context;
- embeddings;
- raw logs/arbitrary telemetry;
- credentials/tokens;
- serial/IMEI/advertising identifiers;
- oversized diagnostic messages.

Fixture references using HTTP(S), S3, or `file:` URI schemes are rejected; v1alpha1 uses explicit local filesystem references only.

## CI integration

The existing `@micrantha/amaryllis-components` test command now runs the repository Verify contract tests after its normal Jest suite. This reuses the existing CI/package job without adding dependencies or changing the lockfile.

## Non-goals

- deriving compatibility `pass|warn|fail|unknown` decisions (#114);
- Verify CLI/runner (#116);
- Android/iOS adapters (#117);
- hosted execution or telemetry.

## Follow-up

After this merges, #99 can be re-reviewed for closure because its schema-level privacy negative-test requirement is implemented.

Closes #113.