### PR TITLE
route Linux workflows through Dubnium JIT

### DIFF
--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   canary:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
 
     steps:
       - name: Wait for required workflows

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   node-compat:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 15
     env:
       MIN_LINES: '76'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   nightly:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 5
     outputs:
       run_root: ${{ steps.classify.outputs.run_root }}
@@ -75,7 +75,7 @@ jobs:
 
   lint:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 15
     steps:
       - name: Root validation not required for this change
@@ -101,7 +101,7 @@ jobs:
 
   test:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 15
     steps:
       - name: Root tests not required for this change
@@ -123,7 +123,7 @@ jobs:
 
   components-package:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 20
     steps:
       - name: Components validation not required for this change
@@ -200,7 +200,7 @@ jobs:
 
   build-library:
     needs: [changes, components-package]
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 15
     steps:
       - name: Root library build not required for this change
@@ -231,7 +231,7 @@ jobs:
   build-android:
     needs: changes
     if: needs.changes.outputs.run_native == 'true'
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 30
     env:
       TURBO_CACHE_DIR: .turbo/android

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     environment: production
     steps:
       - name: Wait for required workflows

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
 
     steps:
       - name: Draft release notes

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
 
     steps:
       - name: Checkout
@@ -98,7 +98,7 @@ jobs:
 
   dependency-snapshot:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     permissions:
       contents: write
 
@@ -121,7 +121,7 @@ jobs:
 
   publish-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   codeql:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   test-publish:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: runner-amaryllis
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- replace every GitHub-hosted Ubuntu `runs-on` selector with exact repository-scoped `runner-amaryllis`
- cover CI, Android, Node compatibility, nightly, workflow lint, coverage, CodeQL, SBOM, release drafting, canary publishing, production publishing, and publish simulation
- preserve `build-ios` on hosted `macos-15` as the genuine Apple-platform exception
- make no workflow logic, permission, release, test, or matrix changes beyond runner routing

## Fleet contract

Per `ryjen/dubnium#762`, ordinary Linux/general-purpose CI must use Dubnium JIT and hosted capacity is reserved for genuine macOS/iOS work.

This branch changes 11 workflow files and the diff is selector-only: 18 additions / 18 deletions. Amaryllis has no hosted Windows path.

Checks remain non-blocking per current operator instruction; source review is the merge gate.

Relates `ryjen/dubnium#762`.