### PR TITLE
verify: implement local runner and CLI

### DIFF
--- a/docs/verify-local-runner.md
+++ b/docs/verify-local-runner.md
@@ -1,0 +1,115 @@
+# Local Verify Runner
+
+Amaryllis Verify currently runs as **repository tooling** while the v1alpha1 behavior stabilizes. The public contract is defined in [Verify v1alpha1](./verify-v1alpha1.md); package promotion is tracked separately in #120.
+
+The current implementation lives under:
+
+```text
+packages/amaryllis-components/tools/verify/
+```
+
+This is temporary dependency reuse, not an `@micrantha/amaryllis-components` public API. The tooling directory is not included in the Components package files or exports.
+
+## Commands
+
+Run commands from the repository root.
+
+### Validate evidence
+
+```bash
+node packages/amaryllis-components/tools/verify/cli.mjs validate \
+  --evidence evidence.json
+```
+
+This checks JSON Schema and semantic invariants without running a device or model.
+
+Exit codes:
+
+- `0` — evidence is valid;
+- `64` — invalid evidence, usage, path, or JSON input;
+- `70` — unexpected tooling failure.
+
+### Check compatibility
+
+```bash
+node packages/amaryllis-components/tools/verify/cli.mjs check \
+  --evidence evidence.json
+```
+
+`check` validates the evidence, re-derives the compatibility decision from the retained evidence and embedded application policy, and rejects a mismatched/tampered embedded decision.
+
+Exit codes:
+
+- `0` — completed execution with `pass` or `warn` compatibility decision;
+- `2` — completed execution with `fail` compatibility decision;
+- `3` — `unknown` compatibility decision **or any non-completed execution**;
+- `64` — invalid/tampered evidence or usage;
+- `70` — unexpected tooling failure.
+
+A compatibility-only `pass` does not make a partial, failed, or cancelled verification run suitable for promotion.
+
+### Run the local fake adapter
+
+Until real Android/iOS adapters are implemented in #117, the runner can be exercised through a deterministic local adapter script:
+
+```bash
+node packages/amaryllis-components/tools/verify/cli.mjs run \
+  --manifest verify.json \
+  --adapter-script adapter.json \
+  --output evidence.json
+```
+
+`run` returns `0` whenever it successfully produces and writes a valid evidence artifact, including when that artifact contains a compatibility `fail` or `unknown` decision. Use `check` as the separate CI/promotion gate.
+
+Runner or target-setup failures that prevent valid evidence from being produced return `70`. Invalid manifest/fixture/path input returns `64`.
+
+## Local-only boundary
+
+The v1alpha1 local runner intentionally has no remote fixture-fetch capability.
+
+- manifest fixture references must be local filesystem paths;
+- HTTP(S), cloud-storage URI, `file:` URI, and UNC-style references are rejected;
+- relative fixture paths are resolved beneath the manifest directory;
+- real paths are checked to prevent `..`/symlink escape;
+- absolute fixture paths are disabled by default;
+- declared fixture SHA-256 digests are verified;
+- fixture size is bounded before reading;
+- fixture bytes remain in adapter context and are not copied into normal evidence.
+
+The fake adapter script and CLI input/output arguments are also explicit local files. The runner does not perform network fallback.
+
+## Adapter trust boundary
+
+Adapters may emit only metrics, checks, and evaluations declared by the manifest.
+
+Each iteration result is validated **before** it mutates accumulated evidence. A result containing an undeclared field/target, invalid value, conflicting available/unavailable target, or malformed identifier is rejected atomically; cleanup still runs and the failed iteration is not committed.
+
+Diagnostic messages are bounded and sanitized. Raw logs, prompts, model output, retrieved context, fixture content, arbitrary telemetry, and application payloads are not fields in the evidence contract.
+
+## Lifecycle
+
+The runner owns:
+
+```text
+manifest validation
+  -> bounded fixture resolution
+  -> capability discovery
+  -> prepare
+  -> warmup
+  -> repetitions
+  -> deterministic aggregation
+  -> application policy evaluation
+  -> bounded cleanup
+  -> evidence validation
+```
+
+The scenario timeout starts before fixture resolution and covers setup/warmup/execution. Cleanup has a separate bounded timeout so cancellation or target failure cannot make teardown unbounded.
+
+Execution status and compatibility decision remain separate. For example, cleanup may fail after all required measurements were successfully collected; the evidence can retain a compatibility `pass` while its execution status is `partial`. The `check` command still blocks that incomplete run.
+
+## Next steps
+
+- #117 — real attached-device Android/iOS adapters;
+- #120 — move the stable tooling into a dedicated `@micrantha/amaryllis-verify` workspace/package with generated Yarn lockfile and release/SBOM/provenance handling.
+
+No hosted service, device farm, telemetry ingestion, or model deployment is required by this runner.

--- a/docs/verify-local-runner.md
+++ b/docs/verify-local-runner.md
@@ -76,6 +76,8 @@ The v1alpha1 local runner intentionally has no remote fixture-fetch capability.
 - fixture size is bounded before reading;
 - fixture bytes remain in adapter context and are not copied into normal evidence.
 
+These checks validate a stable local fixture tree; they are not a filesystem-isolation boundary against another actor concurrently mutating the fixture directory during a run. Callers that require protection from hostile concurrent mutation must provide an isolated or otherwise immutable workspace/fixture tree.
+
 The fake adapter script and CLI input/output arguments are also explicit local files. The runner does not perform network fallback.
 
 ## Adapter trust boundary

