### PR TITLE
ci: pin GitHub Actions to immutable commits

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version-file: .nvmrc
         registry-url: ${{ inputs.registry-url }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - dependencies
-      - github-actions
     commit-message:
       prefix: "ci"

--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Wait for required workflows
         if: github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TARGET_SHA: ${{ github.sha }}
           REQUIRED_WORKFLOWS: '["CI","Dependency Audit","Security - CodeQL"]'
@@ -103,7 +103,7 @@ jobs:
             }
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -87,7 +87,7 @@ jobs:
 
       - name: Comment coverage result on PR
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('node:fs');

--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   audit:
     name: OSV dependency scan
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       scan-args: |-
         --recursive

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -31,7 +31,7 @@ jobs:
       changed_count: ${{ steps.classify.outputs.changed_count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -111,7 +111,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -133,7 +133,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_components == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         if: needs.changes.outputs.run_components == 'true'
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload components test log
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: components-test-log
           path: components-test.log
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload components lint log
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: components-lint-log
           path: components-lint.log
@@ -210,7 +210,7 @@ jobs:
 
       - name: Checkout
         if: needs.changes.outputs.run_root == 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         if: needs.changes.outputs.run_root == 'true'
@@ -237,13 +237,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/android
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for Android
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
@@ -260,13 +260,13 @@ jobs:
 
       - name: Install JDK
         if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: 'zulu'
           java-version: '17'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Create local.properties
         run: |
@@ -275,7 +275,7 @@ jobs:
 
       - name: Cache Gradle
         if: env.turbo_cache_hit != 1
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
             ~/.gradle/wrapper
@@ -300,13 +300,13 @@ jobs:
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
 
       - name: Cache turborepo for iOS
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     environment: production
     steps:
       - name: Wait for required workflows
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TARGET_SHA: ${{ github.sha }}
           REQUIRED_WORKFLOWS: '["CI","Dependency Audit","Security - CodeQL"]'
@@ -90,7 +90,7 @@ jobs:
             }
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Draft release notes
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -57,7 +57,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Generate CycloneDX SBOM
-        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b # upstream main 2026-07-17
         with:
           path: .
           format: cyclonedx-json
@@ -110,7 +110,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Submit dependency snapshot
-        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b # upstream main 2026-07-17
         with:
           path: .
           format: cyclonedx-json
@@ -142,7 +142,7 @@ jobs:
         run: mkdir -p artifacts
 
       - name: Generate release CycloneDX SBOM
-        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b
+        uses: anchore/sbom-action@b1b13de3df818f1657380c7d558539b493c17f2b # upstream main 2026-07-17
         with:
           path: .
           format: cyclonedx-json

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: javascript-typescript
 
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint workflow files
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@d63ba7532e0942965320cd8d73cbae4c7b3c5283 # v1.73.1
         with:
           fail_level: error

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -50,6 +50,83 @@ const actionSources = new Map(
   ].map(path => [relative('.', path), readFileSync(path, 'utf8')]),
 );
 
