### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   node-compat:
     runs-on: ubuntu-latest

--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   audit:
     name: OSV dependency scan

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -39,6 +39,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')) }}
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -15,8 +15,8 @@ on:
     - cron: '0 8 * * 2'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name == 'schedule' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 permissions:
   actions: read

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Make supersedable Amaryllis validation/update workflows cancel obsolete runs while preserving non-cancellable publication boundaries.

- cancel superseded PR compatibility-matrix runs while keeping manual runs independent;
- cancel superseded `main` dependency audits while keeping scheduled/manual audits independent;
- cancel superseded workflow-lint runs on PRs and `main`;
- cancel superseded `main` release-drafter updates while keeping manual updates independent;
- extend CodeQL cancellation to `main` pushes and merge-group checks while keeping scheduled scans independent;
- cancel PR and branch SBOM validation/snapshot work, but keep `v*` SBOM release publication and manual runs non-cancellable.

The immutable package publication workflow remains unchanged. Existing canary publication cancellation remains unchanged.