--- a/packages/amaryllis-components/tools/verify/cli.mjs
+++ b/packages/amaryllis-components/tools/verify/cli.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { Command, CommanderError } from 'commander';
+
+import { FakePlatformAdapter } from './fake-adapter.mjs';
+import { evaluateCompatibility } from './policy.mjs';
+import { runVerification, VerifyRunnerError } from './runner.mjs';
+import {
+  isLocalPathReference,
+  loadVerifySchemaBundle,
+  VerifyValidator,
+} from './validator.mjs';
+
+const EXIT = {
+  ok: 0,
+  compatibilityFail: 2,
+  compatibilityUnknown: 3,
+  invalidInput: 64,
+  internalFailure: 70,
+};
+
+function repositoryRootFromTool() {
+  return path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../..');
+}
+
+function defaultValidator() {
+  return new VerifyValidator(
+    loadVerifySchemaBundle(
+      path.join(repositoryRootFromTool(), 'schemas/verify/v1alpha1')
+    )
+  );
+}
+
+function isUncPath(value) {
+  return value.startsWith('\\\\') || value.startsWith('//');
+}
+
+function resolveLocalPath(value, baseDirectory = process.cwd()) {
+  if (!isLocalPathReference(value) || isUncPath(value)) {
+    throw new VerifyRunnerError(
+      'cli.non-local-path',
+      `expected a local filesystem path, got ${value}`
+    );
+  }
+  return path.resolve(baseDirectory, value);
+}
+
+async function readJsonFile(filePath) {
+  const source = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(source);
+}
+
+function validationText(result) {
+  return result.issues
+    .map((issue) => `${issue.path} ${issue.code}: ${issue.message}`)
+    .join('\n');
+}
+
+function decisionProjection(decision) {
+  return {
+    status: decision.status,
+    reasons: decision.reasons.map(({ requirementId, code }) => ({
+      ...(requirementId ? { requirementId } : {}),
+      code,
+    })),
+  };
+}
+
+function sameDecision(left, right) {
+  return JSON.stringify(decisionProjection(left)) === JSON.stringify(decisionProjection(right));
+}
+
+export function renderSummary(evidence) {
+  const execution = evidence.execution.status;
+  const decision = evidence.decision.status;
+  const subject = `${evidence.subject.application.id}@${evidence.subject.application.version}`;
+  const model = `${evidence.subject.model.id}@${evidence.subject.model.version ?? '<unversioned>'}`;
+  const target = `${evidence.environment.platform} ${evidence.environment.device.model}`;
+  return `${subject} / ${model} / ${target}: execution=${execution}, decision=${decision}`;
+}
+
+function checkExitCode(evidence) {
+  if (evidence.execution.status !== 'completed') {
+    return EXIT.compatibilityUnknown;
+  }
+
+  switch (evidence.decision.status) {
+    case 'pass':
+    case 'warn':
+      return EXIT.ok;
+    case 'fail':
+      return EXIT.compatibilityFail;
+    case 'unknown':
+      return EXIT.compatibilityUnknown;
+    default:
+      return EXIT.invalidInput;
+  }
+}
+
+async function writeJsonAtomically(filePath, value) {
+  const directory = path.dirname(filePath);
+  await fs.access(directory);
+  const temporary = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`
+  );
+
+  try {
+    await fs.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    await fs.rename(temporary, filePath);
+  } catch (error) {
+    await fs.rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+function runnerErrorExitCode(error) {
+  if (!(error instanceof VerifyRunnerError)) {
+    return EXIT.internalFailure;
+  }
+
+  if (
+    error.code === 'invalid-manifest' ||
+    error.code.startsWith('fixture.') ||
+    error.code.startsWith('target.') ||
+    error.code.startsWith('cli.')
+  ) {
+    return EXIT.invalidInput;
+  }
+
+  return EXIT.internalFailure;
+}
+
+function createProgram({ validator, stdout, stderr, adapterFactory, run = runVerification }) {
+  const program = new Command();
+  program
+    .name('amaryllis-verify')
+    .description('Local Amaryllis Verify v1alpha1 tooling')
+    .exitOverride()
+    .configureOutput({
+      writeOut: (text) => stdout(text),
+      writeErr: (text) => stderr(text),
+    });
+
+  program
+    .command('validate')
+    .requiredOption('--evidence <path>', 'VerificationEvidence JSON file')
+    .action(async ({ evidence: evidencePath }) => {
+      const absolute = resolveLocalPath(evidencePath);
+      const evidence = await readJsonFile(absolute);
+      const result = validator.validateEvidence(evidence);
+      if (!result.valid) {
+        stderr(`${validationText(result)}\n`);
+        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        return;
+      }
+      stdout('valid\n');
+      program.setOptionValueWithSource('__result', EXIT.ok, 'implied');
+    });
+
+  program
+    .command('check')
+    .requiredOption('--evidence <path>', 'VerificationEvidence JSON file')
+    .action(async ({ evidence: evidencePath }) => {
+      const absolute = resolveLocalPath(evidencePath);
+      const evidence = await readJsonFile(absolute);
+      const result = validator.validateEvidence(evidence);
+      if (!result.valid) {
+        stderr(`${validationText(result)}\n`);
+        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        return;
+      }
+
+      const derived = evaluateCompatibility(evidence);
+      if (!sameDecision(evidence.decision, derived)) {
+        stderr('embedded compatibility decision does not match validated evidence and policy\n');
+        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        return;
+      }
+
+      stdout(`${renderSummary(evidence)}\n`);
+      program.setOptionValueWithSource('__result', checkExitCode(evidence), 'implied');
+    });
+
+  program
+    .command('run')
+    .requiredOption('--manifest <path>', 'VerificationManifest JSON file')
+    .requiredOption('--output <path>', 'output VerificationEvidence JSON file')
+    .requiredOption('--adapter-script <path>', 'local deterministic adapter script JSON')
+    .action(async ({ manifest: manifestPath, output, adapterScript }) => {
+      const absoluteManifest = resolveLocalPath(manifestPath);
+      const absoluteAdapter = resolveLocalPath(adapterScript);
+      const absoluteOutput = resolveLocalPath(output);
+      const manifest = await readJsonFile(absoluteManifest);
+      const script = await readJsonFile(absoluteAdapter);
+      const adapter = adapterFactory(script);
+
+      const evidence = await run({
+        manifest,
+        validator,
+        adapter,
+        baseDirectory: path.dirname(absoluteManifest),
+      });
+      await writeJsonAtomically(absoluteOutput, evidence);
+      stdout(`${renderSummary(evidence)}\n`);
+      program.setOptionValueWithSource('__result', EXIT.ok, 'implied');
+    });
+
+  return program;
+}
+
+export async function runCli(
+  argv,
+  {
+    validator = defaultValidator(),
+    stdout = (text) => process.stdout.write(text),
+    stderr = (text) => process.stderr.write(text),
+    adapterFactory = (script) => new FakePlatformAdapter(script),
+    run = runVerification,
+  } = {}
+) {
+  const program = createProgram({ validator, stdout, stderr, adapterFactory, run });
+
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+    return program.getOptionValue('__result') ?? EXIT.ok;
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      if (error.code === 'commander.helpDisplayed') {
+        return EXIT.ok;
+      }
+      return EXIT.invalidInput;
+    }
+
+    if (error instanceof SyntaxError) {
+      stderr(`invalid JSON: ${error.message}\n`);
+      return EXIT.invalidInput;
+    }
+
+    if (error instanceof VerifyRunnerError) {
+      stderr(`${error.code}: ${error.message}\n`);
+      return runnerErrorExitCode(error);
+    }
+
+    stderr(`${error instanceof Error ? error.message : String(error)}\n`);
+    return EXIT.internalFailure;
+  }
+}
+
+async function main() {
+  return runCli(process.argv.slice(2));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  process.exitCode = await main();
+}

--- a/packages/amaryllis-components/tools/verify/cli.mjs
+++ b/packages/amaryllis-components/tools/verify/cli.mjs
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { Command, CommanderError } from 'commander';
 
@@ -24,7 +24,7 @@ const EXIT = {
 };
 
 function repositoryRootFromTool() {
-  return path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../..');
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 }
 
 function defaultValidator() {
@@ -50,7 +50,16 @@ function resolveLocalPath(value, baseDirectory = process.cwd()) {
 }
 
 async function readJsonFile(filePath) {
-  const source = await fs.readFile(filePath, 'utf8');
+  let source;
+  try {
+    source = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    throw new VerifyRunnerError(
+      'cli.input-read-failed',
+      `could not read ${filePath}`,
+      { cause: error }
+    );
+  }
   return JSON.parse(source);
 }
 
@@ -138,7 +147,17 @@ function runnerErrorExitCode(error) {
   return EXIT.internalFailure;
 }
 
-function createProgram({ validator, stdout, stderr, adapterFactory, run = runVerification }) {
+function actionOptions(args) {
+  const command = args.at(-1);
+  return command.opts();
+}
+
+function createProgram({ validator, stdout, stderr, adapterFactory, run }) {
+  let resultCode = EXIT.ok;
+  const setResult = (code) => {
+    resultCode = code;
+  };
+
   const program = new Command();
   program
     .name('amaryllis-verify')
@@ -152,41 +171,43 @@ function createProgram({ validator, stdout, stderr, adapterFactory, run = runVer
   program
     .command('validate')
     .requiredOption('--evidence <path>', 'VerificationEvidence JSON file')
-    .action(async ({ evidence: evidencePath }) => {
+    .action(async (...args) => {
+      const { evidence: evidencePath } = actionOptions(args);
       const absolute = resolveLocalPath(evidencePath);
       const evidence = await readJsonFile(absolute);
       const result = validator.validateEvidence(evidence);
       if (!result.valid) {
         stderr(`${validationText(result)}\n`);
-        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        setResult(EXIT.invalidInput);
         return;
       }
       stdout('valid\n');
-      program.setOptionValueWithSource('__result', EXIT.ok, 'implied');
+      setResult(EXIT.ok);
     });
 
   program
     .command('check')
     .requiredOption('--evidence <path>', 'VerificationEvidence JSON file')
-    .action(async ({ evidence: evidencePath }) => {
+    .action(async (...args) => {
+      const { evidence: evidencePath } = actionOptions(args);
       const absolute = resolveLocalPath(evidencePath);
       const evidence = await readJsonFile(absolute);
       const result = validator.validateEvidence(evidence);
       if (!result.valid) {
         stderr(`${validationText(result)}\n`);
-        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        setResult(EXIT.invalidInput);
         return;
       }
 
       const derived = evaluateCompatibility(evidence);
       if (!sameDecision(evidence.decision, derived)) {
         stderr('embedded compatibility decision does not match validated evidence and policy\n');
-        program.setOptionValueWithSource('__result', EXIT.invalidInput, 'implied');
+        setResult(EXIT.invalidInput);
         return;
       }
 
       stdout(`${renderSummary(evidence)}\n`);
-      program.setOptionValueWithSource('__result', checkExitCode(evidence), 'implied');
+      setResult(checkExitCode(evidence));
     });
 
   program
@@ -194,7 +215,12 @@ function createProgram({ validator, stdout, stderr, adapterFactory, run = runVer
     .requiredOption('--manifest <path>', 'VerificationManifest JSON file')
     .requiredOption('--output <path>', 'output VerificationEvidence JSON file')
     .requiredOption('--adapter-script <path>', 'local deterministic adapter script JSON')
-    .action(async ({ manifest: manifestPath, output, adapterScript }) => {
+    .action(async (...args) => {
+      const {
+        manifest: manifestPath,
+        output,
+        adapterScript,
+      } = actionOptions(args);
       const absoluteManifest = resolveLocalPath(manifestPath);
       const absoluteAdapter = resolveLocalPath(adapterScript);
       const absoluteOutput = resolveLocalPath(output);
@@ -210,10 +236,13 @@ function createProgram({ validator, stdout, stderr, adapterFactory, run = runVer
       });
       await writeJsonAtomically(absoluteOutput, evidence);
       stdout(`${renderSummary(evidence)}\n`);
-      program.setOptionValueWithSource('__result', EXIT.ok, 'implied');
+      setResult(EXIT.ok);
     });
 
-  return program;
+  return {
+    program,
+    getResultCode: () => resultCode,
+  };
 }
 
 export async function runCli(
@@ -226,11 +255,17 @@ export async function runCli(
     run = runVerification,
   } = {}
 ) {
-  const program = createProgram({ validator, stdout, stderr, adapterFactory, run });
+  const { program, getResultCode } = createProgram({
+    validator,
+    stdout,
+    stderr,
+    adapterFactory,
+    run,
+  });
 
   try {
     await program.parseAsync(argv, { from: 'user' });
-    return program.getOptionValue('__result') ?? EXIT.ok;
+    return getResultCode();
   } catch (error) {
     if (error instanceof CommanderError) {
       if (error.code === 'commander.helpDisplayed') {

--- a/packages/amaryllis-components/tools/verify/cli.test.mjs
+++ b/packages/amaryllis-components/tools/verify/cli.test.mjs
@@ -1,0 +1,374 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { runCli } from './cli.mjs';
+import { evaluateCompatibility } from './policy.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const exampleDirectory = path.join(repositoryRoot, 'docs/examples/verify');
+
+const DIGEST_A = 'a'.repeat(64);
+const DIGEST_B = 'b'.repeat(64);
+const DIGEST_C = 'c'.repeat(64);
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+async function readExample(name) {
+  return JSON.parse(
+    await fs.readFile(path.join(exampleDirectory, name), 'utf8')
+  );
+}
+
+async function writeJson(filePath, value) {
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function capture() {
+  let stdout = '';
+  let stderr = '';
+  return {
+    options: {
+      stdout: (text) => {
+        stdout += text;
+      },
+      stderr: (text) => {
+        stderr += text;
+      },
+    },
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+function makeManifest() {
+  return {
+    apiVersion: 'amaryllis.dev/verify/v1alpha1',
+    kind: 'VerificationManifest',
+    metadata: { name: 'cli-test' },
+    subject: {
+      application: {
+        id: 'com.example.verify',
+        version: '1.0.0',
+        digest: { algorithm: 'sha256', value: DIGEST_A },
+      },
+      runtime: {
+        package: '@micrantha/react-native-amaryllis',
+        version: '0.1.7',
+        digest: { algorithm: 'sha256', value: DIGEST_B },
+      },
+      model: {
+        id: 'test-model',
+        version: '1',
+        format: 'mediapipe-task',
+        digest: { algorithm: 'sha256', value: DIGEST_C },
+      },
+    },
+    target: {
+      platform: 'android',
+      requiredCapabilities: ['physical-device'],
+    },
+    scenario: {
+      id: 'cli-smoke',
+      version: '1.0.0',
+      timeoutMs: 1000,
+      warmupRuns: 0,
+      repetitions: 1,
+    },
+    collect: {
+      metrics: ['timing.initialization.ms'],
+      checks: [],
+      evaluations: [],
+    },
+    policy: {
+      requirements: [
+        {
+          id: 'startup',
+          severity: 'required',
+          target: {
+            kind: 'metric',
+            name: 'timing.initialization.ms',
+          },
+          operator: 'lte',
+          value: 2000,
+          aggregate: 'max',
+          unit: 'ms',
+        },
+      ],
+    },
+  };
+}
+
+function makeAdapterScript(value = 1000) {
+  return {
+    environment: {
+      platform: 'android',
+      os: { name: 'Android', version: '15' },
+      device: {
+        manufacturer: 'Google',
+        model: 'Pixel 8',
+        architecture: 'arm64-v8a',
+        capabilities: ['physical-device'],
+      },
+    },
+    collectors: [{ name: 'timing', version: 'v1alpha1' }],
+    iterations: [
+      {
+        measurements: [
+          {
+            name: 'timing.initialization.ms',
+            unit: 'ms',
+            value,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function withTemporaryDirectory(t) {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'amaryllis-verify-cli-'));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  return temporary;
+}
+
+test('validate accepts valid evidence', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const evidencePath = path.join(temporary, 'evidence.json');
+  await writeJson(evidencePath, await readExample('android.evidence.json'));
+  const output = capture();
+
+  const code = await runCli(['validate', '--evidence', evidencePath], output.options);
+
+  assert.equal(code, 0);
+  assert.equal(output.stdout(), 'valid\n');
+  assert.equal(output.stderr(), '');
+});
+
+test('validate rejects schema-invalid evidence', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const evidence = await readExample('android.evidence.json');
+  evidence.prompt = 'must not be retained';
+  const evidencePath = path.join(temporary, 'evidence.json');
+  await writeJson(evidencePath, evidence);
+  const output = capture();
+
+  const code = await runCli(['validate', '--evidence', evidencePath], output.options);
+
+  assert.equal(code, 64);
+  assert.match(output.stderr(), /additionalProperties/);
+});
+
+test('check maps warn to zero and unknown to three', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const androidPath = path.join(temporary, 'android.json');
+  const iosPath = path.join(temporary, 'ios.json');
+  await writeJson(androidPath, await readExample('android.evidence.json'));
+  await writeJson(iosPath, await readExample('ios.evidence.json'));
+
+  assert.equal(
+    await runCli(['check', '--evidence', androidPath], capture().options),
+    0
+  );
+  assert.equal(
+    await runCli(['check', '--evidence', iosPath], capture().options),
+    3
+  );
+});
+
+test('check maps a required compatibility violation to two', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const evidence = await readExample('android.evidence.json');
+  const startup = evidence.policy.requirements.find(({ id }) => id === 'startup-budget');
+  startup.value = 500;
+  evidence.decision = evaluateCompatibility(evidence);
+  const evidencePath = path.join(temporary, 'fail.json');
+  await writeJson(evidencePath, evidence);
+
+  assert.equal(
+    await runCli(['check', '--evidence', evidencePath], capture().options),
+    2
+  );
+});
+
+test('check rejects a tampered embedded decision', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const evidence = await readExample('ios.evidence.json');
+  evidence.decision = { status: 'pass', reasons: [] };
+  const evidencePath = path.join(temporary, 'tampered.json');
+  await writeJson(evidencePath, evidence);
+  const output = capture();
+
+  const code = await runCli(['check', '--evidence', evidencePath], output.options);
+
+  assert.equal(code, 64);
+  assert.match(output.stderr(), /does not match/);
+});
+
+test('check blocks incomplete execution even when compatibility evidence passes', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const evidence = await readExample('android.evidence.json');
+  evidence.policy.requirements = evidence.policy.requirements.filter(
+    ({ id }) => id !== 'thermal-observation'
+  );
+  evidence.unavailable = [];
+  evidence.execution.status = 'partial';
+  evidence.decision = evaluateCompatibility(evidence);
+  assert.equal(evidence.decision.status, 'pass');
+  const evidencePath = path.join(temporary, 'partial.json');
+  await writeJson(evidencePath, evidence);
+
+  assert.equal(
+    await runCli(['check', '--evidence', evidencePath], capture().options),
+    3
+  );
+});
+
+test('missing input and malformed JSON are invalid input, not internal failures', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const missing = path.join(temporary, 'missing.json');
+  const malformed = path.join(temporary, 'malformed.json');
+  await fs.writeFile(malformed, '{not-json', 'utf8');
+
+  assert.equal(
+    await runCli(['validate', '--evidence', missing], capture().options),
+    64
+  );
+  assert.equal(
+    await runCli(['validate', '--evidence', malformed], capture().options),
+    64
+  );
+});
+
+test('remote-looking CLI paths are rejected', async () => {
+  assert.equal(
+    await runCli(
+      ['validate', '--evidence', 'https://example.invalid/evidence.json'],
+      capture().options
+    ),
+    64
+  );
+});
+
+test('run writes valid passing evidence and returns zero', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const manifestPath = path.join(temporary, 'manifest.json');
+  const adapterPath = path.join(temporary, 'adapter.json');
+  const outputPath = path.join(temporary, 'evidence.json');
+  await writeJson(manifestPath, makeManifest());
+  await writeJson(adapterPath, makeAdapterScript(1000));
+  const output = capture();
+
+  const code = await runCli(
+    [
+      'run',
+      '--manifest',
+      manifestPath,
+      '--output',
+      outputPath,
+      '--adapter-script',
+      adapterPath,
+    ],
+    output.options
+  );
+
+  assert.equal(code, 0);
+  const evidence = JSON.parse(await fs.readFile(outputPath, 'utf8'));
+  assert.equal(evidence.execution.status, 'completed');
+  assert.equal(evidence.decision.status, 'pass');
+  assert.match(output.stdout(), /execution=completed, decision=pass/);
+});
+
+test('run returns zero when valid evidence has a compatibility fail decision', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const manifestPath = path.join(temporary, 'manifest.json');
+  const adapterPath = path.join(temporary, 'adapter.json');
+  const outputPath = path.join(temporary, 'evidence.json');
+  await writeJson(manifestPath, makeManifest());
+  await writeJson(adapterPath, makeAdapterScript(3000));
+
+  const code = await runCli(
+    [
+      'run',
+      '--manifest',
+      manifestPath,
+      '--output',
+      outputPath,
+      '--adapter-script',
+      adapterPath,
+    ],
+    capture().options
+  );
+
+  assert.equal(code, 0);
+  const evidence = JSON.parse(await fs.readFile(outputPath, 'utf8'));
+  assert.equal(evidence.decision.status, 'fail');
+});
+
+test('run returns seventy and does not create evidence when target setup cannot start', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const manifestPath = path.join(temporary, 'manifest.json');
+  const adapterPath = path.join(temporary, 'adapter.json');
+  const outputPath = path.join(temporary, 'evidence.json');
+  await writeJson(manifestPath, makeManifest());
+  await writeJson(adapterPath, {
+    ...makeAdapterScript(),
+    failure: {
+      phase: 'capabilities',
+      message: 'target unavailable',
+    },
+  });
+
+  const code = await runCli(
+    [
+      'run',
+      '--manifest',
+      manifestPath,
+      '--output',
+      outputPath,
+      '--adapter-script',
+      adapterPath,
+    ],
+    capture().options
+  );
+
+  assert.equal(code, 70);
+  await assert.rejects(() => fs.access(outputPath));
+});
+
+test('run rejects invalid manifest as input error', async (t) => {
+  const temporary = await withTemporaryDirectory(t);
+  const manifest = makeManifest();
+  manifest.policy.requirements = [];
+  const manifestPath = path.join(temporary, 'manifest.json');
+  const adapterPath = path.join(temporary, 'adapter.json');
+  const outputPath = path.join(temporary, 'evidence.json');
+  await writeJson(manifestPath, manifest);
+  await writeJson(adapterPath, makeAdapterScript());
+
+  const code = await runCli(
+    [
+      'run',
+      '--manifest',
+      manifestPath,
+      '--output',
+      outputPath,
+      '--adapter-script',
+      adapterPath,
+    ],
+    capture().options
+  );
+
+  assert.equal(code, 64);
+  await assert.rejects(() => fs.access(outputPath));
+});
+
+test('missing required CLI options return usage error', async () => {
+  assert.equal(await runCli(['run'], capture().options), 64);
+});

--- a/packages/amaryllis-components/tools/verify/fake-adapter.mjs
+++ b/packages/amaryllis-components/tools/verify/fake-adapter.mjs
@@ -1,0 +1,81 @@
+function scriptedError(failure, phase, iteration) {
+  if (!failure || failure.phase !== phase) {
+    return null;
+  }
+  if (failure.iteration !== undefined && failure.iteration !== iteration) {
+    return null;
+  }
+
+  const error = new Error(failure.message ?? `fake adapter ${phase} failure`);
+  error.code = failure.code ?? `fake-${phase}-failure`;
+  return error;
+}
+
+async function delay(milliseconds, signal) {
+  if (!milliseconds || milliseconds <= 0) {
+    return;
+  }
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error ? signal.reason : new Error('operation aborted');
+  }
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, milliseconds);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason instanceof Error ? signal.reason : new Error('operation aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    timer.unref?.();
+  });
+}
+
+export class FakePlatformAdapter {
+  constructor(script) {
+    this.script = structuredClone(script ?? {});
+    this.calls = [];
+  }
+
+  async capabilities(signal) {
+    this.calls.push({ phase: 'capabilities' });
+    await delay(this.script.delays?.capabilitiesMs, signal);
+    const failure = scriptedError(this.script.failure, 'capabilities');
+    if (failure) throw failure;
+
+    return {
+      environment: structuredClone(this.script.environment),
+      collectors: structuredClone(this.script.collectors ?? []),
+      evaluationSuites: structuredClone(this.script.evaluationSuites ?? []),
+    };
+  }
+
+  async prepare(context, signal) {
+    this.calls.push({ phase: 'prepare', fixtureCount: context.fixtures.size });
+    await delay(this.script.delays?.prepareMs, signal);
+    const failure = scriptedError(this.script.failure, 'prepare');
+    if (failure) throw failure;
+  }
+
+  async warmup(_context, iteration, signal) {
+    this.calls.push({ phase: 'warmup', iteration });
+    await delay(this.script.delays?.warmupMs, signal);
+    const failure = scriptedError(this.script.failure, 'warmup', iteration);
+    if (failure) throw failure;
+  }
+
+  async execute(_context, iteration, signal) {
+    this.calls.push({ phase: 'execute', iteration });
+    await delay(this.script.delays?.executeMs, signal);
+    const failure = scriptedError(this.script.failure, 'execute', iteration);
+    if (failure) throw failure;
+
+    return structuredClone(this.script.iterations?.[iteration - 1] ?? {});
+  }
+
+  async cleanup(_context, signal) {
+    this.calls.push({ phase: 'cleanup' });
+    await delay(this.script.delays?.cleanupMs, signal);
+    const failure = scriptedError(this.script.failure, 'cleanup');
+    if (failure) throw failure;
+  }
+}

--- a/packages/amaryllis-components/tools/verify/fake-adapter.mjs
+++ b/packages/amaryllis-components/tools/verify/fake-adapter.mjs
@@ -20,13 +20,17 @@ async function delay(milliseconds, signal) {
   }
 
   await new Promise((resolve, reject) => {
-    const timer = setTimeout(resolve, milliseconds);
+    let timer;
     const onAbort = () => {
       clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
       reject(signal.reason instanceof Error ? signal.reason : new Error('operation aborted'));
     };
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, milliseconds);
     signal?.addEventListener('abort', onAbort, { once: true });
-    timer.unref?.();
   });
 }
 

--- a/packages/amaryllis-components/tools/verify/runner-atomic.test.mjs
+++ b/packages/amaryllis-components/tools/verify/runner-atomic.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { FakePlatformAdapter } from './fake-adapter.mjs';
+import { runVerification } from './runner.mjs';
+import { loadVerifySchemaBundle, VerifyValidator } from './validator.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const validator = new VerifyValidator(
+  loadVerifySchemaBundle(path.join(repositoryRoot, 'schemas/verify/v1alpha1'))
+);
+
+function manifest() {
+  return {
+    apiVersion: 'amaryllis.dev/verify/v1alpha1',
+    kind: 'VerificationManifest',
+    metadata: { name: 'atomic-ingestion' },
+    subject: {
+      application: { id: 'app', version: '1', digest: { algorithm: 'sha256', value: 'a'.repeat(64) } },
+      runtime: { package: '@micrantha/react-native-amaryllis', version: '0.1.7', digest: { algorithm: 'sha256', value: 'b'.repeat(64) } },
+      model: { id: 'model', version: '1', format: 'test', digest: { algorithm: 'sha256', value: 'c'.repeat(64) } },
+    },
+    target: { platform: 'android' },
+    scenario: { id: 'atomic-ingestion', version: '1', timeoutMs: 1000, repetitions: 1 },
+    collect: { metrics: ['timing.initialization.ms'], checks: [], evaluations: [] },
+    policy: {
+      requirements: [
+        {
+          id: 'startup',
+          severity: 'required',
+          target: { kind: 'metric', name: 'timing.initialization.ms' },
+          operator: 'lte',
+          value: 2000,
+          aggregate: 'max',
+          unit: 'ms',
+        },
+      ],
+    },
+  };
+}
+
+function adapter(iterationResult) {
+  return new FakePlatformAdapter({
+    environment: {
+      platform: 'android',
+      os: { name: 'Android', version: '15' },
+      device: { manufacturer: 'Google', model: 'Pixel 8', architecture: 'arm64-v8a' },
+    },
+    iterations: [iterationResult],
+  });
+}
+
+test('mixed valid and undeclared adapter telemetry cannot partially mutate evidence', async () => {
+  const fake = adapter({
+    measurements: [
+      { name: 'timing.initialization.ms', unit: 'ms', value: 900 },
+      { name: 'telemetry.unrequested', unit: 'count', value: 1 },
+    ],
+  });
+
+  const evidence = await runVerification({
+    manifest: manifest(),
+    validator,
+    adapter: fake,
+    baseDirectory: repositoryRoot,
+    idFactory: () => 'atomic-test',
+  });
+
+  assert.equal(evidence.execution.status, 'failed');
+  assert.equal(evidence.execution.repetitions.completed, 0);
+  assert.deepEqual(evidence.measurements, []);
+  assert.equal(evidence.decision.status, 'unknown');
+  assert.ok(
+    evidence.errors.some(({ code }) => code === 'adapter.undeclared-target')
+  );
+  assert.ok(fake.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('a target cannot be emitted as both available and unavailable in one iteration', async () => {
+  const fake = adapter({
+    measurements: [
+      { name: 'timing.initialization.ms', unit: 'ms', value: 900 },
+    ],
+    unavailable: [
+      {
+        kind: 'metric',
+        name: 'timing.initialization.ms',
+        reason: 'collector-failed',
+      },
+    ],
+  });
+
+  const evidence = await runVerification({
+    manifest: manifest(),
+    validator,
+    adapter: fake,
+    baseDirectory: repositoryRoot,
+    idFactory: () => 'atomic-test',
+  });
+
+  assert.deepEqual(evidence.measurements, []);
+  assert.equal(evidence.decision.status, 'unknown');
+  assert.ok(
+    evidence.errors.some(({ code }) => code === 'adapter.available-and-unavailable')
+  );
+});

--- a/packages/amaryllis-components/tools/verify/runner-timeout.test.mjs
+++ b/packages/amaryllis-components/tools/verify/runner-timeout.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { FakePlatformAdapter } from './fake-adapter.mjs';
+import { runVerification, VerifyRunnerError } from './runner.mjs';
+import { loadVerifySchemaBundle, VerifyValidator } from './validator.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const validator = new VerifyValidator(
+  loadVerifySchemaBundle(path.join(repositoryRoot, 'schemas/verify/v1alpha1'))
+);
+
+function manifest() {
+  return {
+    apiVersion: 'amaryllis.dev/verify/v1alpha1',
+    kind: 'VerificationManifest',
+    metadata: { name: 'fixture-timeout' },
+    subject: {
+      application: { id: 'app', version: '1', digest: { algorithm: 'sha256', value: 'a'.repeat(64) } },
+      runtime: { package: '@micrantha/react-native-amaryllis', version: '0.1.7', digest: { algorithm: 'sha256', value: 'b'.repeat(64) } },
+      model: { id: 'model', version: '1', format: 'test', digest: { algorithm: 'sha256', value: 'c'.repeat(64) } },
+    },
+    target: { platform: 'android' },
+    scenario: {
+      id: 'fixture-timeout',
+      version: '1',
+      timeoutMs: 10,
+      repetitions: 1,
+    },
+    collect: { metrics: ['timing.initialization.ms'], checks: [], evaluations: [] },
+    policy: {
+      requirements: [
+        {
+          id: 'startup',
+          severity: 'required',
+          target: { kind: 'metric', name: 'timing.initialization.ms' },
+          operator: 'lte',
+          value: 2000,
+          aggregate: 'max',
+          unit: 'ms',
+        },
+      ],
+    },
+  };
+}
+
+test('scenario timeout bounds fixture resolution before adapter setup', async () => {
+  const adapter = new FakePlatformAdapter({
+    environment: {
+      platform: 'android',
+      os: { name: 'Android', version: '15' },
+      device: { manufacturer: 'Google', model: 'Pixel 8', architecture: 'arm64-v8a' },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      runVerification({
+        manifest: manifest(),
+        validator,
+        adapter,
+        baseDirectory: repositoryRoot,
+        fixtureLoader: () => new Promise(() => {}),
+      }),
+    (error) =>
+      error instanceof VerifyRunnerError &&
+      error.code === 'runner.interrupted-before-setup'
+  );
+
+  assert.deepEqual(adapter.calls, []);
+});

--- a/packages/amaryllis-components/tools/verify/runner.mjs
+++ b/packages/amaryllis-components/tools/verify/runner.mjs
@@ -1,0 +1,643 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { evaluateCompatibility, percentileR7 } from './policy.mjs';
+import { isLocalPathReference } from './validator.mjs';
+
+const DEFAULT_MAX_FIXTURE_BYTES = 32 * 1024 * 1024;
+const DEFAULT_CLEANUP_TIMEOUT_MS = 5000;
+const MAX_MESSAGE_LENGTH = 512;
+
+const ALLOWED_ITERATION_RESULT_KEYS = new Set([
+  'measurements',
+  'checks',
+  'evaluations',
+  'unavailable',
+  'errors',
+]);
+const ALLOWED_MEASUREMENT_KEYS = new Set(['name', 'unit', 'value']);
+const ALLOWED_CHECK_KEYS = new Set(['name', 'status', 'code', 'message']);
+const ALLOWED_EVALUATION_KEYS = new Set([
+  'name',
+  'status',
+  'score',
+  'unit',
+  'code',
+  'message',
+]);
+const ALLOWED_UNAVAILABLE_KEYS = new Set(['kind', 'name', 'reason', 'message']);
+const ALLOWED_ERROR_KEYS = new Set(['phase', 'code', 'message']);
+
+export class VerifyRunnerError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = 'VerifyRunnerError';
+    this.code = code;
+  }
+}
+
+class RunInterruptedError extends Error {
+  constructor(kind, message) {
+    super(message);
+    this.name = 'RunInterruptedError';
+    this.kind = kind;
+  }
+}
+
+function runnerError(code, message, cause) {
+  throw new VerifyRunnerError(code, message, cause ? { cause } : undefined);
+}
+
+function assertKnownKeys(value, allowed, context) {
+  for (const key of Object.keys(value ?? {})) {
+    if (!allowed.has(key)) {
+      runnerError('adapter.unknown-field', `${context} contains undeclared field ${key}`);
+    }
+  }
+}
+
+function assertFiniteNumber(value, context) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    runnerError('adapter.non-finite-number', `${context} must be a finite number`);
+  }
+}
+
+export function sanitizeEvidenceMessage(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  return value
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, ' ')
+    .slice(0, MAX_MESSAGE_LENGTH);
+}
+
+function canonicalizeJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      runnerError('canonicalization.non-finite-number', 'JSON canonicalization requires finite numbers');
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalizeJson(item)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalizeJson(value[key])}`)
+      .join(',')}}`;
+  }
+
+  runnerError(
+    'canonicalization.unsupported-value',
+    `cannot canonicalize JSON value of type ${typeof value}`
+  );
+}
+
+export function sha256Digest(value) {
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+export function digestJson(value) {
+  return sha256Digest(canonicalizeJson(value));
+}
+
+function isPathWithin(base, candidate) {
+  const relative = path.relative(base, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function isUncPath(value) {
+  return value.startsWith('\\\\') || value.startsWith('//');
+}
+
+export async function loadDeclaredFixtures(
+  manifest,
+  baseDirectory,
+  {
+    maxFixtureBytes = DEFAULT_MAX_FIXTURE_BYTES,
+    allowAbsoluteFixturePaths = false,
+  } = {}
+) {
+  const fixtures = new Map();
+  const declarations = manifest.scenario.fixtureRefs ?? [];
+  const realBase = await fs.realpath(path.resolve(baseDirectory));
+
+  for (const fixture of declarations) {
+    if (fixtures.has(fixture.id)) {
+      runnerError('fixture.duplicate-id', `fixture ID ${fixture.id} is duplicated`);
+    }
+    if (!isLocalPathReference(fixture.ref) || isUncPath(fixture.ref)) {
+      runnerError('fixture.non-local-reference', `fixture ${fixture.id} must use a local filesystem path`);
+    }
+
+    const absoluteReference = path.isAbsolute(fixture.ref);
+    if (absoluteReference && !allowAbsoluteFixturePaths) {
+      runnerError(
+        'fixture.absolute-path-disabled',
+        `fixture ${fixture.id} uses an absolute path but absolute fixture paths are disabled`
+      );
+    }
+
+    const candidate = absoluteReference
+      ? path.resolve(fixture.ref)
+      : path.resolve(realBase, fixture.ref);
+    const realCandidate = await fs.realpath(candidate).catch((error) => {
+      runnerError('fixture.not-found', `fixture ${fixture.id} could not be resolved`, error);
+    });
+
+    if (!absoluteReference && !isPathWithin(realBase, realCandidate)) {
+      runnerError(
+        'fixture.path-escape',
+        `fixture ${fixture.id} resolves outside the manifest directory`
+      );
+    }
+
+    const stat = await fs.stat(realCandidate);
+    if (!stat.isFile()) {
+      runnerError('fixture.not-file', `fixture ${fixture.id} is not a regular file`);
+    }
+    if (stat.size > maxFixtureBytes) {
+      runnerError(
+        'fixture.too-large',
+        `fixture ${fixture.id} exceeds the ${maxFixtureBytes} byte limit`
+      );
+    }
+
+    const bytes = await fs.readFile(realCandidate);
+    const digest = sha256Digest(bytes);
+    if (fixture.digest && digest.toLowerCase() !== fixture.digest.value.toLowerCase()) {
+      runnerError('fixture.digest-mismatch', `fixture ${fixture.id} digest does not match the manifest`);
+    }
+
+    fixtures.set(fixture.id, {
+      id: fixture.id,
+      path: realCandidate,
+      bytes,
+      digest: {
+        algorithm: 'sha256',
+        value: digest,
+      },
+    });
+  }
+
+  return fixtures;
+}
+
+function createRunSignal(externalSignal, timeoutMs) {
+  const controller = new AbortController();
+  let interruption = null;
+
+  const abort = (kind, message) => {
+    if (!controller.signal.aborted) {
+      interruption = { kind, message };
+      controller.abort(interruption);
+    }
+  };
+
+  const externalAbort = () => abort('cancelled', 'verification cancelled');
+  if (externalSignal?.aborted) {
+    externalAbort();
+  } else {
+    externalSignal?.addEventListener('abort', externalAbort, { once: true });
+  }
+
+  const timer = setTimeout(() => abort('timeout', 'verification timed out'), timeoutMs);
+
+  return {
+    signal: controller.signal,
+    interruption: () => interruption,
+    dispose() {
+      clearTimeout(timer);
+      externalSignal?.removeEventListener('abort', externalAbort);
+    },
+  };
+}
+
+async function runAbortable(operation, signal) {
+  if (signal.aborted) {
+    const reason = signal.reason ?? { kind: 'cancelled', message: 'verification cancelled' };
+    throw new RunInterruptedError(reason.kind ?? 'cancelled', reason.message ?? 'verification cancelled');
+  }
+
+  let abortHandler;
+  const aborted = new Promise((_, reject) => {
+    abortHandler = () => {
+      const reason = signal.reason ?? { kind: 'cancelled', message: 'verification cancelled' };
+      reject(new RunInterruptedError(reason.kind ?? 'cancelled', reason.message ?? 'verification cancelled'));
+    };
+    signal.addEventListener('abort', abortHandler, { once: true });
+  });
+
+  try {
+    return await Promise.race([Promise.resolve().then(operation), aborted]);
+  } finally {
+    signal.removeEventListener('abort', abortHandler);
+  }
+}
+
+async function runCleanup(adapter, context, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort({ kind: 'cleanup-timeout', message: 'cleanup timed out' }),
+    timeoutMs
+  );
+
+  try {
+    await runAbortable(() => adapter.cleanup(context, controller.signal), controller.signal);
+    return null;
+  } catch (error) {
+    return error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function validateTarget(manifest, environment) {
+  if (environment.platform !== manifest.target.platform) {
+    runnerError(
+      'target.platform-mismatch',
+      `manifest targets ${manifest.target.platform} but adapter reported ${environment.platform}`
+    );
+  }
+
+  const actualCapabilities = new Set(environment.device?.capabilities ?? []);
+  for (const capability of manifest.target.requiredCapabilities ?? []) {
+    if (!actualCapabilities.has(capability)) {
+      runnerError(
+        'target.capability-missing',
+        `target requires capability ${capability}, but the adapter did not report it`
+      );
+    }
+  }
+}
+
+function requestedTargets(manifest) {
+  return {
+    metric: new Set(manifest.collect.metrics),
+    check: new Set(manifest.collect.checks),
+    evaluation: new Set(manifest.collect.evaluations ?? []),
+  };
+}
+
+function assertRequestedTarget(requested, kind, name) {
+  if (!requested[kind]?.has(name)) {
+    runnerError(
+      'adapter.undeclared-target',
+      `adapter attempted to emit undeclared ${kind} ${name}`
+    );
+  }
+}
+
+function recordIterationResult(state, result, iteration) {
+  assertKnownKeys(result, ALLOWED_ITERATION_RESULT_KEYS, `iteration ${iteration} result`);
+
+  for (const measurement of result.measurements ?? []) {
+    assertKnownKeys(measurement, ALLOWED_MEASUREMENT_KEYS, `measurement ${measurement.name ?? '<unknown>'}`);
+    assertRequestedTarget(state.requested, 'metric', measurement.name);
+    assertFiniteNumber(measurement.value, `measurement ${measurement.name}`);
+    if (typeof measurement.unit !== 'string' || measurement.unit.length === 0) {
+      runnerError('adapter.metric-unit-missing', `measurement ${measurement.name} must define a unit`);
+    }
+
+    const existing = state.measurements.get(measurement.name);
+    if (existing && existing.unit !== measurement.unit) {
+      runnerError(
+        'adapter.metric-unit-drift',
+        `measurement ${measurement.name} changed unit from ${existing.unit} to ${measurement.unit}`
+      );
+    }
+    const entry = existing ?? { name: measurement.name, unit: measurement.unit, samples: [] };
+    if (entry.samples.some((sample) => sample.iteration === iteration)) {
+      runnerError(
+        'adapter.duplicate-metric-sample',
+        `measurement ${measurement.name} emitted more than once for iteration ${iteration}`
+      );
+    }
+    entry.samples.push({ iteration, value: measurement.value });
+    state.measurements.set(measurement.name, entry);
+  }
+
+  for (const check of result.checks ?? []) {
+    assertKnownKeys(check, ALLOWED_CHECK_KEYS, `check ${check.name ?? '<unknown>'}`);
+    assertRequestedTarget(state.requested, 'check', check.name);
+    if (state.checks.has(check.name)) {
+      runnerError('adapter.duplicate-check', `check ${check.name} is run-scoped and may be emitted once`);
+    }
+    state.checks.set(check.name, {
+      name: check.name,
+      status: check.status,
+      ...(check.code ? { code: check.code } : {}),
+      ...(sanitizeEvidenceMessage(check.message) !== undefined
+        ? { message: sanitizeEvidenceMessage(check.message) }
+        : {}),
+    });
+  }
+
+  for (const evaluation of result.evaluations ?? []) {
+    assertKnownKeys(
+      evaluation,
+      ALLOWED_EVALUATION_KEYS,
+      `evaluation ${evaluation.name ?? '<unknown>'}`
+    );
+    assertRequestedTarget(state.requested, 'evaluation', evaluation.name);
+    if (state.evaluations.has(evaluation.name)) {
+      runnerError(
+        'adapter.duplicate-evaluation',
+        `evaluation ${evaluation.name} is run-scoped and may be emitted once`
+      );
+    }
+    if (evaluation.score !== undefined) {
+      assertFiniteNumber(evaluation.score, `evaluation ${evaluation.name} score`);
+    }
+    state.evaluations.set(evaluation.name, {
+      name: evaluation.name,
+      status: evaluation.status,
+      ...(evaluation.score !== undefined ? { score: evaluation.score } : {}),
+      ...(evaluation.unit ? { unit: evaluation.unit } : {}),
+      ...(evaluation.code ? { code: evaluation.code } : {}),
+    });
+  }
+
+  for (const unavailable of result.unavailable ?? []) {
+    assertKnownKeys(
+      unavailable,
+      ALLOWED_UNAVAILABLE_KEYS,
+      `unavailable ${unavailable.name ?? '<unknown>'}`
+    );
+    assertRequestedTarget(state.requested, unavailable.kind, unavailable.name);
+    const key = `${unavailable.kind}:${unavailable.name}`;
+    if (state.unavailable.has(key)) {
+      runnerError('adapter.duplicate-unavailable', `target ${key} was marked unavailable more than once`);
+    }
+    state.unavailable.set(key, {
+      kind: unavailable.kind,
+      name: unavailable.name,
+      reason: unavailable.reason,
+      ...(sanitizeEvidenceMessage(unavailable.message) !== undefined
+        ? { message: sanitizeEvidenceMessage(unavailable.message) }
+        : {}),
+    });
+  }
+
+  for (const error of result.errors ?? []) {
+    assertKnownKeys(error, ALLOWED_ERROR_KEYS, `adapter error ${error.code ?? '<unknown>'}`);
+    state.errors.push({
+      phase: error.phase,
+      code: error.code,
+      ...(sanitizeEvidenceMessage(error.message) !== undefined
+        ? { message: sanitizeEvidenceMessage(error.message) }
+        : {}),
+    });
+  }
+}
+
+function summarizeMeasurement(measurement) {
+  const values = measurement.samples.map(({ value }) => value);
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+
+  return {
+    name: measurement.name,
+    unit: measurement.unit,
+    samples: measurement.samples,
+    summary: {
+      count: values.length,
+      min: Math.min(...values),
+      max: Math.max(...values),
+      mean,
+      p50: percentileR7(values, 0.5),
+      p95: percentileR7(values, 0.95),
+    },
+  };
+}
+
+function hasAvailableTarget(state, kind, name) {
+  if (kind === 'metric') return state.measurements.has(name);
+  if (kind === 'check') return state.checks.has(name);
+  return state.evaluations.has(name);
+}
+
+function fillMissingTargets(state, reason) {
+  for (const kind of ['metric', 'check', 'evaluation']) {
+    for (const name of state.requested[kind]) {
+      const key = `${kind}:${name}`;
+      if (!hasAvailableTarget(state, kind, name) && !state.unavailable.has(key)) {
+        state.unavailable.set(key, { kind, name, reason });
+      }
+    }
+  }
+}
+
+function executionStatus(interruption, failed, completed, requested) {
+  if (interruption?.kind === 'cancelled') return 'cancelled';
+  if (interruption?.kind === 'timeout') return 'failed';
+  if (failed) return completed > 0 ? 'partial' : 'failed';
+  return completed === requested ? 'completed' : 'partial';
+}
+
+function isoTime(milliseconds) {
+  return new Date(milliseconds).toISOString();
+}
+
+function validationMessage(result) {
+  return result.issues.map((issue) => `${issue.path} ${issue.code}: ${issue.message}`).join('; ');
+}
+
+export async function runVerification({
+  manifest,
+  validator,
+  adapter,
+  baseDirectory = process.cwd(),
+  signal,
+  clock = () => Date.now(),
+  idFactory = () => crypto.randomUUID(),
+  runnerInfo = { name: 'amaryllis-verify', version: '0.1.0-alpha.1' },
+  cleanupTimeoutMs = DEFAULT_CLEANUP_TIMEOUT_MS,
+  maxFixtureBytes = DEFAULT_MAX_FIXTURE_BYTES,
+  allowAbsoluteFixturePaths = false,
+} = {}) {
+  if (!validator || !adapter || !manifest) {
+    runnerError('runner.invalid-arguments', 'manifest, validator, and adapter are required');
+  }
+
+  const manifestValidation = validator.validateManifest(manifest);
+  if (!manifestValidation.valid) {
+    runnerError('invalid-manifest', validationMessage(manifestValidation));
+  }
+
+  const startMs = clock();
+  const runSignal = createRunSignal(signal, manifest.scenario.timeoutMs);
+  let capabilities;
+  let fixtures;
+
+  try {
+    fixtures = await loadDeclaredFixtures(manifest, baseDirectory, {
+      maxFixtureBytes,
+      allowAbsoluteFixturePaths,
+    });
+    capabilities = await runAbortable(() => adapter.capabilities(runSignal.signal), runSignal.signal);
+    validateTarget(manifest, capabilities.environment);
+  } catch (error) {
+    runSignal.dispose();
+    if (error instanceof VerifyRunnerError) throw error;
+    if (error instanceof RunInterruptedError) {
+      runnerError('runner.interrupted-before-setup', error.message, error);
+    }
+    runnerError('runner.capabilities-failed', 'failed to prepare verification target', error);
+  }
+
+  const state = {
+    requested: requestedTargets(manifest),
+    measurements: new Map(),
+    checks: new Map(),
+    evaluations: new Map(),
+    unavailable: new Map(),
+    errors: [],
+  };
+  const context = {
+    manifest,
+    fixtures,
+    environment: capabilities.environment,
+  };
+
+  let completed = 0;
+  let failed = false;
+  let interruption = null;
+  let failurePhase = null;
+
+  const executePhase = async (phase, operation) => {
+    try {
+      return await runAbortable(operation, runSignal.signal);
+    } catch (error) {
+      if (error instanceof RunInterruptedError) {
+        interruption = { kind: error.kind, message: error.message };
+      } else {
+        failed = true;
+      }
+      failurePhase = phase;
+      state.errors.push({
+        phase,
+        code:
+          error instanceof RunInterruptedError
+            ? error.kind === 'timeout'
+              ? 'run-timeout'
+              : 'run-cancelled'
+            : 'adapter-error',
+        ...(sanitizeEvidenceMessage(error.message) !== undefined
+          ? { message: sanitizeEvidenceMessage(error.message) }
+          : {}),
+      });
+      return undefined;
+    }
+  };
+
+  const prepared = await executePhase('setup', () => adapter.prepare(context, runSignal.signal));
+  const prepareSucceeded = !failed && !interruption && failurePhase === null;
+
+  if (prepareSucceeded) {
+    for (let iteration = 1; iteration <= (manifest.scenario.warmupRuns ?? 0); iteration += 1) {
+      await executePhase('warmup', () => adapter.warmup(context, iteration, runSignal.signal));
+      if (failed || interruption) break;
+    }
+  }
+
+  if (!failed && !interruption) {
+    for (let iteration = 1; iteration <= manifest.scenario.repetitions; iteration += 1) {
+      const result = await executePhase('execute', () =>
+        adapter.execute(context, iteration, runSignal.signal)
+      );
+      if (failed || interruption) break;
+      recordIterationResult(state, result ?? {}, iteration);
+      completed += 1;
+    }
+  }
+
+  const cleanupError = await runCleanup(adapter, context, cleanupTimeoutMs);
+  if (cleanupError) {
+    state.errors.push({
+      phase: 'cleanup',
+      code: cleanupError instanceof RunInterruptedError ? 'cleanup-timeout' : 'cleanup-error',
+      ...(sanitizeEvidenceMessage(cleanupError.message) !== undefined
+        ? { message: sanitizeEvidenceMessage(cleanupError.message) }
+        : {}),
+    });
+    if (!failed && !interruption) {
+      failed = true;
+      failurePhase = 'cleanup';
+    }
+  }
+
+  interruption ??= runSignal.interruption();
+  runSignal.dispose();
+
+  const status = executionStatus(
+    interruption,
+    failed,
+    completed,
+    manifest.scenario.repetitions
+  );
+  const missingReason = interruption?.kind === 'cancelled' ? 'cancelled' : 'not-run';
+  fillMissingTargets(state, missingReason);
+
+  const endMs = Math.max(clock(), startMs);
+  const evidence = {
+    apiVersion: 'amaryllis.dev/verify/v1alpha1',
+    kind: 'VerificationEvidence',
+    metadata: {
+      id: idFactory(),
+      createdAt: isoTime(endMs),
+    },
+    execution: {
+      status,
+      startedAt: isoTime(startMs),
+      endedAt: isoTime(endMs),
+      durationMs: endMs - startMs,
+      repetitions: {
+        requested: manifest.scenario.repetitions,
+        completed,
+      },
+    },
+    subject: structuredClone(manifest.subject),
+    environment: structuredClone(capabilities.environment),
+    provenance: {
+      runner: structuredClone(runnerInfo),
+      scenario: {
+        id: manifest.scenario.id,
+        version: manifest.scenario.version,
+      },
+      manifestDigest: {
+        algorithm: 'sha256',
+        value: digestJson(manifest),
+      },
+      collectors: structuredClone(capabilities.collectors ?? []),
+      ...((capabilities.evaluationSuites ?? []).length > 0
+        ? { evaluationSuites: structuredClone(capabilities.evaluationSuites) }
+        : {}),
+    },
+    measurements: [...state.measurements.values()].map(summarizeMeasurement),
+    checks: [...state.checks.values()],
+    evaluations: [...state.evaluations.values()],
+    unavailable: [...state.unavailable.values()],
+    errors: state.errors,
+    policy: structuredClone(manifest.policy),
+    decision: {
+      status: 'unknown',
+      reasons: [],
+    },
+  };
+
+  evidence.decision = evaluateCompatibility(evidence);
+
+  const evidenceValidation = validator.validateEvidence(evidence);
+  if (!evidenceValidation.valid) {
+    runnerError('invalid-evidence', validationMessage(evidenceValidation));
+  }
+
+  return evidence;
+}

--- a/packages/amaryllis-components/tools/verify/runner.mjs
+++ b/packages/amaryllis-components/tools/verify/runner.mjs
@@ -21,6 +21,24 @@ const ALLOWED_CHECK_KEYS = new Set(['name', 'status', 'code', 'message']);
 const ALLOWED_EVALUATION_KEYS = new Set(['name', 'status', 'score', 'unit', 'code']);
 const ALLOWED_UNAVAILABLE_KEYS = new Set(['kind', 'name', 'reason', 'message']);
 const ALLOWED_ERROR_KEYS = new Set(['phase', 'code', 'message']);
+const RESULT_STATUSES = new Set(['pass', 'fail', 'unknown']);
+const UNAVAILABLE_REASONS = new Set([
+  'unsupported',
+  'collector-failed',
+  'not-run',
+  'cancelled',
+  'insufficient-samples',
+]);
+const ERROR_PHASES = new Set([
+  'setup',
+  'launch',
+  'warmup',
+  'execute',
+  'collect',
+  'evaluate',
+  'cleanup',
+]);
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export class VerifyRunnerError extends Error {
   constructor(code, message, options = {}) {
@@ -43,10 +61,25 @@ function runnerError(code, message, cause) {
 }
 
 function assertKnownKeys(value, allowed, context) {
-  for (const key of Object.keys(value ?? {})) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    runnerError('adapter.invalid-object', `${context} must be an object`);
+  }
+  for (const key of Object.keys(value)) {
     if (!allowed.has(key)) {
       runnerError('adapter.unknown-field', `${context} contains undeclared field ${key}`);
     }
+  }
+}
+
+function assertOptionalArray(value, context) {
+  if (value !== undefined && !Array.isArray(value)) {
+    runnerError('adapter.invalid-array', `${context} must be an array when provided`);
+  }
+}
+
+function assertIdentifier(value, context) {
+  if (typeof value !== 'string' || !IDENTIFIER.test(value)) {
+    runnerError('adapter.invalid-identifier', `${context} must be a bounded identifier`);
   }
 }
 
@@ -288,17 +321,39 @@ function assertRequestedTarget(requested, kind, name) {
   }
 }
 
-function recordIterationResult(state, result, iteration) {
+function hasAvailableTarget(state, kind, name) {
+  if (kind === 'metric') return state.measurements.has(name);
+  if (kind === 'check') return state.checks.has(name);
+  return state.evaluations.has(name);
+}
+
+function prevalidateIterationResult(state, result, iteration) {
   assertKnownKeys(result, ALLOWED_ITERATION_RESULT_KEYS, `iteration ${iteration} result`);
 
+  for (const key of ['measurements', 'checks', 'evaluations', 'unavailable', 'errors']) {
+    assertOptionalArray(result[key], `iteration ${iteration} ${key}`);
+  }
+
+  const resultTargets = new Set();
+
   for (const measurement of result.measurements ?? []) {
-    assertKnownKeys(measurement, ALLOWED_MEASUREMENT_KEYS, `measurement ${measurement.name ?? '<unknown>'}`);
+    assertKnownKeys(measurement, ALLOWED_MEASUREMENT_KEYS, `measurement ${measurement?.name ?? '<unknown>'}`);
+    assertIdentifier(measurement.name, 'measurement name');
     assertRequestedTarget(state.requested, 'metric', measurement.name);
     assertFiniteNumber(measurement.value, `measurement ${measurement.name}`);
-    if (typeof measurement.unit !== 'string' || measurement.unit.length === 0) {
-      runnerError('adapter.metric-unit-missing', `measurement ${measurement.name} must define a unit`);
+    if (typeof measurement.unit !== 'string' || measurement.unit.length === 0 || measurement.unit.length > 32) {
+      runnerError('adapter.metric-unit-invalid', `measurement ${measurement.name} must define a bounded unit`);
     }
 
+    const key = `metric:${measurement.name}`;
+    if (resultTargets.has(key)) {
+      runnerError('adapter.duplicate-target', `iteration ${iteration} emitted ${key} more than once`);
+    }
+    resultTargets.add(key);
+
+    if (state.unavailable.has(key)) {
+      runnerError('adapter.available-after-unavailable', `${key} was previously marked unavailable`);
+    }
     const existing = state.measurements.get(measurement.name);
     if (existing && existing.unit !== measurement.unit) {
       runnerError(
@@ -306,23 +361,119 @@ function recordIterationResult(state, result, iteration) {
         `measurement ${measurement.name} changed unit from ${existing.unit} to ${measurement.unit}`
       );
     }
-    const entry = existing ?? { name: measurement.name, unit: measurement.unit, samples: [] };
-    if (entry.samples.some((sample) => sample.iteration === iteration)) {
+    if (existing?.samples.some((sample) => sample.iteration === iteration)) {
       runnerError(
         'adapter.duplicate-metric-sample',
         `measurement ${measurement.name} emitted more than once for iteration ${iteration}`
       );
     }
+  }
+
+  for (const check of result.checks ?? []) {
+    assertKnownKeys(check, ALLOWED_CHECK_KEYS, `check ${check?.name ?? '<unknown>'}`);
+    assertIdentifier(check.name, 'check name');
+    assertRequestedTarget(state.requested, 'check', check.name);
+    if (!RESULT_STATUSES.has(check.status)) {
+      runnerError('adapter.check-status-invalid', `check ${check.name} has invalid status ${String(check.status)}`);
+    }
+    if (check.code !== undefined) assertIdentifier(check.code, `check ${check.name} code`);
+
+    const key = `check:${check.name}`;
+    if (resultTargets.has(key) || state.checks.has(check.name)) {
+      runnerError('adapter.duplicate-check', `check ${check.name} is run-scoped and may be emitted once`);
+    }
+    if (state.unavailable.has(key)) {
+      runnerError('adapter.available-after-unavailable', `${key} was previously marked unavailable`);
+    }
+    resultTargets.add(key);
+  }
+
+  for (const evaluation of result.evaluations ?? []) {
+    assertKnownKeys(
+      evaluation,
+      ALLOWED_EVALUATION_KEYS,
+      `evaluation ${evaluation?.name ?? '<unknown>'}`
+    );
+    assertIdentifier(evaluation.name, 'evaluation name');
+    assertRequestedTarget(state.requested, 'evaluation', evaluation.name);
+    if (!RESULT_STATUSES.has(evaluation.status)) {
+      runnerError(
+        'adapter.evaluation-status-invalid',
+        `evaluation ${evaluation.name} has invalid status ${String(evaluation.status)}`
+      );
+    }
+    if (evaluation.score !== undefined) {
+      assertFiniteNumber(evaluation.score, `evaluation ${evaluation.name} score`);
+    }
+    if (evaluation.unit !== undefined && (typeof evaluation.unit !== 'string' || evaluation.unit.length === 0 || evaluation.unit.length > 32)) {
+      runnerError('adapter.evaluation-unit-invalid', `evaluation ${evaluation.name} has invalid unit`);
+    }
+    if (evaluation.code !== undefined) {
+      assertIdentifier(evaluation.code, `evaluation ${evaluation.name} code`);
+    }
+
+    const key = `evaluation:${evaluation.name}`;
+    if (resultTargets.has(key) || state.evaluations.has(evaluation.name)) {
+      runnerError(
+        'adapter.duplicate-evaluation',
+        `evaluation ${evaluation.name} is run-scoped and may be emitted once`
+      );
+    }
+    if (state.unavailable.has(key)) {
+      runnerError('adapter.available-after-unavailable', `${key} was previously marked unavailable`);
+    }
+    resultTargets.add(key);
+  }
+
+  const unavailableTargets = new Set();
+  for (const unavailable of result.unavailable ?? []) {
+    assertKnownKeys(
+      unavailable,
+      ALLOWED_UNAVAILABLE_KEYS,
+      `unavailable ${unavailable?.name ?? '<unknown>'}`
+    );
+    if (!['metric', 'check', 'evaluation'].includes(unavailable.kind)) {
+      runnerError('adapter.unavailable-kind-invalid', `invalid unavailable kind ${String(unavailable.kind)}`);
+    }
+    assertIdentifier(unavailable.name, 'unavailable target name');
+    assertRequestedTarget(state.requested, unavailable.kind, unavailable.name);
+    if (!UNAVAILABLE_REASONS.has(unavailable.reason)) {
+      runnerError(
+        'adapter.unavailable-reason-invalid',
+        `target ${unavailable.kind}:${unavailable.name} has invalid unavailable reason`
+      );
+    }
+
+    const key = `${unavailable.kind}:${unavailable.name}`;
+    if (unavailableTargets.has(key) || state.unavailable.has(key)) {
+      runnerError('adapter.duplicate-unavailable', `target ${key} was marked unavailable more than once`);
+    }
+    if (resultTargets.has(key) || hasAvailableTarget(state, unavailable.kind, unavailable.name)) {
+      runnerError('adapter.available-and-unavailable', `${key} cannot be both available and unavailable`);
+    }
+    unavailableTargets.add(key);
+  }
+
+  for (const error of result.errors ?? []) {
+    assertKnownKeys(error, ALLOWED_ERROR_KEYS, `adapter error ${error?.code ?? '<unknown>'}`);
+    if (!ERROR_PHASES.has(error.phase)) {
+      runnerError('adapter.error-phase-invalid', `adapter error has invalid phase ${String(error.phase)}`);
+    }
+    assertIdentifier(error.code, 'adapter error code');
+  }
+}
+
+function recordIterationResult(state, result, iteration) {
+  prevalidateIterationResult(state, result, iteration);
+
+  for (const measurement of result.measurements ?? []) {
+    const existing = state.measurements.get(measurement.name);
+    const entry = existing ?? { name: measurement.name, unit: measurement.unit, samples: [] };
     entry.samples.push({ iteration, value: measurement.value });
     state.measurements.set(measurement.name, entry);
   }
 
   for (const check of result.checks ?? []) {
-    assertKnownKeys(check, ALLOWED_CHECK_KEYS, `check ${check.name ?? '<unknown>'}`);
-    assertRequestedTarget(state.requested, 'check', check.name);
-    if (state.checks.has(check.name)) {
-      runnerError('adapter.duplicate-check', `check ${check.name} is run-scoped and may be emitted once`);
-    }
     state.checks.set(check.name, {
       name: check.name,
       status: check.status,
@@ -334,21 +485,6 @@ function recordIterationResult(state, result, iteration) {
   }
 
   for (const evaluation of result.evaluations ?? []) {
-    assertKnownKeys(
-      evaluation,
-      ALLOWED_EVALUATION_KEYS,
-      `evaluation ${evaluation.name ?? '<unknown>'}`
-    );
-    assertRequestedTarget(state.requested, 'evaluation', evaluation.name);
-    if (state.evaluations.has(evaluation.name)) {
-      runnerError(
-        'adapter.duplicate-evaluation',
-        `evaluation ${evaluation.name} is run-scoped and may be emitted once`
-      );
-    }
-    if (evaluation.score !== undefined) {
-      assertFiniteNumber(evaluation.score, `evaluation ${evaluation.name} score`);
-    }
     state.evaluations.set(evaluation.name, {
       name: evaluation.name,
       status: evaluation.status,
@@ -359,16 +495,7 @@ function recordIterationResult(state, result, iteration) {
   }
 
   for (const unavailable of result.unavailable ?? []) {
-    assertKnownKeys(
-      unavailable,
-      ALLOWED_UNAVAILABLE_KEYS,
-      `unavailable ${unavailable.name ?? '<unknown>'}`
-    );
-    assertRequestedTarget(state.requested, unavailable.kind, unavailable.name);
     const key = `${unavailable.kind}:${unavailable.name}`;
-    if (state.unavailable.has(key)) {
-      runnerError('adapter.duplicate-unavailable', `target ${key} was marked unavailable more than once`);
-    }
     state.unavailable.set(key, {
       kind: unavailable.kind,
       name: unavailable.name,
@@ -380,7 +507,6 @@ function recordIterationResult(state, result, iteration) {
   }
 
   for (const error of result.errors ?? []) {
-    assertKnownKeys(error, ALLOWED_ERROR_KEYS, `adapter error ${error.code ?? '<unknown>'}`);
     state.errors.push({
       phase: error.phase,
       code: error.code,
@@ -408,12 +534,6 @@ function summarizeMeasurement(measurement) {
       p95: percentileR7(values, 0.95),
     },
   };
-}
-
-function hasAvailableTarget(state, kind, name) {
-  if (kind === 'metric') return state.measurements.has(name);
-  if (kind === 'check') return state.checks.has(name);
-  return state.evaluations.has(name);
 }
 
 function fillMissingTargets(state, reason) {

--- a/packages/amaryllis-components/tools/verify/runner.mjs
+++ b/packages/amaryllis-components/tools/verify/runner.mjs
@@ -454,6 +454,7 @@ export async function runVerification({
   cleanupTimeoutMs = DEFAULT_CLEANUP_TIMEOUT_MS,
   maxFixtureBytes = DEFAULT_MAX_FIXTURE_BYTES,
   allowAbsoluteFixturePaths = false,
+  fixtureLoader = loadDeclaredFixtures,
 } = {}) {
   if (!validator || !adapter || !manifest) {
     runnerError('runner.invalid-arguments', 'manifest, validator, and adapter are required');
@@ -470,10 +471,14 @@ export async function runVerification({
   let fixtures;
 
   try {
-    fixtures = await loadDeclaredFixtures(manifest, baseDirectory, {
-      maxFixtureBytes,
-      allowAbsoluteFixturePaths,
-    });
+    fixtures = await runAbortable(
+      () =>
+        fixtureLoader(manifest, baseDirectory, {
+          maxFixtureBytes,
+          allowAbsoluteFixturePaths,
+        }),
+      runSignal.signal
+    );
     capabilities = await runAbortable(() => adapter.capabilities(runSignal.signal), runSignal.signal);
     validateTarget(manifest, capabilities.environment);
   } catch (error) {

--- a/packages/amaryllis-components/tools/verify/runner.mjs
+++ b/packages/amaryllis-components/tools/verify/runner.mjs
@@ -18,14 +18,7 @@ const ALLOWED_ITERATION_RESULT_KEYS = new Set([
 ]);
 const ALLOWED_MEASUREMENT_KEYS = new Set(['name', 'unit', 'value']);
 const ALLOWED_CHECK_KEYS = new Set(['name', 'status', 'code', 'message']);
-const ALLOWED_EVALUATION_KEYS = new Set([
-  'name',
-  'status',
-  'score',
-  'unit',
-  'code',
-  'message',
-]);
+const ALLOWED_EVALUATION_KEYS = new Set(['name', 'status', 'score', 'unit', 'code']);
 const ALLOWED_UNAVAILABLE_KEYS = new Set(['kind', 'name', 'reason', 'message']);
 const ALLOWED_ERROR_KEYS = new Set(['phase', 'code', 'message']);
 
@@ -509,7 +502,6 @@ export async function runVerification({
   let completed = 0;
   let failed = false;
   let interruption = null;
-  let failurePhase = null;
 
   const executePhase = async (phase, operation) => {
     try {
@@ -520,15 +512,17 @@ export async function runVerification({
       } else {
         failed = true;
       }
-      failurePhase = phase;
+      const errorCode =
+        error instanceof RunInterruptedError
+          ? error.kind === 'timeout'
+            ? 'run-timeout'
+            : 'run-cancelled'
+          : error instanceof VerifyRunnerError
+            ? error.code
+            : 'adapter-error';
       state.errors.push({
         phase,
-        code:
-          error instanceof RunInterruptedError
-            ? error.kind === 'timeout'
-              ? 'run-timeout'
-              : 'run-cancelled'
-            : 'adapter-error',
+        code: errorCode,
         ...(sanitizeEvidenceMessage(error.message) !== undefined
           ? { message: sanitizeEvidenceMessage(error.message) }
           : {}),
@@ -537,10 +531,9 @@ export async function runVerification({
     }
   };
 
-  const prepared = await executePhase('setup', () => adapter.prepare(context, runSignal.signal));
-  const prepareSucceeded = !failed && !interruption && failurePhase === null;
+  await executePhase('setup', () => adapter.prepare(context, runSignal.signal));
 
-  if (prepareSucceeded) {
+  if (!failed && !interruption) {
     for (let iteration = 1; iteration <= (manifest.scenario.warmupRuns ?? 0); iteration += 1) {
       await executePhase('warmup', () => adapter.warmup(context, iteration, runSignal.signal));
       if (failed || interruption) break;
@@ -549,11 +542,11 @@ export async function runVerification({
 
   if (!failed && !interruption) {
     for (let iteration = 1; iteration <= manifest.scenario.repetitions; iteration += 1) {
-      const result = await executePhase('execute', () =>
-        adapter.execute(context, iteration, runSignal.signal)
-      );
+      await executePhase('execute', async () => {
+        const result = await adapter.execute(context, iteration, runSignal.signal);
+        recordIterationResult(state, result ?? {}, iteration);
+      });
       if (failed || interruption) break;
-      recordIterationResult(state, result ?? {}, iteration);
       completed += 1;
     }
   }
@@ -569,7 +562,6 @@ export async function runVerification({
     });
     if (!failed && !interruption) {
       failed = true;
-      failurePhase = 'cleanup';
     }
   }
 

--- a/packages/amaryllis-components/tools/verify/runner.test.mjs
+++ b/packages/amaryllis-components/tools/verify/runner.test.mjs
@@ -1,0 +1,496 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { FakePlatformAdapter } from './fake-adapter.mjs';
+import {
+  loadDeclaredFixtures,
+  runVerification,
+  sanitizeEvidenceMessage,
+  sha256Digest,
+  VerifyRunnerError,
+} from './runner.mjs';
+import { loadVerifySchemaBundle, VerifyValidator } from './validator.mjs';
+
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(toolDirectory, '../../../..');
+const validator = new VerifyValidator(
+  loadVerifySchemaBundle(path.join(repositoryRoot, 'schemas/verify/v1alpha1'))
+);
+
+const DIGEST_A = 'a'.repeat(64);
+const DIGEST_B = 'b'.repeat(64);
+const DIGEST_C = 'c'.repeat(64);
+
+function makeEnvironment() {
+  return {
+    platform: 'android',
+    os: {
+      name: 'Android',
+      version: '15',
+    },
+    device: {
+      manufacturer: 'Google',
+      model: 'Pixel 8',
+      architecture: 'arm64-v8a',
+      capabilities: ['physical-device'],
+    },
+  };
+}
+
+function makeManifest(overrides = {}) {
+  const manifest = {
+    apiVersion: 'amaryllis.dev/verify/v1alpha1',
+    kind: 'VerificationManifest',
+    metadata: {
+      name: 'runner-test',
+    },
+    subject: {
+      application: {
+        id: 'com.example.verify',
+        version: '1.0.0',
+        digest: { algorithm: 'sha256', value: DIGEST_A },
+      },
+      runtime: {
+        package: '@micrantha/react-native-amaryllis',
+        version: '0.1.7',
+        digest: { algorithm: 'sha256', value: DIGEST_B },
+      },
+      model: {
+        id: 'test-model',
+        version: '1',
+        format: 'mediapipe-task',
+        digest: { algorithm: 'sha256', value: DIGEST_C },
+      },
+    },
+    target: {
+      platform: 'android',
+      requiredCapabilities: ['physical-device'],
+    },
+    scenario: {
+      id: 'runner-smoke',
+      version: '1.0.0',
+      timeoutMs: 1000,
+      warmupRuns: 1,
+      repetitions: 3,
+    },
+    collect: {
+      metrics: ['timing.initialization.ms'],
+      checks: [],
+      evaluations: [],
+    },
+    policy: {
+      requirements: [
+        {
+          id: 'startup',
+          severity: 'required',
+          target: {
+            kind: 'metric',
+            name: 'timing.initialization.ms',
+          },
+          operator: 'lte',
+          value: 2000,
+          aggregate: 'max',
+          unit: 'ms',
+        },
+      ],
+    },
+  };
+
+  return {
+    ...manifest,
+    ...overrides,
+    scenario: {
+      ...manifest.scenario,
+      ...(overrides.scenario ?? {}),
+    },
+    collect: {
+      ...manifest.collect,
+      ...(overrides.collect ?? {}),
+    },
+    policy: overrides.policy ?? manifest.policy,
+  };
+}
+
+function makeAdapterScript(overrides = {}) {
+  return {
+    environment: makeEnvironment(),
+    collectors: [{ name: 'timing', version: 'v1alpha1' }],
+    iterations: [
+      {
+        measurements: [
+          { name: 'timing.initialization.ms', unit: 'ms', value: 1000 },
+        ],
+      },
+      {
+        measurements: [
+          { name: 'timing.initialization.ms', unit: 'ms', value: 1100 },
+        ],
+      },
+      {
+        measurements: [
+          { name: 'timing.initialization.ms', unit: 'ms', value: 1200 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function run(manifest, script, options = {}) {
+  const adapter = new FakePlatformAdapter(script);
+  const evidence = await runVerification({
+    manifest,
+    validator,
+    adapter,
+    baseDirectory: repositoryRoot,
+    idFactory: () => 'verify-test-id',
+    ...options,
+  });
+  return { evidence, adapter };
+}
+
+test('runs warmup and all repetitions and emits valid passing evidence', async () => {
+  const { evidence, adapter } = await run(makeManifest(), makeAdapterScript());
+
+  assert.equal(evidence.execution.status, 'completed');
+  assert.deepEqual(evidence.execution.repetitions, {
+    requested: 3,
+    completed: 3,
+  });
+  assert.equal(evidence.decision.status, 'pass');
+  assert.deepEqual(
+    evidence.measurements[0].samples.map(({ value }) => value),
+    [1000, 1100, 1200]
+  );
+  assert.deepEqual(evidence.measurements[0].summary, {
+    count: 3,
+    min: 1000,
+    max: 1200,
+    mean: 1100,
+    p50: 1100,
+    p95: 1190,
+  });
+  assert.equal(evidence.provenance.manifestDigest.algorithm, 'sha256');
+  assert.match(evidence.provenance.manifestDigest.value, /^[a-f0-9]{64}$/);
+  assert.deepEqual(
+    adapter.calls.map(({ phase, iteration }) =>
+      iteration === undefined ? phase : `${phase}:${iteration}`
+    ),
+    ['capabilities', 'prepare', 'warmup:1', 'execute:1', 'execute:2', 'execute:3', 'cleanup']
+  );
+  assert.deepEqual(validator.validateEvidence(evidence), { valid: true, issues: [] });
+});
+
+test('undeclared adapter telemetry fails inside execute lifecycle and still cleans up', async () => {
+  const { evidence, adapter } = await run(
+    makeManifest(),
+    makeAdapterScript({
+      iterations: [
+        {
+          measurements: [
+            { name: 'telemetry.secretMetric', unit: 'count', value: 1 },
+          ],
+        },
+      ],
+    })
+  );
+
+  assert.equal(evidence.execution.status, 'failed');
+  assert.equal(evidence.execution.repetitions.completed, 0);
+  assert.equal(evidence.decision.status, 'unknown');
+  assert.deepEqual(evidence.measurements, []);
+  assert.ok(
+    evidence.errors.some(({ code }) => code === 'adapter.undeclared-target')
+  );
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('adapter failure stops later repetitions, cleans up, and emits partial evidence', async () => {
+  const { evidence, adapter } = await run(
+    makeManifest(),
+    makeAdapterScript({
+      failure: {
+        phase: 'execute',
+        iteration: 2,
+        message: 'iteration failed',
+      },
+    })
+  );
+
+  assert.equal(evidence.execution.status, 'partial');
+  assert.equal(evidence.execution.repetitions.completed, 1);
+  assert.equal(evidence.measurements[0].samples.length, 1);
+  assert.equal(evidence.decision.status, 'pass');
+  assert.equal(
+    adapter.calls.some(({ phase, iteration }) => phase === 'execute' && iteration === 3),
+    false
+  );
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('overall timeout produces failed evidence, no later iterations, and cleanup', async () => {
+  const manifest = makeManifest({
+    scenario: {
+      timeoutMs: 25,
+      warmupRuns: 0,
+      repetitions: 3,
+    },
+  });
+  const { evidence, adapter } = await run(
+    manifest,
+    makeAdapterScript({
+      delays: { executeMs: 100 },
+    })
+  );
+
+  assert.equal(evidence.execution.status, 'failed');
+  assert.equal(evidence.execution.repetitions.completed, 0);
+  assert.equal(evidence.decision.status, 'unknown');
+  assert.ok(evidence.errors.some(({ code }) => code === 'run-timeout'));
+  assert.equal(
+    adapter.calls.some(({ phase, iteration }) => phase === 'execute' && iteration === 2),
+    false
+  );
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('external cancellation during prepare emits cancelled evidence and cleanup', async () => {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 10);
+
+  const { evidence, adapter } = await run(
+    makeManifest({ scenario: { warmupRuns: 0 } }),
+    makeAdapterScript({ delays: { prepareMs: 100 } }),
+    { signal: controller.signal }
+  );
+
+  assert.equal(evidence.execution.status, 'cancelled');
+  assert.equal(evidence.decision.status, 'unknown');
+  assert.ok(evidence.unavailable.every(({ reason }) => reason === 'cancelled'));
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('external cancellation during warmup prevents execution', async () => {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 10);
+
+  const { evidence, adapter } = await run(
+    makeManifest({ scenario: { warmupRuns: 1 } }),
+    makeAdapterScript({ delays: { warmupMs: 100 } }),
+    { signal: controller.signal }
+  );
+
+  assert.equal(evidence.execution.status, 'cancelled');
+  assert.equal(
+    adapter.calls.some(({ phase }) => phase === 'execute'),
+    false
+  );
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('external cancellation during execution prevents subsequent iterations', async () => {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 10);
+
+  const { evidence, adapter } = await run(
+    makeManifest({ scenario: { warmupRuns: 0 } }),
+    makeAdapterScript({ delays: { executeMs: 100 } }),
+    { signal: controller.signal }
+  );
+
+  assert.equal(evidence.execution.status, 'cancelled');
+  assert.equal(evidence.execution.repetitions.completed, 0);
+  assert.equal(
+    adapter.calls.some(({ phase, iteration }) => phase === 'execute' && iteration === 2),
+    false
+  );
+  assert.ok(adapter.calls.some(({ phase }) => phase === 'cleanup'));
+});
+
+test('cleanup failure remains separate from compatibility evidence', async () => {
+  const { evidence } = await run(
+    makeManifest({ scenario: { repetitions: 1, warmupRuns: 0 } }),
+    makeAdapterScript({
+      iterations: [
+        {
+          measurements: [
+            { name: 'timing.initialization.ms', unit: 'ms', value: 900 },
+          ],
+        },
+      ],
+      failure: { phase: 'cleanup', message: 'cleanup failed' },
+    })
+  );
+
+  assert.equal(evidence.execution.status, 'partial');
+  assert.equal(evidence.execution.repetitions.completed, 1);
+  assert.equal(evidence.decision.status, 'pass');
+  assert.ok(evidence.errors.some(({ phase, code }) => phase === 'cleanup' && code === 'cleanup-error'));
+});
+
+test('cleanup timeout is bounded and reported', async () => {
+  const { evidence } = await run(
+    makeManifest({ scenario: { repetitions: 1, warmupRuns: 0 } }),
+    makeAdapterScript({
+      iterations: [
+        {
+          measurements: [
+            { name: 'timing.initialization.ms', unit: 'ms', value: 900 },
+          ],
+        },
+      ],
+      delays: { cleanupMs: 100 },
+    }),
+    { cleanupTimeoutMs: 10 }
+  );
+
+  assert.equal(evidence.execution.status, 'partial');
+  assert.ok(evidence.errors.some(({ code }) => code === 'cleanup-timeout'));
+});
+
+test('sanitizes and bounds adapter messages before evidence serialization', async () => {
+  const manifest = makeManifest({
+    scenario: { repetitions: 1, warmupRuns: 0 },
+    collect: {
+      metrics: ['timing.initialization.ms'],
+      checks: ['runtime.requestCompletes'],
+      evaluations: [],
+    },
+    policy: {
+      requirements: [
+        {
+          id: 'request-completes',
+          severity: 'required',
+          target: { kind: 'check', name: 'runtime.requestCompletes' },
+          operator: 'pass',
+        },
+      ],
+    },
+  });
+  const longMessage = `before\u0000after${'x'.repeat(600)}`;
+  const { evidence } = await run(
+    manifest,
+    makeAdapterScript({
+      iterations: [
+        {
+          checks: [
+            {
+              name: 'runtime.requestCompletes',
+              status: 'pass',
+              code: 'completed',
+              message: longMessage,
+            },
+          ],
+        },
+      ],
+    })
+  );
+
+  assert.equal(evidence.checks[0].message.includes('\u0000'), false);
+  assert.ok(evidence.checks[0].message.length <= 512);
+  assert.equal(sanitizeEvidenceMessage(longMessage), evidence.checks[0].message);
+});
+
+test('fixture loader verifies digest and passes bytes only through runner context', async (t) => {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'amaryllis-verify-'));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  const fixturePath = path.join(temporary, 'fixture.txt');
+  const fixtureBytes = Buffer.from('local sensitive fixture');
+  await fs.writeFile(fixturePath, fixtureBytes);
+
+  const manifest = makeManifest({
+    scenario: {
+      repetitions: 1,
+      warmupRuns: 0,
+      fixtureRefs: [
+        {
+          id: 'local-fixture',
+          ref: 'fixture.txt',
+          digest: {
+            algorithm: 'sha256',
+            value: sha256Digest(fixtureBytes),
+          },
+          evidencePolicy: 'exclude-content',
+        },
+      ],
+    },
+  });
+  const adapter = new FakePlatformAdapter(
+    makeAdapterScript({
+      iterations: [
+        {
+          measurements: [
+            { name: 'timing.initialization.ms', unit: 'ms', value: 900 },
+          ],
+        },
+      ],
+    })
+  );
+  const evidence = await runVerification({
+    manifest,
+    validator,
+    adapter,
+    baseDirectory: temporary,
+    idFactory: () => 'fixture-test',
+  });
+
+  assert.equal(adapter.calls.find(({ phase }) => phase === 'prepare').fixtureCount, 1);
+  assert.equal(JSON.stringify(evidence).includes('local sensitive fixture'), false);
+});
+
+test('fixture loader rejects digest mismatch', async (t) => {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'amaryllis-verify-'));
+  t.after(() => fs.rm(temporary, { recursive: true, force: true }));
+  await fs.writeFile(path.join(temporary, 'fixture.txt'), 'fixture');
+
+  const manifest = makeManifest({
+    scenario: {
+      fixtureRefs: [
+        {
+          id: 'fixture',
+          ref: 'fixture.txt',
+          digest: { algorithm: 'sha256', value: DIGEST_A },
+          evidencePolicy: 'exclude-content',
+        },
+      ],
+    },
+  });
+
+  await assert.rejects(
+    () => loadDeclaredFixtures(manifest, temporary),
+    (error) => error instanceof VerifyRunnerError && error.code === 'fixture.digest-mismatch'
+  );
+});
+
+test('fixture loader rejects symlink escape outside the manifest directory', async (t) => {
+  const temporary = await fs.mkdtemp(path.join(os.tmpdir(), 'amaryllis-verify-'));
+  const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'amaryllis-verify-outside-'));
+  t.after(() => Promise.all([
+    fs.rm(temporary, { recursive: true, force: true }),
+    fs.rm(outside, { recursive: true, force: true }),
+  ]));
+  const outsideFile = path.join(outside, 'outside.txt');
+  await fs.writeFile(outsideFile, 'outside');
+  await fs.symlink(outsideFile, path.join(temporary, 'linked.txt'));
+
+  const manifest = makeManifest({
+    scenario: {
+      fixtureRefs: [
+        {
+          id: 'fixture',
+          ref: 'linked.txt',
+          evidencePolicy: 'exclude-content',
+        },
+      ],
+    },
+  });
+
+  await assert.rejects(
+    () => loadDeclaredFixtures(manifest, temporary),
+    (error) => error instanceof VerifyRunnerError && error.code === 'fixture.path-escape'
+  );
+});


### PR DESCRIPTION
## Summary

Implements #116 on top of the merged v1alpha1 contract, validator, and deterministic policy evaluator.

This PR proves the local orchestration and CLI behavior as repository tooling. It deliberately does **not** create a new published workspace package; #120 owns that promotion after the behavior is stable.

## Runner

Adds a local `runVerification` orchestration path that:

- validates the manifest before execution;
- accepts only local fixture paths and verifies declared SHA-256 digests;
- bounds fixture size and prevents relative-path/symlink escape outside the manifest directory;
- separates runner orchestration from platform adapters;
- enforces scenario timeout, warmup, repetitions, cancellation, and bounded cleanup;
- accepts only manifest-declared metric/check/evaluation targets from adapters;
- rejects undeclared/unknown adapter telemetry inside the bounded execute lifecycle;
- sanitizes/bounds diagnostic messages before evidence serialization;
- retains raw numeric samples and derives deterministic summaries;
- fills missing requested targets with explicit unavailable evidence;
- derives the compatibility decision through the shared #114 evaluator;
- validates the assembled evidence before returning it.

Fixture bytes are available only to the local adapter context and are never copied into normal evidence.

## Fake adapter

Adds a deterministic script-driven adapter for lifecycle tests. It can script:

- environment/capabilities;
- measurement/check/evaluation results;
- unavailable evidence;
- delays;
- failures by phase/iteration.

This proves runner behavior without mobile SDKs, hardware, or model downloads.

## CLI

Adds repository-local commands matching the future package contract:

```bash
node packages/amaryllis-components/tools/verify/cli.mjs run \
  --manifest verify.json \
  --output evidence.json \
  --adapter-script adapter.json