+function splitUsesScalar(raw, path, lineNumber) {
+  let quote = null;
+  let commentIndex = -1;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+
+    if (quote === "'") {
+      if (character === "'" && raw[index + 1] === "'") {
+        index += 1;
+      } else if (character === "'") {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (quote === '"') {
+      if (character === '\\') {
+        index += 1;
+      } else if (character === '"') {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+
+    if (character === '#') {
+      commentIndex = index;
+      break;
+    }
+  }
+
+  assert.equal(quote, null, `${path}:${lineNumber} has an unterminated quoted uses value`);
+
+  const valuePart = (commentIndex === -1 ? raw : raw.slice(0, commentIndex)).trim();
+  const comment = commentIndex === -1 ? '' : raw.slice(commentIndex + 1).trim();
+
+  assert.ok(valuePart, `${path}:${lineNumber} has an empty uses value`);
+  assert.ok(!['|', '>'].includes(valuePart[0]), `${path}:${lineNumber} uses multiline uses syntax`);
+
+  let value = valuePart;
+  if (valuePart.startsWith("'")) {
+    assert.ok(valuePart.endsWith("'"), `${path}:${lineNumber} has malformed single-quoted uses syntax`);
+    value = valuePart.slice(1, -1).replaceAll("''", "'");
+  } else if (valuePart.startsWith('"')) {
+    assert.ok(valuePart.endsWith('"'), `${path}:${lineNumber} has malformed double-quoted uses syntax`);
+    value = JSON.parse(valuePart);
+  }
+
+  return { value, comment };
+}
+
+function extractUsesReferences(source, path) {
+  const references = [];
+
+  for (const [index, line] of source.split('\n').entries()) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('uses:')) {
+      continue;
+    }
+
+    const match = line.match(/^\s*(?:-\s*)?uses:\s*(.+?)\s*$/);
+    assert.ok(match, `${path}:${index + 1} uses unsupported YAML uses syntax`);
+
+    references.push({
+      ...splitUsesScalar(match[1], path, index + 1),
+      lineNumber: index + 1,
+    });
+  }
+
+  return references;
+}
+
 test('change classifier exposes every CI dimension', () => {
   const changes = jobBlock('changes');
 
@@ -109,41 +186,24 @@ test('native jobs remain controlled by the native dimension', () => {
   }
 });
 
-test('workflow actions use Node 24-compatible releases', () => {
-  const obsoleteActions = [
-    ['actions/checkout', /actions\/checkout@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
-    ['actions/setup-node', /actions\/setup-node@v[1-6]\b/],
-    ['actions/cache', /actions\/cache@v[1-4]\b/],
-    ['actions/setup-java', /actions\/setup-java@v[1-4]\b/],
-    ['actions/upload-artifact', /actions\/upload-artifact@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],
-    ['actions/github-script', /actions\/github-script@v[1-8]\b/],
-    ['github/codeql-action', /github\/codeql-action\/(?:init|autobuild|analyze)@v[1-3]\b/],
-    ['android-actions/setup-android', /android-actions\/setup-android@v[1-3]\b/],
-    ['marocchino/sticky-pull-request-comment', /marocchino\/sticky-pull-request-comment@/],
-  ];
+test('external workflow and composite-action references are immutable', () => {
+  const immutableRef = /^[^@\s]+@[0-9a-f]{40}$/;
 
   for (const [path, source] of actionSources) {
-    for (const [action, pattern] of obsoleteActions) {
-      assert.doesNotMatch(source, pattern, `${path} uses an obsolete ${action} release`);
+    for (const { value, comment, lineNumber } of extractUsesReferences(source, path)) {
+      if (value.startsWith('./')) {
+        continue;
+      }
+
+      assert.match(
+        value,
+        immutableRef,
+        `${path}:${lineNumber} must pin external uses to a full 40-character commit SHA`,
+      );
+      assert.ok(
+        comment && /\d/.test(comment),
+        `${path}:${lineNumber} must include a readable upstream version/revision comment`,
+      );
     }
   }
-
-  const setup = actionSources.get('.github/actions/setup/action.yml');
-  assert.ok(setup, 'missing composite setup action');
-  assert.match(setup, /actions\/setup-node@v7\b/);
-
-  const coverage = actionSources.get('.github/workflows/coverage-gate.yml');
-  assert.ok(coverage, 'missing coverage workflow');
-  assert.match(coverage, /actions\/github-script@v9\b/);
-
-  const sbom = actionSources.get('.github/workflows/sbom.yml');
-  assert.ok(sbom, 'missing SBOM workflow');
-  assert.match(
-    sbom,
-    /actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7\.0\.1/,
-  );
-  assert.match(
-    sbom,
-    /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/,
-  );
 });


### PR DESCRIPTION
## Summary

Completes the immutable GitHub Actions supply-chain hardening tracked by #111 and serves as Morifolium second-consumer adoption evidence.

- pins external workflow and composite-action `uses:` references to full 40-character commit SHAs;
- preserves readable upstream version/revision comments;
- leaves repository-local `./.github/actions/setup` references local;
- adds a fail-closed CI contract test that rejects mutable or unsupported external `uses:` syntax;
- configures weekly Dependabot updates for the `github-actions` ecosystem so pinned revisions remain maintainable;
- preserves existing workflow permissions, concurrency, Yarn/Turbo behavior, package contracts, and Android/iOS build architecture.

## Morifolium adoption evidence

Amaryllis already had several platform-level invariants that Morifolium now documents, including self-cancelling primary CI and read-only baseline repository permissions. This change adopts the remaining reusable supply-chain invariant without imposing Morifolium's Android fixture, `mise` task layout, or application architecture on the React Native project.

That is the intended golden-path boundary: reuse policy and delivery invariants where they improve the consumer, while the consumer retains its own stack and product architecture.

## Validation

The existing Amaryllis CI remains authoritative. In particular:

- `scripts/ci-workflow-contract.test.mjs` runs in the change-classification job before expensive native validation;
- Workflow Lint parses changed workflow/composite-action YAML;
- primary CI retains lint, unit tests, package validation, Android build, and iOS build paths;
- security and SBOM workflows retain their existing behavior and permissions.

Closes #111.