### PR TITLE
build: pin MediaPipe native dependencies to 0.10.24

### DIFF
--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -40,7 +40,8 @@ jobs:
           node --test \
             scripts/ci-workflow-contract.test.mjs \
             scripts/classify-ci-changes.test.mjs \
-            scripts/detect-ci-changes.test.mjs
+            scripts/detect-ci-changes.test.mjs \
+            scripts/validate-native-dependencies.test.mjs
 
       - name: Classify changed paths
         id: classify

--- a/Amaryllis.podspec
+++ b/Amaryllis.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "ios/tests/**/*"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "MediaPipeTasksGenAI"
+  s.dependency "MediaPipeTasksGenAI", "= 0.10.24"
 
   install_modules_dependencies(s)
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,6 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.mediapipe:tasks-core:0.10.24'
   implementation 'com.google.mediapipe:tasks-genai:0.10.24'
 
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,8 +73,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.mediapipe:tasks-core:latest.release'
-  implementation 'com.google.mediapipe:tasks-genai:latest.release'
+  implementation 'com.google.mediapipe:tasks-core:0.10.24'
+  implementation 'com.google.mediapipe:tasks-genai:0.10.24'
 
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
   testImplementation 'junit:junit:4.13.2'

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -3,6 +3,8 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import test from 'node:test';
 
+import './validate-native-dependencies.test.mjs';
+
 const workflow = readFileSync('.github/workflows/primary-ci.yml', 'utf8');
 const lines = workflow.split('\n');
 const jobsStart = lines.findIndex(line => line === 'jobs:');

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -3,8 +3,6 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import test from 'node:test';
 
-import './validate-native-dependencies.test.mjs';
-
 const workflow = readFileSync('.github/workflows/primary-ci.yml', 'utf8');
 const lines = workflow.split('\n');
 const jobsStart = lines.findIndex(line => line === 'jobs:');