node packages/amaryllis-components/tools/verify/cli.mjs validate \
  --evidence evidence.json

node packages/amaryllis-components/tools/verify/cli.mjs check \
  --evidence evidence.json
```

Exit semantics:

```text
0   run produced valid evidence; or check result is pass/warn
2   check result is fail
3   check result is unknown or execution itself is incomplete
64  invalid usage/input/manifest/evidence
70  runner/internal failure with no valid evidence artifact
```

`check` re-derives the decision from validated evidence and rejects a tampered embedded decision.

`run` returns `0` whenever it successfully writes valid evidence, even when that evidence has a compatibility `fail` or `unknown`; policy gating is the separate `check` operation.

## Security boundaries

- no HTTP(S), cloud-storage, URI, or implicit network fixture fetching;
- relative fixtures cannot escape their manifest directory through `..` or symlinks;
- absolute fixture paths are disabled by default;
- adapter output cannot introduce undeclared telemetry targets;
- arbitrary result fields are rejected;
- prompt/output/context/fixture content is not serialized into evidence;
- output writes are explicit and atomic within an existing local directory;
- incomplete execution cannot pass the CLI `check` gate even if the compatibility-only decision is `pass`.

## Tests

Adds deterministic coverage for:

- successful warmup/repetition execution and evidence summaries;
- undeclared adapter telemetry;
- adapter execution failure and no subsequent iterations;
- overall timeout;
- cancellation during prepare, warmup, and execute;
- cleanup failure and cleanup timeout;
- message sanitization/bounding;
- fixture digest verification;
- symlink path escape;
- `validate`, `check`, and `run` CLI exit semantics;
- tampered embedded decisions;
- incomplete-execution gating;
- malformed/missing/local-only CLI inputs;
- runner failure with no evidence artifact.

The existing `tools/verify/*.test.mjs` Components CI hook automatically executes these alongside the already-merged validator and policy tests.

## Non-goals

- dedicated `@micrantha/amaryllis-verify` package/workspace (#120);
- real Android/iOS adapters (#117);
- hosted orchestration/device farm;
- model registry/deployment;
- fleet telemetry.

Closes #116 when merged.