### PR TITLE
verify: implement deterministic compatibility policy evaluation

### DIFF
--- a/packages/amaryllis-components/package.json
+++ b/packages/amaryllis-components/package.json
@@ -15,9 +15,9 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "jest && node --test tools/verify/validator.test.mjs",
+    "test": "jest && node --test tools/verify/*.test.mjs",
     "verify:examples": "node ../../scripts/verify-component-examples.mjs",
-    "verify:contract": "node --test tools/verify/validator.test.mjs",
+    "verify:contract": "node --test tools/verify/*.test.mjs",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "prepare": "npm run build"
   },

--- a/packages/amaryllis-components/tools/verify/policy.mjs
+++ b/packages/amaryllis-components/tools/verify/policy.mjs
@@ -1,0 +1,336 @@
+const STATUS_RANK = {
+  pass: 0,
+  warn: 1,
+  unknown: 2,
+  fail: 3,
+};
+
+const NUMERIC_OPERATORS = new Set(['lte', 'lt', 'gte', 'gt']);
+const NUMERIC_AGGREGATES = new Set(['min', 'max', 'mean', 'p50', 'p95', 'last']);
+const RESULT_STATUSES = new Set(['pass', 'fail', 'unknown']);
+
+export class PolicyEvaluationError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'PolicyEvaluationError';
+    this.code = code;
+  }
+}
+
+function fail(code, message) {
+  throw new PolicyEvaluationError(code, message);
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+export function percentileR7(values, probability) {
+  if (!Array.isArray(values) || values.length === 0) {
+    fail('aggregate.empty-samples', 'percentile requires at least one numeric sample');
+  }
+  if (!isFiniteNumber(probability) || probability < 0 || probability > 1) {
+    fail('aggregate.invalid-probability', 'percentile probability must be within 0..1');
+  }
+  if (!values.every(isFiniteNumber)) {
+    fail('aggregate.non-finite-sample', 'metric samples must be finite numbers');
+  }
+
+  const sorted = [...values].sort((left, right) => left - right);
+  if (sorted.length === 1) {
+    return sorted[0];
+  }
+
+  // R-7 / linear interpolation: h = (n - 1) * p.
+  const position = (sorted.length - 1) * probability;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  const fraction = position - lower;
+
+  return sorted[lower] + fraction * (sorted[upper] - sorted[lower]);
+}
+
+export function aggregateMeasurement(measurement, aggregate) {
+  if (!measurement?.samples?.length) {
+    fail('aggregate.empty-samples', `metric ${measurement?.name ?? '<unknown>'} has no samples`);
+  }
+
+  const values = measurement.samples.map(({ value }) => value);
+  if (!values.every(isFiniteNumber)) {
+    fail('aggregate.non-finite-sample', `metric ${measurement.name} contains a non-finite sample`);
+  }
+
+  switch (aggregate) {
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+    case 'mean':
+      return values.reduce((sum, value) => sum + value, 0) / values.length;
+    case 'p50':
+      return percentileR7(values, 0.5);
+    case 'p95':
+      return percentileR7(values, 0.95);
+    case 'last': {
+      const last = measurement.samples.reduce((current, candidate) =>
+        candidate.iteration > current.iteration ? candidate : current
+      );
+      return last.value;
+    }
+    default:
+      fail(
+        'aggregate.unsupported',
+        `aggregate ${String(aggregate)} is not defined for numeric v1alpha1 metrics`
+      );
+  }
+}
+
+function compare(actual, operator, expected) {
+  switch (operator) {
+    case 'lte':
+      return actual <= expected;
+    case 'lt':
+      return actual < expected;
+    case 'gte':
+      return actual >= expected;
+    case 'gt':
+      return actual > expected;
+    case 'eq':
+      return actual === expected;
+    case 'neq':
+      return actual !== expected;
+    default:
+      fail('operator.unsupported', `unsupported comparison operator ${operator}`);
+  }
+}
+
+function numericRequirementValue(requirement) {
+  if (!isFiniteNumber(requirement.value)) {
+    fail(
+      'requirement.invalid-numeric-value',
+      `requirement ${requirement.id} requires a finite numeric comparison value`
+    );
+  }
+  return requirement.value;
+}
+
+function evaluateMetric(requirement, measurement) {
+  if (requirement.operator === 'present') {
+    return 'satisfied';
+  }
+  if (requirement.operator === 'pass') {
+    fail('requirement.invalid-metric-operator', '`pass` is invalid for metric requirements');
+  }
+  if (!NUMERIC_AGGREGATES.has(requirement.aggregate)) {
+    fail(
+      'requirement.invalid-metric-aggregate',
+      `requirement ${requirement.id} has invalid metric aggregate ${String(requirement.aggregate)}`
+    );
+  }
+
+  const actual = aggregateMeasurement(measurement, requirement.aggregate);
+  const expected = numericRequirementValue(requirement);
+  return compare(actual, requirement.operator, expected) ? 'satisfied' : 'violated';
+}
+
+function statusOutcome(status, requirement) {
+  if (!RESULT_STATUSES.has(status)) {
+    fail('evidence.invalid-status', `target ${requirement.target.name} has invalid status ${status}`);
+  }
+  if (status === 'unknown') {
+    return 'unknown';
+  }
+  return status === 'pass' ? 'satisfied' : 'violated';
+}
+
+function evaluateCheck(requirement, check) {
+  if (requirement.operator === 'present') {
+    return 'satisfied';
+  }
+  if (requirement.operator === 'pass') {
+    return statusOutcome(check.status, requirement);
+  }
+  if (check.status === 'unknown') {
+    return 'unknown';
+  }
+  if (requirement.operator !== 'eq' && requirement.operator !== 'neq') {
+    fail(
+      'requirement.invalid-check-operator',
+      `operator ${requirement.operator} is invalid for check requirements`
+    );
+  }
+  if (!RESULT_STATUSES.has(requirement.value)) {
+    fail(
+      'requirement.invalid-check-value',
+      `check requirement ${requirement.id} must compare against pass/fail/unknown`
+    );
+  }
+  return compare(check.status, requirement.operator, requirement.value)
+    ? 'satisfied'
+    : 'violated';
+}
+
+function evaluateEvaluation(requirement, evaluation) {
+  if (requirement.operator === 'present') {
+    return 'satisfied';
+  }
+  if (requirement.operator === 'pass') {
+    return statusOutcome(evaluation.status, requirement);
+  }
+  if (evaluation.status === 'unknown') {
+    return 'unknown';
+  }
+
+  if (NUMERIC_OPERATORS.has(requirement.operator)) {
+    if (!isFiniteNumber(evaluation.score)) {
+      return 'unknown';
+    }
+    return compare(
+      evaluation.score,
+      requirement.operator,
+      numericRequirementValue(requirement)
+    )
+      ? 'satisfied'
+      : 'violated';
+  }
+
+  if (requirement.operator === 'eq' || requirement.operator === 'neq') {
+    if (isFiniteNumber(requirement.value)) {
+      if (!isFiniteNumber(evaluation.score)) {
+        return 'unknown';
+      }
+      return compare(evaluation.score, requirement.operator, requirement.value)
+        ? 'satisfied'
+        : 'violated';
+    }
+    if (typeof requirement.value === 'string' && RESULT_STATUSES.has(requirement.value)) {
+      return compare(evaluation.status, requirement.operator, requirement.value)
+        ? 'satisfied'
+        : 'violated';
+    }
+    fail(
+      'requirement.invalid-evaluation-value',
+      `evaluation requirement ${requirement.id} must compare a finite score or status`
+    );
+  }
+
+  fail(
+    'requirement.invalid-evaluation-operator',
+    `operator ${requirement.operator} is invalid for evaluation requirements`
+  );
+}
+
+function buildEvidenceIndex(evidence) {
+  return {
+    metric: new Map(evidence.measurements.map((entry) => [entry.name, entry])),
+    check: new Map(evidence.checks.map((entry) => [entry.name, entry])),
+    evaluation: new Map(evidence.evaluations.map((entry) => [entry.name, entry])),
+    unavailable: new Set(
+      evidence.unavailable.map((entry) => `${entry.kind}:${entry.name}`)
+    ),
+  };
+}
+
+function evaluateRequirement(requirement, index) {
+  const key = `${requirement.target.kind}:${requirement.target.name}`;
+  if (index.unavailable.has(key)) {
+    return 'unknown';
+  }
+
+  const evidence = index[requirement.target.kind]?.get(requirement.target.name);
+  if (!evidence) {
+    return 'unknown';
+  }
+
+  switch (requirement.target.kind) {
+    case 'metric':
+      return evaluateMetric(requirement, evidence);
+    case 'check':
+      return evaluateCheck(requirement, evidence);
+    case 'evaluation':
+      return evaluateEvaluation(requirement, evidence);
+    default:
+      fail(
+        'requirement.invalid-target-kind',
+        `unsupported target kind ${requirement.target.kind}`
+      );
+  }
+}
+
+function contribution(requirement, outcome) {
+  if (outcome === 'satisfied') {
+    return null;
+  }
+
+  if (outcome === 'unknown') {
+    return requirement.severity === 'required'
+      ? {
+          status: 'unknown',
+          reason: {
+            requirementId: requirement.id,
+            code: 'required-evidence-unavailable',
+          },
+        }
+      : {
+          status: 'warn',
+          reason: {
+            requirementId: requirement.id,
+            code: 'advisory-evidence-unavailable',
+          },
+        };
+  }
+
+  if (outcome === 'violated') {
+    return requirement.severity === 'required'
+      ? {
+          status: 'fail',
+          reason: {
+            requirementId: requirement.id,
+            code: 'required-violation',
+          },
+        }
+      : {
+          status: 'warn',
+          reason: {
+            requirementId: requirement.id,
+            code: 'advisory-violation',
+          },
+        };
+  }
+
+  fail('evaluation.invalid-outcome', `unexpected requirement outcome ${outcome}`);
+}
+
+export function evaluateCompatibility(evidence, policy = evidence?.policy) {
+  if (!evidence || !policy || !Array.isArray(policy.requirements)) {
+    fail('policy.invalid', 'validated evidence and policy requirements are required');
+  }
+  if (policy.requirements.length === 0) {
+    fail('policy.empty', 'compatibility policy must contain at least one requirement');
+  }
+
+  const index = buildEvidenceIndex(evidence);
+  let status = 'pass';
+  const reasons = [];
+
+  for (const requirement of policy.requirements) {
+    if (requirement.severity !== 'required' && requirement.severity !== 'advisory') {
+      fail(
+        'requirement.invalid-severity',
+        `requirement ${requirement.id} has invalid severity ${requirement.severity}`
+      );
+    }
+
+    const result = contribution(requirement, evaluateRequirement(requirement, index));
+    if (!result) {
+      continue;
+    }
+
+    reasons.push(result.reason);
+    if (STATUS_RANK[result.status] > STATUS_RANK[status]) {
+      status = result.status;
+    }
+  }
+
+  return { status, reasons };
+}

--- a/packages/amaryllis-components/tools/verify/policy.mjs
+++ b/packages/amaryllis-components/tools/verify/policy.mjs
@@ -25,6 +25,43 @@ function isFiniteNumber(value) {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function requireNoComparisonMetadata(requirement) {
+  if (
+    requirement.value !== undefined ||
+    requirement.aggregate !== undefined ||
+    requirement.unit !== undefined
+  ) {
+    fail(
+      'requirement.unexpected-comparison-metadata',
+      `operator ${requirement.operator} on requirement ${requirement.id} must not define value, aggregate, or unit`
+    );
+  }
+}
+
+function requireNumericUnit(requirement) {
+  if (typeof requirement.unit !== 'string' || requirement.unit.length === 0) {
+    fail(
+      'requirement.missing-unit',
+      `numeric requirement ${requirement.id} requires an explicit unit`
+    );
+  }
+  return requirement.unit;
+}
+
+function requireMatchingUnit(requirement, evidenceUnit) {
+  const expected = requireNumericUnit(requirement);
+  if (evidenceUnit === undefined) {
+    return false;
+  }
+  if (evidenceUnit !== expected) {
+    fail(
+      'evidence.unit-mismatch',
+      `target ${requirement.target.name} uses unit ${evidenceUnit}; requirement ${requirement.id} expects ${expected}`
+    );
+  }
+  return true;
+}
+
 export function percentileR7(values, probability) {
   if (!Array.isArray(values) || values.length === 0) {
     fail('aggregate.empty-samples', 'percentile requires at least one numeric sample');
@@ -116,9 +153,11 @@ function numericRequirementValue(requirement) {
 
 function evaluateMetric(requirement, measurement) {
   if (requirement.operator === 'present') {
+    requireNoComparisonMetadata(requirement);
     return 'satisfied';
   }
   if (requirement.operator === 'pass') {
+    requireNoComparisonMetadata(requirement);
     fail('requirement.invalid-metric-operator', '`pass` is invalid for metric requirements');
   }
   if (!NUMERIC_AGGREGATES.has(requirement.aggregate)) {
@@ -126,6 +165,9 @@ function evaluateMetric(requirement, measurement) {
       'requirement.invalid-metric-aggregate',
       `requirement ${requirement.id} has invalid metric aggregate ${String(requirement.aggregate)}`
     );
+  }
+  if (!requireMatchingUnit(requirement, measurement.unit)) {
+    return 'unknown';
   }
 
   const actual = aggregateMeasurement(measurement, requirement.aggregate);
@@ -145,9 +187,11 @@ function statusOutcome(status, requirement) {
 
 function evaluateCheck(requirement, check) {
   if (requirement.operator === 'present') {
+    requireNoComparisonMetadata(requirement);
     return 'satisfied';
   }
   if (requirement.operator === 'pass') {
+    requireNoComparisonMetadata(requirement);
     return statusOutcome(check.status, requirement);
   }
   if (check.status === 'unknown') {
@@ -157,6 +201,12 @@ function evaluateCheck(requirement, check) {
     fail(
       'requirement.invalid-check-operator',
       `operator ${requirement.operator} is invalid for check requirements`
+    );
+  }
+  if (requirement.aggregate !== undefined || requirement.unit !== undefined) {
+    fail(
+      'requirement.invalid-check-metadata',
+      `check requirement ${requirement.id} must not define aggregate or unit`
     );
   }
   if (!RESULT_STATUSES.has(requirement.value)) {
@@ -172,9 +222,11 @@ function evaluateCheck(requirement, check) {
 
 function evaluateEvaluation(requirement, evaluation) {
   if (requirement.operator === 'present') {
+    requireNoComparisonMetadata(requirement);
     return 'satisfied';
   }
   if (requirement.operator === 'pass') {
+    requireNoComparisonMetadata(requirement);
     return statusOutcome(evaluation.status, requirement);
   }
   if (evaluation.status === 'unknown') {
@@ -182,7 +234,16 @@ function evaluateEvaluation(requirement, evaluation) {
   }
 
   if (NUMERIC_OPERATORS.has(requirement.operator)) {
+    if (requirement.aggregate !== undefined) {
+      fail(
+        'requirement.invalid-evaluation-aggregate',
+        `evaluation requirement ${requirement.id} must not define an aggregate`
+      );
+    }
     if (!isFiniteNumber(evaluation.score)) {
+      return 'unknown';
+    }
+    if (!requireMatchingUnit(requirement, evaluation.unit)) {
       return 'unknown';
     }
     return compare(
@@ -195,19 +256,37 @@ function evaluateEvaluation(requirement, evaluation) {
   }
 
   if (requirement.operator === 'eq' || requirement.operator === 'neq') {
+    if (requirement.aggregate !== undefined) {
+      fail(
+        'requirement.invalid-evaluation-aggregate',
+        `evaluation requirement ${requirement.id} must not define an aggregate`
+      );
+    }
+
     if (isFiniteNumber(requirement.value)) {
       if (!isFiniteNumber(evaluation.score)) {
+        return 'unknown';
+      }
+      if (!requireMatchingUnit(requirement, evaluation.unit)) {
         return 'unknown';
       }
       return compare(evaluation.score, requirement.operator, requirement.value)
         ? 'satisfied'
         : 'violated';
     }
+
     if (typeof requirement.value === 'string' && RESULT_STATUSES.has(requirement.value)) {
+      if (requirement.unit !== undefined) {
+        fail(
+          'requirement.invalid-evaluation-status-unit',
+          `status comparison ${requirement.id} must not define a unit`
+        );
+      }
       return compare(evaluation.status, requirement.operator, requirement.value)
         ? 'satisfied'
         : 'violated';
     }
+
     fail(
       'requirement.invalid-evaluation-value',
       `evaluation requirement ${requirement.id} must compare a finite score or status`

--- a/packages/amaryllis-components/tools/verify/policy.test.mjs
+++ b/packages/amaryllis-components/tools/verify/policy.test.mjs
@@ -1,0 +1,275 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  aggregateMeasurement,
+  evaluateCompatibility,
+  percentileR7,
+  PolicyEvaluationError,
+} from './policy.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const exampleDirectory = path.join(repositoryRoot, 'docs/examples/verify');
+
+function readEvidence(name) {
+  return JSON.parse(fs.readFileSync(path.join(exampleDirectory, name), 'utf8'));
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function requirementById(evidence, id) {
+  const requirement = evidence.policy.requirements.find((entry) => entry.id === id);
+  assert.ok(requirement, `expected requirement ${id}`);
+  return requirement;
+}
+
+function assertPolicyError(callback, code) {
+  assert.throws(callback, (error) => {
+    assert.ok(error instanceof PolicyEvaluationError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}
+
+const androidEvidence = readEvidence('android.evidence.json');
+const iosEvidence = readEvidence('ios.evidence.json');
+
+test('reference Android evidence derives warn for unavailable advisory evidence', () => {
+  assert.deepEqual(evaluateCompatibility(androidEvidence), {
+    status: 'warn',
+    reasons: [
+      {
+        requirementId: 'thermal-observation',
+        code: 'advisory-evidence-unavailable',
+      },
+    ],
+  });
+});
+
+test('reference iOS evidence derives unknown for unavailable required evidence', () => {
+  assert.deepEqual(evaluateCompatibility(iosEvidence), {
+    status: 'unknown',
+    reasons: [
+      {
+        requirementId: 'energy-budget',
+        code: 'required-evidence-unavailable',
+      },
+    ],
+  });
+});
+
+test('all satisfied required requirements derive pass', () => {
+  const evidence = clone(androidEvidence);
+  evidence.policy.requirements = evidence.policy.requirements.filter(
+    ({ id }) => id !== 'thermal-observation'
+  );
+  evidence.unavailable = [];
+
+  assert.deepEqual(evaluateCompatibility(evidence), { status: 'pass', reasons: [] });
+});
+
+test('advisory threshold violation derives warn', () => {
+  const evidence = clone(androidEvidence);
+  const startup = requirementById(evidence, 'startup-budget');
+  startup.severity = 'advisory';
+  startup.value = 1000;
+  evidence.policy.requirements = evidence.policy.requirements.filter(
+    ({ id }) => id !== 'thermal-observation'
+  );
+  evidence.unavailable = [];
+
+  assert.deepEqual(evaluateCompatibility(evidence), {
+    status: 'warn',
+    reasons: [
+      {
+        requirementId: 'startup-budget',
+        code: 'advisory-violation',
+      },
+    ],
+  });
+});
+
+test('required threshold violation derives fail', () => {
+  const evidence = clone(androidEvidence);
+  requirementById(evidence, 'startup-budget').value = 1000;
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'fail');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'startup-budget' && code === 'required-violation'
+    )
+  );
+});
+
+test('required unavailable evidence derives unknown', () => {
+  const evidence = clone(androidEvidence);
+  evidence.measurements = evidence.measurements.filter(
+    ({ name }) => name !== 'timing.ttft.ms'
+  );
+  evidence.unavailable.push({
+    kind: 'metric',
+    name: 'timing.ttft.ms',
+    reason: 'collector-failed',
+  });
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'unknown');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'ttft-budget' && code === 'required-evidence-unavailable'
+    )
+  );
+});
+
+test('known required violation outranks required unknown while preserving both reasons', () => {
+  const evidence = clone(androidEvidence);
+  requirementById(evidence, 'startup-budget').value = 1000;
+  evidence.measurements = evidence.measurements.filter(
+    ({ name }) => name !== 'timing.ttft.ms'
+  );
+  evidence.unavailable.push({
+    kind: 'metric',
+    name: 'timing.ttft.ms',
+    reason: 'collector-failed',
+  });
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'fail');
+  assert.deepEqual(
+    new Set(result.reasons.map(({ code }) => code)),
+    new Set(['required-violation', 'required-evidence-unavailable', 'advisory-evidence-unavailable'])
+  );
+});
+
+test('unknown check outcome is unknown rather than a known failure', () => {
+  const evidence = clone(androidEvidence);
+  const check = evidence.checks.find(({ name }) => name === 'lifecycle.cancelRestart');
+  check.status = 'unknown';
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'unknown');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'cancel-restart' && code === 'required-evidence-unavailable'
+    )
+  );
+});
+
+test('failed required check is a known fail', () => {
+  const evidence = clone(androidEvidence);
+  const check = evidence.checks.find(({ name }) => name === 'lifecycle.cancelRestart');
+  check.status = 'fail';
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'fail');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'cancel-restart' && code === 'required-violation'
+    )
+  );
+});
+
+test('unknown required evaluation score derives unknown', () => {
+  const evidence = clone(androidEvidence);
+  const evaluation = evidence.evaluations.find(({ name }) => name === 'quality.chatSmoke');
+  evaluation.status = 'unknown';
+  delete evaluation.score;
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'unknown');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'quality-floor' && code === 'required-evidence-unavailable'
+    )
+  );
+});
+
+test('numeric comparison is inclusive at lte and gte equality boundaries', () => {
+  const evidence = clone(androidEvidence);
+  const initialization = evidence.measurements.find(
+    ({ name }) => name === 'timing.initialization.ms'
+  );
+  const startup = requirementById(evidence, 'startup-budget');
+  startup.value = aggregateMeasurement(initialization, 'max');
+
+  const quality = requirementById(evidence, 'quality-floor');
+  const evaluation = evidence.evaluations.find(({ name }) => name === 'quality.chatSmoke');
+  quality.value = evaluation.score;
+
+  evidence.policy.requirements = evidence.policy.requirements.filter(
+    ({ id }) => id !== 'thermal-observation'
+  );
+  evidence.unavailable = [];
+
+  assert.equal(evaluateCompatibility(evidence).status, 'pass');
+});
+
+test('R-7 percentile interpolation is deterministic', () => {
+  assert.equal(percentileR7([1, 2, 3], 0.5), 2);
+  assert.equal(percentileR7([1, 2, 3], 0.95), 2.9);
+  assert.equal(percentileR7([5], 0.95), 5);
+});
+
+test('last aggregate uses the highest iteration rather than array order', () => {
+  const measurement = {
+    name: 'example',
+    samples: [
+      { iteration: 3, value: 30 },
+      { iteration: 1, value: 10 },
+      { iteration: 2, value: 20 },
+    ],
+  };
+  assert.equal(aggregateMeasurement(measurement, 'last'), 30);
+});
+
+test('non-finite metric samples fail closed', () => {
+  const evidence = clone(androidEvidence);
+  const measurement = evidence.measurements.find(
+    ({ name }) => name === 'timing.initialization.ms'
+  );
+  measurement.samples[0].value = Number.NaN;
+
+  assertPolicyError(
+    () => evaluateCompatibility(evidence),
+    'aggregate.non-finite-sample'
+  );
+});
+
+test('numeric comparator on a check fails closed', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = requirementById(evidence, 'cancel-restart');
+  requirement.operator = 'lte';
+  requirement.value = 1;
+  requirement.aggregate = 'max';
+  requirement.unit = 'count';
+
+  assertPolicyError(
+    () => evaluateCompatibility(evidence),
+    'requirement.invalid-check-operator'
+  );
+});
+
+test('empty policy fails closed', () => {
+  const evidence = clone(androidEvidence);
+  evidence.policy.requirements = [];
+  assertPolicyError(() => evaluateCompatibility(evidence), 'policy.empty');
+});
+
+test('evaluation does not mutate evidence or embedded policy', () => {
+  const evidence = clone(androidEvidence);
+  const before = clone(evidence);
+  evaluateCompatibility(evidence);
+  assert.deepEqual(evidence, before);
+});

--- a/packages/amaryllis-components/tools/verify/policy.test.mjs
+++ b/packages/amaryllis-components/tools/verify/policy.test.mjs
@@ -261,6 +261,82 @@ test('numeric comparator on a check fails closed', () => {
   );
 });
 
+test('present requirements reject comparison metadata', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = requirementById(evidence, 'thermal-observation');
+  requirement.unit = 'state';
+
+  evidence.unavailable = [];
+  evidence.measurements.push({
+    name: 'thermal.maxState',
+    unit: 'state',
+    samples: [{ iteration: 1, value: 1 }],
+    summary: { count: 1, min: 1, max: 1, mean: 1 },
+  });
+
+  assertPolicyError(
+    () => evaluateCompatibility(evidence),
+    'requirement.unexpected-comparison-metadata'
+  );
+});
+
+test('pass requirements reject comparison metadata', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = requirementById(evidence, 'cancel-restart');
+  requirement.unit = 'status';
+
+  assertPolicyError(
+    () => evaluateCompatibility(evidence),
+    'requirement.unexpected-comparison-metadata'
+  );
+});
+
+test('numeric evaluation comparison requires an explicit policy unit', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = requirementById(evidence, 'quality-floor');
+  delete requirement.unit;
+
+  assertPolicyError(() => evaluateCompatibility(evidence), 'requirement.missing-unit');
+});
+
+test('missing evaluation score unit becomes unknown rather than dimensionless pass', () => {
+  const evidence = clone(androidEvidence);
+  const evaluation = evidence.evaluations.find(({ name }) => name === 'quality.chatSmoke');
+  delete evaluation.unit;
+
+  const result = evaluateCompatibility(evidence);
+  assert.equal(result.status, 'unknown');
+  assert.ok(
+    result.reasons.some(
+      ({ requirementId, code }) =>
+        requirementId === 'quality-floor' && code === 'required-evidence-unavailable'
+    )
+  );
+});
+
+test('mismatched metric units fail closed during direct evaluation', () => {
+  const evidence = clone(androidEvidence);
+  const measurement = evidence.measurements.find(
+    ({ name }) => name === 'timing.initialization.ms'
+  );
+  measurement.unit = 'seconds';
+
+  assertPolicyError(() => evaluateCompatibility(evidence), 'evidence.unit-mismatch');
+});
+
+test('status equality on evaluations rejects units', () => {
+  const evidence = clone(androidEvidence);
+  const requirement = requirementById(evidence, 'quality-floor');
+  requirement.operator = 'eq';
+  requirement.value = 'pass';
+  requirement.unit = 'ratio';
+
+  assertPolicyError(
+    () => evaluateCompatibility(evidence),
+    'requirement.invalid-evaluation-status-unit'
+  );
+});
+
 test('empty policy fails closed', () => {
   const evidence = clone(androidEvidence);
   evidence.policy.requirements = [];


### PR DESCRIPTION
## Summary

Implements #114 as a pure deterministic policy layer on top of the merged validation foundation in #118/#113.

## Behavior

Derives one compatibility result from validated evidence and application-owned requirements using the v1alpha1 precedence:

```text
known required violation   -> fail
required evidence missing  -> unknown
advisory violation/missing -> warn
otherwise                  -> pass
```

Stable severity ordering:

```text
fail > unknown > warn > pass
```

A known required violation outranks an unknown required fact, while both machine-readable reasons are preserved.

## Deterministic aggregation

Implements numeric aggregation directly from retained raw samples:

- `min`
- `max`
- `mean`
- `p50`
- `p95`
- `last`

Percentiles use explicit R-7 linear interpolation (`h = (n - 1) * p`) rather than relying on library-specific statistics behavior.

`last` uses the highest iteration number rather than array order.

## Target semantics

- metrics support numeric comparisons and equality over declared aggregates;
- checks support `pass`, `present`, and equality/inequality over status;
- evaluations support `pass`, `present`, numeric score comparisons, or status equality;
- an explicit `unknown` check/evaluation outcome remains unknown rather than becoming a known failure;
- unavailable or absent targets are fail-safe unknown inputs;
- invalid operator/target/value combinations throw `PolicyEvaluationError` rather than coercing data.

## Reason codes

The evaluator emits stable requirement-linked codes:

- `required-violation`
- `required-evidence-unavailable`
- `advisory-violation`
- `advisory-evidence-unavailable`

Human-readable messages remain a presentation concern.

## Tests

Covers:

- Android reference evidence -> `warn`;
- iOS reference evidence -> `unknown`;
- all-pass;
- advisory threshold violation;
- required threshold violation;
- required unavailable evidence;
- required fail + required unknown precedence;
- unknown/failed checks;
- unknown evaluation scores;
- inclusive comparator boundaries;
- deterministic R-7 percentiles;
- iteration-based `last` aggregation;
- non-finite sample rejection;
- invalid check comparator rejection;
- empty policy rejection;
- non-mutation of evidence/policy.

## Architecture

This module is pure: no filesystem, device, network, model, UI, or hosted-service dependency.

It does not mutate source evidence. #116 will consume the same evaluator from the future local runner/CLI.

## Non-goals

- schema/semantic validation (#113/#118);
- runner orchestration (#116);
- device adapters (#117);
- baseline selection/history;
- hosted policy administration;
- AI-assisted verdicts.

Closes #114 when merged.