--- a/scripts/validate-native-dependencies.mjs
+++ b/scripts/validate-native-dependencies.mjs
@@ -1,0 +1,107 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const EXPECTED_MEDIAPIPE_VERSION = '0.10.24';
+
+const ANDROID_ARTIFACTS = ['tasks-core', 'tasks-genai'];
+
+function requireMatch(value, message) {
+  if (!value) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function extractAndroidVersions(contents) {
+  const versions = new Map();
+  const dependencyPattern =
+    /implementation\s+['"]com\.google\.mediapipe:(tasks-core|tasks-genai):([^'"]+)['"]/g;
+
+  for (const match of contents.matchAll(dependencyPattern)) {
+    const [, artifact, version] = match;
+    if (versions.has(artifact)) {
+      throw new Error(`duplicate Android MediaPipe dependency: ${artifact}`);
+    }
+    versions.set(artifact, version);
+  }
+
+  for (const artifact of ANDROID_ARTIFACTS) {
+    requireMatch(
+      versions.get(artifact),
+      `missing Android MediaPipe dependency: ${artifact}`
+    );
+  }
+
+  return versions;
+}
+
+function extractIosVersion(contents) {
+  const match = contents.match(
+    /s\.dependency\s+['"]MediaPipeTasksGenAI['"]\s*,\s*['"]\s*=\s*([^'"]+)['"]/m
+  );
+  return requireMatch(
+    match?.[1],
+    'MediaPipeTasksGenAI must use an exact CocoaPods version constraint'
+  );
+}
+
+function extractLockedVersion(contents, podName) {
+  const escapedPodName = podName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(
+    `^  - ${escapedPodName} \\(([^)]+)\\):?\\s*$`,
+    'm'
+  );
+  const match = contents.match(pattern);
+  return requireMatch(match?.[1], `missing locked iOS pod: ${podName}`);
+}
+
+function assertExpectedVersion(actual, location) {
+  if (actual !== EXPECTED_MEDIAPIPE_VERSION) {
+    throw new Error(
+      `${location} must be pinned to ${EXPECTED_MEDIAPIPE_VERSION}; found ${actual}`
+    );
+  }
+}
+
+export async function validateNativeDependencies({ rootDir = process.cwd() } = {}) {
+  const [gradle, podspec, lockfile] = await Promise.all([
+    readFile(path.join(rootDir, 'android/build.gradle'), 'utf8'),
+    readFile(path.join(rootDir, 'Amaryllis.podspec'), 'utf8'),
+    readFile(path.join(rootDir, 'example/ios/Podfile.lock'), 'utf8'),
+  ]);
+
+  const androidVersions = extractAndroidVersions(gradle);
+  const coreVersion = androidVersions.get('tasks-core');
+  const genaiVersion = androidVersions.get('tasks-genai');
+  const iosVersion = extractIosVersion(podspec);
+  const iosLockedVersion = extractLockedVersion(lockfile, 'MediaPipeTasksGenAI');
+  const iosCLockedVersion = extractLockedVersion(lockfile, 'MediaPipeTasksGenAIC');
+
+  assertExpectedVersion(coreVersion, 'Android tasks-core');
+  assertExpectedVersion(genaiVersion, 'Android tasks-genai');
+  assertExpectedVersion(iosVersion, 'iOS MediaPipeTasksGenAI podspec');
+  assertExpectedVersion(iosLockedVersion, 'iOS MediaPipeTasksGenAI lockfile');
+  assertExpectedVersion(iosCLockedVersion, 'iOS MediaPipeTasksGenAIC lockfile');
+
+  if (coreVersion !== genaiVersion || genaiVersion !== iosVersion) {
+    throw new Error(
+      `MediaPipe versions must match across native declarations; found tasks-core=${coreVersion}, tasks-genai=${genaiVersion}, iOS=${iosVersion}`
+    );
+  }
+
+  return EXPECTED_MEDIAPIPE_VERSION;
+}
+
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  try {
+    const version = await validateNativeDependencies();
+    console.log(`Native MediaPipe dependencies are pinned to ${version}.`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-native-dependencies.mjs
+++ b/scripts/validate-native-dependencies.mjs
@@ -11,18 +11,47 @@ function requireMatch(value, message) {
   return value;
 }
 
+function stripGradleComments(contents) {
+  return contents
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
 function extractAndroidVersion(contents) {
-  const matches = [
-    ...contents.matchAll(
-      /implementation\s+['"]com\.google\.mediapipe:tasks-genai:([^'"]+)['"]/g
+  const source = stripGradleComments(contents);
+  const coordinateMatches = [
+    ...source.matchAll(
+      /['"]com\.google\.mediapipe:tasks-genai:([^'"]+)['"]/g
     ),
   ];
-  if (matches.length !== 1) {
+  const taskReferences = [...source.matchAll(/\btasks-genai\b/g)];
+
+  if (taskReferences.length !== coordinateMatches.length) {
     throw new Error(
-      `expected exactly one Android tasks-genai dependency; found ${matches.length}`
+      'Android tasks-genai dependencies must use one literal com.google.mediapipe:tasks-genai:<version> coordinate'
     );
   }
-  return matches[0][1];
+
+  if (coordinateMatches.length !== 1) {
+    throw new Error(
+      `expected exactly one Android tasks-genai dependency; found ${coordinateMatches.length}`
+    );
+  }
+
+  const implementationMatches = [
+    ...source.matchAll(
+      /^\s*implementation\s*(?:\(\s*)?['"]com\.google\.mediapipe:tasks-genai:([^'"]+)['"]\s*\)?\s*;?\s*$/gm
+    ),
+  ];
+  if (implementationMatches.length !== 1) {
+    throw new Error(
+      'Android tasks-genai must have exactly one implementation declaration and no alternate dependency configuration'
+    );
+  }
+
+  return coordinateMatches[0][1];
 }
 
 function extractIosVersion(contents) {

--- a/scripts/validate-native-dependencies.mjs
+++ b/scripts/validate-native-dependencies.mjs
@@ -4,8 +4,6 @@ import { fileURLToPath } from 'node:url';
 
 export const EXPECTED_MEDIAPIPE_VERSION = '0.10.24';
 
-const ANDROID_ARTIFACTS = ['tasks-core', 'tasks-genai'];
-
 function requireMatch(value, message) {
   if (!value) {
     throw new Error(message);
@@ -13,27 +11,18 @@ function requireMatch(value, message) {
   return value;
 }
 
-function extractAndroidVersions(contents) {
-  const versions = new Map();
-  const dependencyPattern =
-    /implementation\s+['"]com\.google\.mediapipe:(tasks-core|tasks-genai):([^'"]+)['"]/g;
-
-  for (const match of contents.matchAll(dependencyPattern)) {
-    const [, artifact, version] = match;
-    if (versions.has(artifact)) {
-      throw new Error(`duplicate Android MediaPipe dependency: ${artifact}`);
-    }
-    versions.set(artifact, version);
-  }
-
-  for (const artifact of ANDROID_ARTIFACTS) {
-    requireMatch(
-      versions.get(artifact),
-      `missing Android MediaPipe dependency: ${artifact}`
+function extractAndroidVersion(contents) {
+  const matches = [
+    ...contents.matchAll(
+      /implementation\s+['"]com\.google\.mediapipe:tasks-genai:([^'"]+)['"]/g
+    ),
+  ];
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one Android tasks-genai dependency; found ${matches.length}`
     );
   }
-
-  return versions;
+  return matches[0][1];
 }
 
 function extractIosVersion(contents) {
@@ -48,11 +37,9 @@ function extractIosVersion(contents) {
 
 function extractLockedVersion(contents, podName) {
   const escapedPodName = podName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const pattern = new RegExp(
-    `^  - ${escapedPodName} \\(([^)]+)\\):?\\s*$`,
-    'm'
+  const match = contents.match(
+    new RegExp(`^  - ${escapedPodName} \\(([^)]+)\\):?\\s*$`, 'm')
   );
-  const match = contents.match(pattern);
   return requireMatch(match?.[1], `missing locked iOS pod: ${podName}`);
 }
 
@@ -71,22 +58,19 @@ export async function validateNativeDependencies({ rootDir = process.cwd() } = {
     readFile(path.join(rootDir, 'example/ios/Podfile.lock'), 'utf8'),
   ]);
 
-  const androidVersions = extractAndroidVersions(gradle);
-  const coreVersion = androidVersions.get('tasks-core');
-  const genaiVersion = androidVersions.get('tasks-genai');
+  const androidVersion = extractAndroidVersion(gradle);
   const iosVersion = extractIosVersion(podspec);
   const iosLockedVersion = extractLockedVersion(lockfile, 'MediaPipeTasksGenAI');
   const iosCLockedVersion = extractLockedVersion(lockfile, 'MediaPipeTasksGenAIC');
 
-  assertExpectedVersion(coreVersion, 'Android tasks-core');
-  assertExpectedVersion(genaiVersion, 'Android tasks-genai');
+  assertExpectedVersion(androidVersion, 'Android tasks-genai');
   assertExpectedVersion(iosVersion, 'iOS MediaPipeTasksGenAI podspec');
   assertExpectedVersion(iosLockedVersion, 'iOS MediaPipeTasksGenAI lockfile');
   assertExpectedVersion(iosCLockedVersion, 'iOS MediaPipeTasksGenAIC lockfile');
 
-  if (coreVersion !== genaiVersion || genaiVersion !== iosVersion) {
+  if (androidVersion !== iosVersion) {
     throw new Error(
-      `MediaPipe versions must match across native declarations; found tasks-core=${coreVersion}, tasks-genai=${genaiVersion}, iOS=${iosVersion}`
+      `MediaPipe versions must match across native declarations; found Android=${androidVersion}, iOS=${iosVersion}`
     );
   }
 

--- a/scripts/validate-native-dependencies.test.mjs
+++ b/scripts/validate-native-dependencies.test.mjs
@@ -10,11 +10,11 @@ import {
 } from './validate-native-dependencies.mjs';
 
 async function createFixture({
-  coreVersion = EXPECTED_MEDIAPIPE_VERSION,
-  genaiVersion = EXPECTED_MEDIAPIPE_VERSION,
+  androidVersion = EXPECTED_MEDIAPIPE_VERSION,
   podspecConstraint = `= ${EXPECTED_MEDIAPIPE_VERSION}`,
   lockedVersion = EXPECTED_MEDIAPIPE_VERSION,
   lockedCVersion = EXPECTED_MEDIAPIPE_VERSION,
+  duplicateAndroidDependency = false,
 } = {}) {
   const rootDir = await mkdtemp(
     path.join(os.tmpdir(), 'amaryllis-native-deps-')
@@ -22,9 +22,11 @@ async function createFixture({
   await mkdir(path.join(rootDir, 'android'), { recursive: true });
   await mkdir(path.join(rootDir, 'example/ios'), { recursive: true });
 
+  const androidDependency =
+    `  implementation 'com.google.mediapipe:tasks-genai:${androidVersion}'\n`;
   await writeFile(
     path.join(rootDir, 'android/build.gradle'),
-    `dependencies {\n  implementation 'com.google.mediapipe:tasks-core:${coreVersion}'\n  implementation 'com.google.mediapipe:tasks-genai:${genaiVersion}'\n}\n`
+    `dependencies {\n${androidDependency}${duplicateAndroidDependency ? androidDependency : ''}}\n`
   );
   await writeFile(
     path.join(rootDir, 'Amaryllis.podspec'),
@@ -48,10 +50,7 @@ async function withFixture(options, callback) {
 }
 
 test('repository declarations use the reviewed MediaPipe baseline', async () => {
-  assert.equal(
-    await validateNativeDependencies(),
-    EXPECTED_MEDIAPIPE_VERSION
-  );
+  assert.equal(await validateNativeDependencies(), EXPECTED_MEDIAPIPE_VERSION);
 });
 
 test('accepts the reviewed cross-platform MediaPipe baseline', async () => {
@@ -64,10 +63,19 @@ test('accepts the reviewed cross-platform MediaPipe baseline', async () => {
 });
 
 test('rejects floating Android MediaPipe versions', async () => {
-  await withFixture({ genaiVersion: 'latest.release' }, async (rootDir) => {
+  await withFixture({ androidVersion: 'latest.release' }, async (rootDir) => {
     await assert.rejects(
       validateNativeDependencies({ rootDir }),
-      /tasks-genai must be pinned to 0\.10\.24/
+      /Android tasks-genai must be pinned to 0\.10\.24/
+    );
+  });
+});
+
+test('rejects duplicate Android MediaPipe declarations', async () => {
+  await withFixture({ duplicateAndroidDependency: true }, async (rootDir) => {
+    await assert.rejects(
+      validateNativeDependencies({ rootDir }),
+      /expected exactly one Android tasks-genai dependency; found 2/
     );
   });
 });

--- a/scripts/validate-native-dependencies.test.mjs
+++ b/scripts/validate-native-dependencies.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  EXPECTED_MEDIAPIPE_VERSION,
+  validateNativeDependencies,
+} from './validate-native-dependencies.mjs';
+
+async function createFixture({
+  coreVersion = EXPECTED_MEDIAPIPE_VERSION,
+  genaiVersion = EXPECTED_MEDIAPIPE_VERSION,
+  podspecConstraint = `= ${EXPECTED_MEDIAPIPE_VERSION}`,
+  lockedVersion = EXPECTED_MEDIAPIPE_VERSION,
+  lockedCVersion = EXPECTED_MEDIAPIPE_VERSION,
+} = {}) {
+  const rootDir = await mkdtemp(
+    path.join(os.tmpdir(), 'amaryllis-native-deps-')
+  );
+  await mkdir(path.join(rootDir, 'android'), { recursive: true });
+  await mkdir(path.join(rootDir, 'example/ios'), { recursive: true });
+
+  await writeFile(
+    path.join(rootDir, 'android/build.gradle'),
+    `dependencies {\n  implementation 'com.google.mediapipe:tasks-core:${coreVersion}'\n  implementation 'com.google.mediapipe:tasks-genai:${genaiVersion}'\n}\n`
+  );
+  await writeFile(
+    path.join(rootDir, 'Amaryllis.podspec'),
+    `Pod::Spec.new do |s|\n  s.dependency \"MediaPipeTasksGenAI\", \"${podspecConstraint}\"\nend\n`
+  );
+  await writeFile(
+    path.join(rootDir, 'example/ios/Podfile.lock'),
+    `PODS:\n  - MediaPipeTasksGenAI (${lockedVersion}):\n    - MediaPipeTasksGenAIC (= ${lockedCVersion})\n  - MediaPipeTasksGenAIC (${lockedCVersion})\n`
+  );
+
+  return rootDir;
+}
+
+async function withFixture(options, callback) {
+  const rootDir = await createFixture(options);
+  try {
+    await callback(rootDir);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+test('accepts the reviewed cross-platform MediaPipe baseline', async () => {
+  await withFixture({}, async (rootDir) => {
+    assert.equal(
+      await validateNativeDependencies({ rootDir }),
+      EXPECTED_MEDIAPIPE_VERSION
+    );
+  });
+});
+
+test('rejects floating Android MediaPipe versions', async () => {
+  await withFixture({ genaiVersion: 'latest.release' }, async (rootDir) => {
+    await assert.rejects(
+      validateNativeDependencies({ rootDir }),
+      /tasks-genai must be pinned to 0\.10\.24/
+    );
+  });
+});
+
+test('rejects unconstrained iOS MediaPipe dependency', async () => {
+  const rootDir = await createFixture();
+  try {
+    await writeFile(
+      path.join(rootDir, 'Amaryllis.podspec'),
+      'Pod::Spec.new do |s|\n  s.dependency "MediaPipeTasksGenAI"\nend\n'
+    );
+    await assert.rejects(
+      validateNativeDependencies({ rootDir }),
+      /must use an exact CocoaPods version constraint/
+    );
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test('rejects Android and iOS MediaPipe version drift', async () => {
+  await withFixture({ podspecConstraint: '= 0.10.23' }, async (rootDir) => {
+    await assert.rejects(
+      validateNativeDependencies({ rootDir }),
+      /iOS MediaPipeTasksGenAI podspec must be pinned to 0\.10\.24/
+    );
+  });
+});
+
+test('rejects a stale iOS lockfile', async () => {
+  await withFixture({ lockedVersion: '0.10.23' }, async (rootDir) => {
+    await assert.rejects(
+      validateNativeDependencies({ rootDir }),
+      /lockfile must be pinned to 0\.10\.24/
+    );
+  });
+});

--- a/scripts/validate-native-dependencies.test.mjs
+++ b/scripts/validate-native-dependencies.test.mjs
@@ -47,6 +47,13 @@ async function withFixture(options, callback) {
   }
 }
 
+test('repository declarations use the reviewed MediaPipe baseline', async () => {
+  assert.equal(
+    await validateNativeDependencies(),
+    EXPECTED_MEDIAPIPE_VERSION
+  );
+});
+
 test('accepts the reviewed cross-platform MediaPipe baseline', async () => {
   await withFixture({}, async (rootDir) => {
     assert.equal(

--- a/scripts/validate-native-dependencies.test.mjs
+++ b/scripts/validate-native-dependencies.test.mjs
@@ -15,6 +15,7 @@ async function createFixture({
   lockedVersion = EXPECTED_MEDIAPIPE_VERSION,
   lockedCVersion = EXPECTED_MEDIAPIPE_VERSION,
   duplicateAndroidDependency = false,
+  extraAndroidDeclaration = '',
 } = {}) {
   const rootDir = await mkdtemp(
     path.join(os.tmpdir(), 'amaryllis-native-deps-')
@@ -26,7 +27,7 @@ async function createFixture({
     `  implementation 'com.google.mediapipe:tasks-genai:${androidVersion}'\n`;
   await writeFile(
     path.join(rootDir, 'android/build.gradle'),
-    `dependencies {\n${androidDependency}${duplicateAndroidDependency ? androidDependency : ''}}\n`
+    `dependencies {\n${androidDependency}${duplicateAndroidDependency ? androidDependency : ''}${extraAndroidDeclaration}}\n`
   );
   await writeFile(
     path.join(rootDir, 'Amaryllis.podspec'),
@@ -78,6 +79,51 @@ test('rejects duplicate Android MediaPipe declarations', async () => {
       /expected exactly one Android tasks-genai dependency; found 2/
     );
   });
+});
+
+test('rejects a floating api shadow declaration', async () => {
+  await withFixture(
+    {
+      extraAndroidDeclaration:
+        "  api 'com.google.mediapipe:tasks-genai:latest.release'\n",
+    },
+    async (rootDir) => {
+      await assert.rejects(
+        validateNativeDependencies({ rootDir }),
+        /expected exactly one Android tasks-genai dependency; found 2/
+      );
+    }
+  );
+});
+
+test('rejects a runtimeOnly shadow declaration', async () => {
+  await withFixture(
+    {
+      extraAndroidDeclaration:
+        `  runtimeOnly 'com.google.mediapipe:tasks-genai:${EXPECTED_MEDIAPIPE_VERSION}'\n`,
+    },
+    async (rootDir) => {
+      await assert.rejects(
+        validateNativeDependencies({ rootDir }),
+        /expected exactly one Android tasks-genai dependency; found 2/
+      );
+    }
+  );
+});
+
+test('rejects alternate tasks-genai notation outside the single implementation authority', async () => {
+  await withFixture(
+    {
+      extraAndroidDeclaration:
+        "  api group: 'com.google.mediapipe', name: 'tasks-genai', version: '0.10.24'\n",
+    },
+    async (rootDir) => {
+      await assert.rejects(
+        validateNativeDependencies({ rootDir }),
+        /must use one literal com\.google\.mediapipe:tasks-genai:<version> coordinate/
+      );
+    }
+  );
 });
 
 test('rejects unconstrained iOS MediaPipe dependency', async () => {


### PR DESCRIPTION
## Summary

Pin the native MediaPipe GenAI dependency surface to the reviewed 0.10.24 baseline on Android and iOS, remove a redundant Android task-core declaration, and add a fail-closed repository guard against floating or drifted versions.

Closes #115

## What changed

- replace Android `tasks-genai:latest.release` with exact `tasks-genai:0.10.24`;
- remove the separate direct `tasks-core` declaration because Amaryllis has no direct task-core imports and Google documents `tasks-genai` as the LLM Inference application dependency;
- constrain `MediaPipeTasksGenAI` in `Amaryllis.podspec` to `= 0.10.24`;
- add a dependency-free validation script that requires one Android GenAI declaration, the exact iOS constraint, matching 0.10.24 lock entries, and cross-platform version agreement;
- require the Android declaration to have one `implementation` authority while rejecting shadow `api`, `runtimeOnly`, duplicate, floating, or unsupported alternate `tasks-genai` declarations;
- add deterministic fixture coverage for floating/duplicate/alternate Android declarations, unconstrained CocoaPods declarations, version drift, and stale iOS lock resolution;
- list the native dependency policy test explicitly in the existing mandatory `node --test` CI step;
- keep the branch current with `main` after unrelated Verify work landed.

## Why

The previous dynamic Android and unconstrained CocoaPods declarations allowed the native API/runtime surface to change without an Amaryllis repository change. That makes lifecycle behavior—especially cancellation work in #89—non-reproducible and weakens supply-chain reviewability.

The review/fix pass also found that the original #115 plan unnecessarily preserved a direct `tasks-core` dependency despite no direct task-core imports. Removing it follows economy of mechanism and leaves one Android GenAI dependency authority.

## Review fix

Review identified that the first dependency guard only scanned Gradle `implementation`, so a second floating `api` or `runtimeOnly` declaration could bypass the guard. The final guard now scans all literal `tasks-genai` coordinates after comment stripping, requires exactly one declaration, and separately requires that sole declaration to use `implementation`. Unsupported alternate notation also fails closed rather than becoming a shadow dependency authority.

## Validation

- deterministic policy suite: 10 tests covering the repository baseline and negative pin/drift/duplicate/alternate-configuration cases;
- mandatory CI policy step on the final head;
- branch diff reviewed against current `main`;
- Android/iOS PR CI provides platform dependency-resolution/build verification against 0.10.24.

## Non-goals

- no MediaPipe lifecycle/API changes;
- no cancellation implementation from #89;
- no GitHub Actions pinning from #111;
- no upgrade beyond the already-reviewed 0.10.24 baseline.