### PR TITLE
fix: make async cancellation terminal

### DIFF
--- a/android/src/main/java/com/micrantha/amaryllis/Amaryllis.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/Amaryllis.kt
@@ -6,9 +6,9 @@ import android.util.Log
 import androidx.core.graphics.scale
 import androidx.core.net.toFile
 import androidx.core.net.toUri
-import java.io.File as JavaFile
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.google.common.util.concurrent.ListenableFuture
 import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.framework.image.MPImage
 import com.google.mediapipe.tasks.genai.llminference.GraphOptions
@@ -32,21 +32,33 @@ import com.micrantha.amaryllis.AmaryllisModule.Companion.PARAM_TOP_P
 import com.micrantha.amaryllis.AmaryllisModule.Companion.PARAM_VISION_ADAPTER
 import com.micrantha.amaryllis.AmaryllisModule.Companion.PARAM_VISION_ENCODER
 import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
-import java.net.URI
-import java.net.URISyntaxException
-import android.os.Build
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
 
+internal typealias AsyncTerminalHandler = (Throwable?) -> Unit
 
 class Amaryllis {
 
+    private class ActiveAsyncGeneration(
+        val session: LlmInferenceSession,
+        val ownsSession: Boolean,
+    ) {
+        val settled = AtomicBoolean(false)
+
+        @Volatile
+        var future: ListenableFuture<String>? = null
+    }
+
     private var llmInference: LlmInference? = null
     private var session: LlmInferenceSession? = null
+    private val asyncLock = Any()
+    private var activeAsyncGeneration: ActiveAsyncGeneration? = null
 
     fun init(context: Context, config: ReadableMap) {
         val modelPath = config.getString(PARAM_MODEL_PATH) ?: throw InvalidModelPathException()
-        
+
         if (!isValidFilePath(modelPath)) {
             throw InvalidModelPathException()
         }
@@ -122,21 +134,110 @@ class Amaryllis {
         }
     }
 
-    fun generateAsync(params: ReadableMap, listener: ProgressListener<String>) {
+    fun generateAsync(
+        params: ReadableMap,
+        listener: ProgressListener<String>,
+        terminalHandler: AsyncTerminalHandler,
+    ) {
         val llm = llmInference ?: throw NotInitializedException()
-
         val prompt = params.validateAndGetPrompt()
 
-        if (session == null) {
+        val persistentSession = session
+        val asyncSession: LlmInferenceSession
+        val ownsSession: Boolean
+        if (persistentSession == null) {
             params.validateNoSession()
-            llm.generateResponseAsync(prompt, listener)
+            asyncSession = LlmInferenceSession.createFromOptions(
+                llm,
+                LlmInferenceSession.LlmInferenceSessionOptions.builder().build(),
+            )
+            ownsSession = true
+            asyncSession.addQueryChunk(prompt)
         } else {
-            this.session?.updateQueryFromParams(params)
-            this.session?.generateResponseAsync(listener)
+            persistentSession.updateQueryFromParams(params)
+            asyncSession = persistentSession
+            ownsSession = false
+        }
+
+        val active = ActiveAsyncGeneration(asyncSession, ownsSession)
+        synchronized(asyncLock) {
+            check(activeAsyncGeneration == null) { "asynchronous generation already active" }
+            activeAsyncGeneration = active
+        }
+
+        fun settle(error: Throwable?) {
+            if (!active.settled.compareAndSet(false, true)) {
+                return
+            }
+            synchronized(asyncLock) {
+                if (activeAsyncGeneration === active) {
+                    activeAsyncGeneration = null
+                }
+            }
+            var terminalError = error
+            if (active.ownsSession) {
+                try {
+                    active.session.close()
+                } catch (closeError: Throwable) {
+                    if (terminalError == null) {
+                        terminalError = closeError
+                    } else {
+                        terminalError.addSuppressed(closeError)
+                    }
+                }
+            }
+            terminalHandler(terminalError)
+        }
+
+        try {
+            val future = asyncSession.generateResponseAsync { partialResult, done ->
+                listener.run(partialResult, done)
+                if (done) {
+                    settle(null)
+                }
+            }
+            active.future = future
+            future.addListener(
+                {
+                    try {
+                        future.get()
+                    } catch (error: ExecutionException) {
+                        settle(error.cause ?: error)
+                    } catch (error: CancellationException) {
+                        settle(error)
+                    } catch (error: Throwable) {
+                        settle(error)
+                    }
+                },
+                Executor { command -> command.run() },
+            )
+        } catch (error: Throwable) {
+            active.settled.set(true)
+            synchronized(asyncLock) {
+                if (activeAsyncGeneration === active) {
+                    activeAsyncGeneration = null
+                }
+            }
+            if (active.ownsSession) {
+                try {
+                    active.session.close()
+                } catch (closeError: Throwable) {
+                    error.addSuppressed(closeError)
+                }
+            }
+            throw error
         }
     }
 
     fun close() {
+        val active = synchronized(asyncLock) {
+            activeAsyncGeneration.also { activeAsyncGeneration = null }
+        }
+        if (active != null && active.settled.compareAndSet(false, true)) {
+            if (active.ownsSession) {
+                active.session.close()
+            }
+        }
         session?.close()
         llmInference?.close()
         session = null
@@ -144,7 +245,8 @@ class Amaryllis {
     }
 
     fun cancelAsync() {
-        session?.cancelGenerateResponseAsync()
+        val active = synchronized(asyncLock) { activeAsyncGeneration }
+        active?.session?.cancelGenerateResponseAsync()
     }
 
     private fun LlmInferenceSession.updateQueryFromParams(params: ReadableMap): LlmInferenceSession {
@@ -212,26 +314,26 @@ class Amaryllis {
         val options = BitmapFactory.Options().apply {
             inJustDecodeBounds = true
         }
-        
+
         BitmapFactory.decodeFile(file.absolutePath, options)
-        
+
         // Calculate sample size to reduce memory usage if image is too large
         val maxSize = 2048
         var sampleSize = 1
         while (options.outWidth / sampleSize > maxSize || options.outHeight / sampleSize > maxSize) {
             sampleSize *= 2
         }
-        
+
         options.inJustDecodeBounds = false
         options.inSampleSize = sampleSize
-        
+
         val bitmap = BitmapFactory.decodeFile(file.absolutePath, options)
             ?: return null
 
         try {
             // Resize bitmap
             val resized = bitmap.scale(targetWidth, targetHeight)
-            
+
             // Clean up original bitmap
             if (resized != bitmap) {
                 bitmap.recycle()
@@ -257,14 +359,14 @@ class Amaryllis {
 
     private fun isValidFilePath(path: String): Boolean {
         if (path.isBlank()) return false
-        
+
         // Check for path traversal attempts
         if (path.contains("..") || path.contains("~")) return false
-        
+
         // Check for invalid characters
         val invalidChars = setOf('|', '<', '>', '"', '?', '*')
         if (invalidChars.any { char -> path.contains(char) }) return false
-        
+
         return true
     }
 

--- a/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/AmaryllisModule.kt
@@ -69,40 +69,60 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     }
 
     val accumulatedText = StringBuilder()
+    var terminalDelta = ""
     try {
-      amaryllis.generateAsync(params) { partialResult, done ->
-        val text = partialResult ?: ""
-        if (done) {
-          if (!requestTracker.clear(requestId)) {
-            return@generateAsync
+      amaryllis.generateAsync(
+        params,
+        { partialResult, done ->
+          synchronized(this@AmaryllisModule) {
+            if (!requestTracker.owns(requestId) || requestTracker.isCancelling(requestId)) {
+              return@synchronized
+            }
+
+            val text = partialResult ?: ""
+            synchronized(accumulatedText) {
+              accumulatedText.append(text)
+              if (done) {
+                terminalDelta = text
+              }
+            }
+            if (!done) {
+              sendTextEvent(EVENT_ON_PARTIAL_RESULT, requestId, text)
+            }
           }
-          val finalText = synchronized(accumulatedText) {
-            accumulatedText.append(text).toString()
+        },
+        { error ->
+          synchronized(this@AmaryllisModule) {
+            when (requestTracker.settle(requestId)) {
+              NativeRequestState.CANCELLING -> sendCancelledEvent(requestId)
+              NativeRequestState.GENERATING -> {
+                if (error != null) {
+                  Log.e(NAME, "asynchronous generation failed", error)
+                  sendErrorEvent(requestId, "unable to generate response", ERROR_CODE_INFER)
+                } else {
+                  val (finalText, finalDelta) = synchronized(accumulatedText) {
+                    accumulatedText.toString() to terminalDelta
+                  }
+                  sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, finalDelta, finalText)
+                }
+              }
+              null -> Unit
+            }
           }
-          sendTextEvent(EVENT_ON_FINAL_RESULT, requestId, text, finalText)
-        } else {
-          if (!requestTracker.owns(requestId)) {
-            return@generateAsync
-          }
-          synchronized(accumulatedText) {
-            accumulatedText.append(text)
-          }
-          sendTextEvent(EVENT_ON_PARTIAL_RESULT, requestId, text)
-        }
-      }
+        },
+      )
       promise.resolve(null)
     } catch (e: Amaryllis.SessionRequiredException) {
-      requestTracker.clear(requestId)
+      requestTracker.settle(requestId)
       Log.e(NAME, "session is required", e)
       promise.reject(ERROR_CODE_SESSION, "session is required", e)
     } catch (e: Amaryllis.NotInitializedException) {
-      requestTracker.clear(requestId)
+      requestTracker.settle(requestId)
       Log.e(NAME, "sdk is not initialized", e)
       promise.reject(ERROR_CODE_INFER, "sdk is not initialized", e)
     } catch (e: Throwable) {
-      requestTracker.clear(requestId)
+      requestTracker.settle(requestId)
       Log.e(NAME, "unable to generate response", e)
-      sendErrorEvent(requestId, "unable to generate response", ERROR_CODE_INFER)
       promise.reject(ERROR_CODE_INFER, "unable to generate response", e)
     }
   }
@@ -111,16 +131,22 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
   @Synchronized
   override fun close() {
     Log.d(NAME, "closing")
-    requestTracker.clearAll()
     amaryllis.close()
+    requestTracker.clearAll()
   }
 
   @ReactMethod
+  @Synchronized
   override fun cancelAsync(requestId: String) {
-    if (!requestTracker.clear(requestId)) {
+    if (!requestTracker.requestCancellation(requestId)) {
       return
     }
-    amaryllis.cancelAsync()
+    try {
+      amaryllis.cancelAsync()
+    } catch (error: Throwable) {
+      requestTracker.restoreGenerating(requestId)
+      throw error
+    }
   }
 
   @Override
@@ -149,6 +175,13 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     sendEvent(event, data)
   }
 
+  private fun sendCancelledEvent(requestId: String) {
+    val data = Arguments.createMap().apply {
+      putString("requestId", requestId)
+    }
+    sendEvent(EVENT_ON_CANCELLED, data)
+  }
+
   private fun sendErrorEvent(requestId: String, message: String, code: String) {
     val data = Arguments.createMap().apply {
       putString("requestId", requestId)
@@ -169,6 +202,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     "EVENT_ON_PARTIAL_RESULT" to EVENT_ON_PARTIAL_RESULT,
     "EVENT_ON_FINAL_RESULT" to EVENT_ON_FINAL_RESULT,
     "EVENT_ON_ERROR" to EVENT_ON_ERROR,
+    "EVENT_ON_CANCELLED" to EVENT_ON_CANCELLED,
     "ERROR_CODE_INFER" to ERROR_CODE_INFER,
     "ERROR_CODE_SESSION" to ERROR_CODE_SESSION,
     "ERROR_CODE_IN_PROGRESS" to ERROR_CODE_IN_PROGRESS,
@@ -194,6 +228,7 @@ class AmaryllisModule(reactContext: ReactApplicationContext) :
     const val EVENT_ON_PARTIAL_RESULT = "onPartialResult"
     const val EVENT_ON_FINAL_RESULT = "onFinalResult"
     const val EVENT_ON_ERROR = "onError"
+    const val EVENT_ON_CANCELLED = "onCancelled"
 
     const val ERROR_CODE_INFER = "ERR_INFER"
     const val ERROR_CODE_SESSION = "ERR_SESSION"

--- a/android/src/main/java/com/micrantha/amaryllis/NativeRequestTracker.kt
+++ b/android/src/main/java/com/micrantha/amaryllis/NativeRequestTracker.kt
@@ -1,7 +1,13 @@
 package com.micrantha.amaryllis
 
+internal enum class NativeRequestState {
+  GENERATING,
+  CANCELLING,
+}
+
 internal class NativeRequestTracker {
   private var activeRequestId: String? = null
+  private var state: NativeRequestState? = null
 
   @Synchronized
   fun tryStart(requestId: String): Boolean {
@@ -9,6 +15,7 @@ internal class NativeRequestTracker {
       return false
     }
     activeRequestId = requestId
+    state = NativeRequestState.GENERATING
     return true
   }
 
@@ -16,16 +23,41 @@ internal class NativeRequestTracker {
   fun owns(requestId: String): Boolean = activeRequestId == requestId
 
   @Synchronized
-  fun clear(requestId: String): Boolean {
-    if (activeRequestId != requestId) {
+  fun isCancelling(requestId: String): Boolean =
+    activeRequestId == requestId && state == NativeRequestState.CANCELLING
+
+  @Synchronized
+  fun requestCancellation(requestId: String): Boolean {
+    if (activeRequestId != requestId || state != NativeRequestState.GENERATING) {
       return false
     }
-    activeRequestId = null
+    state = NativeRequestState.CANCELLING
     return true
+  }
+
+  @Synchronized
+  fun restoreGenerating(requestId: String): Boolean {
+    if (activeRequestId != requestId || state != NativeRequestState.CANCELLING) {
+      return false
+    }
+    state = NativeRequestState.GENERATING
+    return true
+  }
+
+  @Synchronized
+  fun settle(requestId: String): NativeRequestState? {
+    if (activeRequestId != requestId) {
+      return null
+    }
+    val settledState = state
+    activeRequestId = null
+    state = null
+    return settledState
   }
 
   @Synchronized
   fun clearAll() {
     activeRequestId = null
+    state = null
   }
 }

--- a/android/src/test/java/com/micrantha/amaryllis/NativeRequestTrackerTest.kt
+++ b/android/src/test/java/com/micrantha/amaryllis/NativeRequestTrackerTest.kt
@@ -3,7 +3,9 @@ package com.micrantha.amaryllis
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class NativeRequestTrackerTest {
@@ -13,20 +15,36 @@ class NativeRequestTrackerTest {
 
     assertTrue(tracker.tryStart("first"))
     assertFalse(tracker.tryStart("second"))
-    assertTrue(tracker.clear("first"))
+    assertEquals(NativeRequestState.GENERATING, tracker.settle("first"))
     assertTrue(tracker.tryStart("second"))
   }
 
   @Test
-  fun cancellationIsRequestScopedAndLateCallbacksAreIgnored() {
+  fun cancellationRetainsOwnershipUntilTerminalSettlement() {
     val tracker = NativeRequestTracker()
 
     assertTrue(tracker.tryStart("first"))
-    assertFalse(tracker.clear("other"))
+    assertFalse(tracker.requestCancellation("other"))
+    assertTrue(tracker.requestCancellation("first"))
     assertTrue(tracker.owns("first"))
-    assertTrue(tracker.clear("first"))
+    assertTrue(tracker.isCancelling("first"))
+    assertFalse(tracker.tryStart("second"))
+    assertFalse(tracker.requestCancellation("first"))
+    assertEquals(NativeRequestState.CANCELLING, tracker.settle("first"))
     assertFalse(tracker.owns("first"))
-    assertFalse(tracker.clear("first"))
+    assertTrue(tracker.tryStart("second"))
+  }
+
+  @Test
+  fun failedCancellationCanRestoreGeneratingState() {
+    val tracker = NativeRequestTracker()
+
+    assertTrue(tracker.tryStart("first"))
+    assertTrue(tracker.requestCancellation("first"))
+    assertTrue(tracker.restoreGenerating("first"))
+    assertFalse(tracker.isCancelling("first"))
+    assertTrue(tracker.owns("first"))
+    assertEquals(NativeRequestState.GENERATING, tracker.settle("first"))
   }
 
   @Test
@@ -34,6 +52,7 @@ class NativeRequestTrackerTest {
     val tracker = NativeRequestTracker()
 
     assertTrue(tracker.tryStart("first"))
+    assertTrue(tracker.requestCancellation("first"))
     tracker.clearAll()
     assertFalse(tracker.owns("first"))
     assertTrue(tracker.tryStart("second"))
@@ -44,9 +63,9 @@ class NativeRequestTrackerTest {
     val tracker = NativeRequestTracker()
 
     assertTrue(tracker.tryStart("first"))
-    assertTrue(tracker.clear("first"))
+    assertEquals(NativeRequestState.GENERATING, tracker.settle("first"))
     assertTrue(tracker.tryStart("second"))
-    assertFalse(tracker.clear("first"))
+    assertNull(tracker.settle("first"))
     assertTrue(tracker.owns("second"))
   }
 

--- a/docs/async-inference.md
+++ b/docs/async-inference.md
@@ -23,7 +23,7 @@ const cancel = await generate({ prompt, images });
 
 `await generate(...)` waits for validation and native startup. It does **not** wait for the model to finish. The final `onResult(..., true)` callback delivers the complete output, while `onComplete` is the safe boundary for immediately starting another request. Do not start the next request synchronously from inside the final `onResult` callback; hook ownership is released immediately after that callback returns.
 
-The returned function cancels only the generation started by that call. Calling it more than once, or after settlement, is a no-op.
+The returned function requests cancellation only for the generation started by that call. Calling it more than once, or after settlement, is a no-op. Cancellation is not terminal until the native request reaches a terminal state.
 
 ## Single-flight contract
 
@@ -38,13 +38,13 @@ An overlapping call:
 
 At the low-level `LlmPipe` API, the overlapping call rejects with `GenerationInProgressError`. `useInferenceAsync` reports the same error through `onError` and returns a no-op cancellation function for the rejected attempt. It does not invoke `onComplete` for that rejected attempt; the already-active generation continues with its original callbacks.
 
-Starting a generation while the native engine is closing is rejected by the same contract.
+Starting a generation while the native engine is closing or while a prior request is cancelling is rejected by the same contract.
 
 Sequential calls are supported after the prior operation reaches a terminal state and releases ownership.
 
 ## Request isolation
 
-Every accepted asynchronous generation receives an internal request ID. Android and iOS include that ID in structured partial, final, and error events. JavaScript ignores events that do not match the active request.
+Every accepted asynchronous generation receives an internal request ID. Android and iOS include that ID in structured partial, final, error, and cancellation events. JavaScript ignores events that do not match the active request.
 
 This prevents:
 
@@ -102,20 +102,28 @@ A configured protocol sanitizes the accumulated hook output before `onResult` is
 Calling the cancellation function returned by `generate(...)`:
 
 - targets only that generation;
-- releases listeners and ownership;
-- invokes `onComplete` by default;
+- transitions the request from generating to cancelling;
+- asks native inference to cancel but does **not** treat the request as terminal yet;
+- suppresses later partial/final/error delivery for the cancelling request;
+- retains listeners and native ownership, so overlapping work remains rejected;
+- releases ownership only after native emits request-scoped `onCancelled { requestId }`;
+- invokes `onComplete` once after that terminal cancellation event;
 - does not emit a final result;
-- is idempotent.
+- is idempotent while cancellation is pending.
+
+If the synchronous native cancellation request itself throws, the request returns to the generating state and remains owned; no false cancellation completion is emitted.
+
+Android MediaPipe 0.10.24 supports physical cancellation on `LlmInferenceSession`. Amaryllis therefore runs asynchronous Android inference through an explicit session even for requests that did not create a persistent session, retaining the active session and future until terminal settlement. On iOS, when the pinned MediaPipe runtime does not expose a cancellation selector, Amaryllis uses cooperative cancellation: output is suppressed, ownership remains held, and the eventual native completion or error is translated into the same request-scoped `onCancelled` terminal event.
 
 `onComplete` means that the operation ended; it does not mean that generation succeeded. Applications that distinguish success, error, and cancellation should track that state explicitly.
 
 ### Component unmount
 
-Unmount cancels only the generation owned by that hook instance. Cleanup is silent: it does not invoke `onComplete` after the component has unmounted.
+Unmount requests cancellation only for the generation owned by that hook instance. Cleanup is silent: it does not invoke `onComplete` after the component has unmounted. Native ownership is still retained until cancellation reaches a terminal state or the owning engine is closed.
 
 ### Engine close
 
-`close()` owns the engine lifecycle. It may cancel active work, removes listeners, and releases native resources. Generation startup and close are serialized on Android and iOS so a new request cannot enter MediaPipe during teardown.
+`close()` owns the engine lifecycle. For active asynchronous work it requests cancellation first, closes the native engine, and only after native close returns releases JavaScript ownership and listeners. A failed native close therefore cannot falsely advertise an idle engine. Later request callbacks from a successfully closed engine are ignored.
 
 ## Sequential generations
 

--- a/ios/AMRequestTracker.h
+++ b/ios/AMRequestTracker.h
@@ -2,11 +2,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, AMRequestState) {
+  AMRequestStateNone = 0,
+  AMRequestStateGenerating,
+  AMRequestStateCancelling,
+};
+
 @interface AMRequestTracker : NSObject
 
 - (BOOL)tryStart:(NSString *)requestId;
 - (BOOL)owns:(NSString *)requestId;
-- (BOOL)clear:(NSString *)requestId;
+- (BOOL)isCancelling:(NSString *)requestId;
+- (BOOL)requestCancellation:(NSString *)requestId;
+- (BOOL)restoreGenerating:(NSString *)requestId;
+- (AMRequestState)settle:(NSString *)requestId;
 - (void)clearAll;
 
 @end

--- a/ios/AMRequestTracker.m
+++ b/ios/AMRequestTracker.m
@@ -2,6 +2,7 @@
 
 @interface AMRequestTracker ()
 @property(nonatomic, copy, nullable) NSString *activeRequestId;
+@property(nonatomic, assign) AMRequestState state;
 @end
 
 @implementation AMRequestTracker
@@ -12,6 +13,7 @@
       return NO;
     }
     self.activeRequestId = requestId;
+    self.state = AMRequestStateGenerating;
     return YES;
   }
 }
@@ -22,19 +24,51 @@
   }
 }
 
-- (BOOL)clear:(NSString *)requestId {
+- (BOOL)isCancelling:(NSString *)requestId {
   @synchronized(self) {
-    if (![self.activeRequestId isEqualToString:requestId]) {
+    return [self.activeRequestId isEqualToString:requestId] &&
+           self.state == AMRequestStateCancelling;
+  }
+}
+
+- (BOOL)requestCancellation:(NSString *)requestId {
+  @synchronized(self) {
+    if (![self.activeRequestId isEqualToString:requestId] ||
+        self.state != AMRequestStateGenerating) {
       return NO;
     }
-    self.activeRequestId = nil;
+    self.state = AMRequestStateCancelling;
     return YES;
+  }
+}
+
+- (BOOL)restoreGenerating:(NSString *)requestId {
+  @synchronized(self) {
+    if (![self.activeRequestId isEqualToString:requestId] ||
+        self.state != AMRequestStateCancelling) {
+      return NO;
+    }
+    self.state = AMRequestStateGenerating;
+    return YES;
+  }
+}
+
+- (AMRequestState)settle:(NSString *)requestId {
+  @synchronized(self) {
+    if (![self.activeRequestId isEqualToString:requestId]) {
+      return AMRequestStateNone;
+    }
+    AMRequestState settledState = self.state;
+    self.activeRequestId = nil;
+    self.state = AMRequestStateNone;
+    return settledState;
   }
 }
 
 - (void)clearAll {
   @synchronized(self) {
     self.activeRequestId = nil;
+    self.state = AMRequestStateNone;
   }
 }
 

--- a/ios/AmaryllisModule.mm
+++ b/ios/AmaryllisModule.mm
@@ -6,6 +6,7 @@
 static NSString *const EVENT_ON_PARTIAL_RESULT = @"onPartialResult";
 static NSString *const EVENT_ON_FINAL_RESULT = @"onFinalResult";
 static NSString *const EVENT_ON_ERROR = @"onError";
+static NSString *const EVENT_ON_CANCELLED = @"onCancelled";
 static NSString *const ERROR_CODE_INFER = @"ERR_INFER";
 static NSString *const ERROR_CODE_SESSION = @"ERR_SESSION";
 static NSString *const ERROR_CODE_IN_PROGRESS = @"GENERATION_IN_PROGRESS";
@@ -14,6 +15,8 @@ static NSString *const ERROR_CODE_IN_PROGRESS = @"GENERATION_IN_PROGRESS";
 
 @property(nonatomic, strong) Amaryllis *amaryllis;
 @property(nonatomic, strong) AMRequestTracker *requestTracker;
+
+- (void)sendCancelledEvent:(NSString *)requestId;
 
 @end
 
@@ -36,7 +39,12 @@ RCT_EXPORT_MODULE(Amaryllis)
 #pragma mark - Event Emitter
 
 - (NSArray *)supportedEvents {
-  return @[ EVENT_ON_PARTIAL_RESULT, EVENT_ON_FINAL_RESULT, EVENT_ON_ERROR ];
+  return @[
+    EVENT_ON_PARTIAL_RESULT,
+    EVENT_ON_FINAL_RESULT,
+    EVENT_ON_ERROR,
+    EVENT_ON_CANCELLED
+  ];
 }
 
 #pragma mark - Configure Engine
@@ -120,48 +128,73 @@ RCT_EXPORT_MODULE(Amaryllis)
 
       PartialResponseHandler progress = ^(NSString *result, NSError *err) {
         AmaryllisModule *strongSelf = weakSelf;
-        if (!strongSelf || ![strongSelf.requestTracker owns:requestId]) {
+        if (!strongSelf) {
           return;
         }
 
-        if (err) {
-          [strongSelf.requestTracker clear:requestId];
-          [strongSelf sendEventWithName:EVENT_ON_ERROR
+        @synchronized(strongSelf) {
+          if (![strongSelf.requestTracker owns:requestId]) {
+            return;
+          }
+
+          if (err) {
+            AMRequestState state = [strongSelf.requestTracker settle:requestId];
+            if (state == AMRequestStateCancelling) {
+              [strongSelf sendCancelledEvent:requestId];
+            } else if (state == AMRequestStateGenerating) {
+              [strongSelf sendEventWithName:EVENT_ON_ERROR
+                                       body:@{
+                                         @"requestId" : requestId,
+                                         @"message" : err.localizedDescription ?: @"unknown error",
+                                         @"code" : ERROR_CODE_INFER,
+                                       }];
+            }
+            return;
+          }
+
+          if ([strongSelf.requestTracker isCancelling:requestId]) {
+            return;
+          }
+
+          NSString *partialText = result ?: @"";
+          @synchronized(accumulatedText) {
+            [accumulatedText appendString:partialText];
+          }
+          [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
                                    body:@{
                                      @"requestId" : requestId,
-                                     @"message" : err.localizedDescription ?: @"unknown error",
-                                     @"code" : ERROR_CODE_INFER,
+                                     @"text" : partialText,
                                    }];
-          return;
         }
-
-        NSString *partialText = result ?: @"";
-        @synchronized(accumulatedText) {
-          [accumulatedText appendString:partialText];
-        }
-        [strongSelf sendEventWithName:EVENT_ON_PARTIAL_RESULT
-                                 body:@{
-                                   @"requestId" : requestId,
-                                   @"text" : partialText,
-                                 }];
       };
 
       CompletionHandler completion = ^{
         AmaryllisModule *strongSelf = weakSelf;
-        if (!strongSelf || ![strongSelf.requestTracker clear:requestId]) {
+        if (!strongSelf) {
           return;
         }
 
-        NSString *finalText;
-        @synchronized(accumulatedText) {
-          finalText = [accumulatedText copy];
+        @synchronized(strongSelf) {
+          AMRequestState state = [strongSelf.requestTracker settle:requestId];
+          if (state == AMRequestStateCancelling) {
+            [strongSelf sendCancelledEvent:requestId];
+            return;
+          }
+          if (state != AMRequestStateGenerating) {
+            return;
+          }
+
+          NSString *finalText;
+          @synchronized(accumulatedText) {
+            finalText = [accumulatedText copy];
+          }
+          [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
+                                   body:@{
+                                     @"requestId" : requestId,
+                                     @"text" : @"",
+                                     @"finalText" : finalText,
+                                   }];
         }
-        [strongSelf sendEventWithName:EVENT_ON_FINAL_RESULT
-                                 body:@{
-                                   @"requestId" : requestId,
-                                   @"text" : @"",
-                                   @"finalText" : finalText,
-                                 }];
       };
 
       [self.amaryllis generateAsyncWithParams:params
@@ -170,21 +203,15 @@ RCT_EXPORT_MODULE(Amaryllis)
                                    completion:completion];
 
       if (error) {
-        [self.requestTracker clear:requestId];
+        [self.requestTracker settle:requestId];
         reject(ERROR_CODE_INFER, @"unable to generate response", error);
         return;
       }
 
       resolve(nil);
     } @catch (NSException *exception) {
-      [self.requestTracker clear:requestId];
+      [self.requestTracker settle:requestId];
       NSLog(@"Amaryllis: error generating inference (%@)", exception.description);
-      [self sendEventWithName:EVENT_ON_ERROR
-                         body:@{
-                           @"requestId" : requestId,
-                           @"message" : @"unable to generate response",
-                           @"code" : ERROR_CODE_INFER,
-                         }];
       reject(ERROR_CODE_INFER, @"unable to generate response", nil);
     }
   }
@@ -194,16 +221,27 @@ RCT_EXPORT_MODULE(Amaryllis)
 
 - (void)close {
   @synchronized(self) {
-    [self.requestTracker clearAll];
     [self.amaryllis close];
+    [self.requestTracker clearAll];
   }
 }
 
 - (void)cancelAsync:(nonnull NSString *)requestId {
-  if (![self.requestTracker clear:requestId]) {
-    return;
+  @synchronized(self) {
+    if (![self.requestTracker requestCancellation:requestId]) {
+      return;
+    }
+    @try {
+      [self.amaryllis cancelAsync];
+    } @catch (NSException *exception) {
+      [self.requestTracker restoreGenerating:requestId];
+      @throw exception;
+    }
   }
-  [self.amaryllis cancelAsync];
+}
+
+- (void)sendCancelledEvent:(NSString *)requestId {
+  [self sendEventWithName:EVENT_ON_CANCELLED body:@{ @"requestId" : requestId }];
 }
 
 - (NSDictionary *)constantsToExport {
@@ -211,6 +249,7 @@ RCT_EXPORT_MODULE(Amaryllis)
     @"EVENT_ON_PARTIAL_RESULT" : EVENT_ON_PARTIAL_RESULT,
     @"EVENT_ON_FINAL_RESULT" : EVENT_ON_FINAL_RESULT,
     @"EVENT_ON_ERROR" : EVENT_ON_ERROR,
+    @"EVENT_ON_CANCELLED" : EVENT_ON_CANCELLED,
     @"ERROR_CODE_INFER" : ERROR_CODE_INFER,
     @"ERROR_CODE_SESSION" : ERROR_CODE_SESSION,
     @"ERROR_CODE_IN_PROGRESS" : ERROR_CODE_IN_PROGRESS,

--- a/ios/tests/AMRequestTrackerTests.m
+++ b/ios/tests/AMRequestTrackerTests.m
@@ -14,21 +14,49 @@ int main(void) {
 
     Assert([tracker tryStart:@"first"], @"first request should start");
     Assert(![tracker tryStart:@"second"], @"overlap should be rejected");
-    Assert(![tracker clear:@"other"], @"unrelated cancellation should be ignored");
-    Assert([tracker owns:@"first"], @"first request should remain active");
-    Assert([tracker clear:@"first"], @"owner should clear request");
-    Assert(![tracker clear:@"first"], @"late completion should be ignored");
-    Assert([tracker tryStart:@"second"], @"restart after completion should succeed");
-    Assert(![tracker clear:@"first"], @"stale completion must not clear newer request");
-    Assert([tracker owns:@"second"], @"second request should remain active");
+    Assert(![tracker requestCancellation:@"other"],
+           @"unrelated cancellation should be ignored");
+    Assert([tracker requestCancellation:@"first"],
+           @"owner cancellation should transition state");
+    Assert([tracker owns:@"first"], @"cancellation should retain ownership");
+    Assert([tracker isCancelling:@"first"],
+           @"request should be marked cancelling");
+    Assert(![tracker tryStart:@"second"],
+           @"cancelling request should still reject overlap");
+    Assert(![tracker requestCancellation:@"first"],
+           @"repeated cancellation should be idempotent");
+    Assert([tracker settle:@"first"] == AMRequestStateCancelling,
+           @"terminal settlement should report cancellation state");
+    Assert(![tracker owns:@"first"],
+           @"terminal settlement should release ownership");
+
+    Assert([tracker tryStart:@"second"],
+           @"restart after terminal settlement should succeed");
+    Assert([tracker requestCancellation:@"second"],
+           @"second request should enter cancelling");
+    Assert([tracker restoreGenerating:@"second"],
+           @"failed cancellation should restore generating");
+    Assert(![tracker isCancelling:@"second"],
+           @"restored request should no longer be cancelling");
+    Assert([tracker settle:@"second"] == AMRequestStateGenerating,
+           @"restored request should settle as generating");
+
+    Assert([tracker tryStart:@"third"], @"third request should start");
+    Assert([tracker settle:@"third"] == AMRequestStateGenerating,
+           @"normal completion should report generating state");
+    Assert([tracker tryStart:@"fourth"], @"fourth request should start");
+    Assert([tracker settle:@"third"] == AMRequestStateNone,
+           @"stale completion must not clear newer request");
+    Assert([tracker owns:@"fourth"], @"newer request should remain active");
 
     [tracker clearAll];
-    Assert(![tracker owns:@"second"], @"close should clear active request");
-    Assert([tracker tryStart:@"third"], @"restart after close should succeed");
+    Assert(![tracker owns:@"fourth"], @"close should clear active request");
+    Assert([tracker tryStart:@"fifth"], @"restart after close should succeed");
     [tracker clearAll];
 
     dispatch_group_t group = dispatch_group_create();
-    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_queue_t queue =
+        dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
     NSLock *lock = [[NSLock alloc] init];
     __block NSInteger winners = 0;
 

--- a/src/Amaryllis.ts
+++ b/src/Amaryllis.ts
@@ -20,12 +20,23 @@ import { GenerationInProgressError } from './Errors';
 const EVENT_ON_PARTIAL_RESULT = 'onPartialResult';
 const EVENT_ON_FINAL_RESULT = 'onFinalResult';
 const EVENT_ON_ERROR = 'onError';
+const EVENT_ON_CANCELLED = 'onCancelled';
 
-type NativeOperation = {
-  id: number;
-  kind: 'sync' | 'async';
-  owner: LlmPipe;
-};
+type AsyncOperationPhase = 'generating' | 'cancelling';
+
+type NativeOperation =
+  | {
+      id: number;
+      kind: 'sync';
+      owner: LlmPipe;
+    }
+  | {
+      id: number;
+      kind: 'async';
+      owner: LlmPipe;
+      phase: AsyncOperationPhase;
+      notifyCancellation: boolean;
+    };
 
 type NativeTextEvent = {
   requestId: string;
@@ -37,6 +48,10 @@ type NativeErrorEvent = {
   requestId: string;
   message: string;
   code?: string;
+};
+
+type NativeCancelledEvent = {
+  requestId: string;
 };
 
 const activeNativeOperations = new WeakMap<LlmNativeEngine, NativeOperation>();
@@ -105,7 +120,19 @@ export class LlmPipe implements LlmEngine {
       const nativeParams = toNativeRequestParams(params);
       await this.llmNative.generateAsync(nativeParams, String(generationId));
     } catch (error) {
-      this.finishAsyncGeneration(generationId);
+      if (closingNativeEngines.has(this.llmNative)) {
+        throw error;
+      }
+
+      const activeOperation = this.getActiveAsyncOperation(generationId);
+      if (activeOperation?.phase === 'cancelling') {
+        const notifyCancellation = activeOperation.notifyCancellation;
+        if (this.releaseNativeOperation(generationId) && notifyCancellation) {
+          this.notifyAsyncLifecycle({ type: 'cancelled' });
+        }
+      } else {
+        this.finishAsyncGeneration(generationId);
+      }
       throw error;
     }
   }
@@ -121,6 +148,7 @@ export class LlmPipe implements LlmEngine {
     }
 
     closingNativeEngines.add(this.llmNative);
+    let closeSucceeded = false;
     try {
       if (activeOperation?.kind === 'async') {
         try {
@@ -129,11 +157,19 @@ export class LlmPipe implements LlmEngine {
           console.warn('Failed to cancel generation while closing:', error);
         }
       }
+
       this.llmNative.close();
+
+      if (activeOperation?.kind === 'async') {
+        this.releaseNativeOperation(activeOperation.id);
+      }
       this.notifyAsyncLifecycle({ type: 'closed' });
+      closeSucceeded = true;
     } finally {
       this.closeRequested = false;
-      closingNativeEngines.delete(this.llmNative);
+      if (closeSucceeded) {
+        closingNativeEngines.delete(this.llmNative);
+      }
     }
   }
 
@@ -162,7 +198,7 @@ export class LlmPipe implements LlmEngine {
         EVENT_ON_PARTIAL_RESULT,
         (payload: NativeTextEvent | string) => {
           const result = this.normalizeTextEvent(payload, requestId);
-          if (!result || !this.isActiveGeneration(scopedGenerationId)) {
+          if (!result || !this.isGenerating(scopedGenerationId)) {
             return;
           }
           try {
@@ -184,7 +220,7 @@ export class LlmPipe implements LlmEngine {
       EVENT_ON_FINAL_RESULT,
       (payload: NativeTextEvent | string) => {
         const result = this.normalizeTextEvent(payload, requestId);
-        if (!result || !this.isActiveGeneration(scopedGenerationId)) {
+        if (!result || !this.isGenerating(scopedGenerationId)) {
           return;
         }
 
@@ -207,7 +243,7 @@ export class LlmPipe implements LlmEngine {
       EVENT_ON_ERROR,
       (payload: NativeErrorEvent | string) => {
         const result = this.normalizeErrorEvent(payload, requestId);
-        if (!result || !this.isActiveGeneration(scopedGenerationId)) {
+        if (!result || !this.isGenerating(scopedGenerationId)) {
           return;
         }
 
@@ -229,6 +265,30 @@ export class LlmPipe implements LlmEngine {
       }
     );
     this.subscriptions.push(errorSubscription);
+
+    const cancelledSubscription = this.llmEmitter.addListener(
+      EVENT_ON_CANCELLED,
+      (payload: NativeCancelledEvent) => {
+        const result = this.normalizeCancelledEvent(payload, requestId);
+        if (!result || closingNativeEngines.has(this.llmNative)) {
+          return;
+        }
+
+        const activeOperation = this.getActiveAsyncOperation(scopedGenerationId);
+        if (!activeOperation || activeOperation.phase !== 'cancelling') {
+          return;
+        }
+
+        const notifyCancellation = activeOperation.notifyCancellation;
+        if (!this.releaseNativeOperation(scopedGenerationId)) {
+          return;
+        }
+        if (notifyCancellation) {
+          this.notifyAsyncLifecycle({ type: 'cancelled' });
+        }
+      }
+    );
+    this.subscriptions.push(cancelledSubscription);
   }
 
   private normalizeTextEvent(
@@ -266,6 +326,16 @@ export class LlmPipe implements LlmEngine {
     return payload;
   }
 
+  private normalizeCancelledEvent(
+    payload: NativeCancelledEvent,
+    requestId: string
+  ): NativeCancelledEvent | null {
+    if (!payload || payload.requestId !== requestId) {
+      return null;
+    }
+    return payload;
+  }
+
   private claimNativeOperation(kind: NativeOperation['kind']): number {
     if (
       closingNativeEngines.has(this.llmNative) ||
@@ -275,47 +345,65 @@ export class LlmPipe implements LlmEngine {
     }
 
     const operationId = nextOperationId++;
-    activeNativeOperations.set(this.llmNative, {
-      id: operationId,
-      kind,
-      owner: this,
-    });
+    const operation: NativeOperation =
+      kind === 'async'
+        ? {
+            id: operationId,
+            kind,
+            owner: this,
+            phase: 'generating',
+            notifyCancellation: false,
+          }
+        : { id: operationId, kind, owner: this };
+    activeNativeOperations.set(this.llmNative, operation);
     return operationId;
   }
 
   private cancelOwnedAsync(notifyLifecycle: boolean): void {
-    const activeOperation = activeNativeOperations.get(this.llmNative);
-    if (
-      !activeOperation ||
-      activeOperation.owner !== this ||
-      activeOperation.kind !== 'async' ||
-      activeOperation.id !== this.activeGenerationId
-    ) {
+    const activeOperation = this.getActiveAsyncOperation(
+      this.activeGenerationId
+    );
+    if (!activeOperation || activeOperation.phase === 'cancelling') {
       return;
     }
 
-    this.releaseNativeOperation(activeOperation.id);
+    activeOperation.phase = 'cancelling';
+    activeOperation.notifyCancellation = notifyLifecycle;
     try {
       this.llmNative.cancelAsync(String(activeOperation.id));
-    } finally {
-      if (notifyLifecycle) {
-        this.notifyAsyncLifecycle({ type: 'cancelled' });
-      }
+    } catch (error) {
+      activeOperation.phase = 'generating';
+      activeOperation.notifyCancellation = false;
+      throw error;
     }
   }
 
-  private isActiveGeneration(generationId: number): boolean {
+  private getActiveAsyncOperation(
+    generationId: number | null
+  ): Extract<NativeOperation, { kind: 'async' }> | null {
+    if (generationId === null) {
+      return null;
+    }
     const activeOperation = activeNativeOperations.get(this.llmNative);
-    return (
-      this.activeGenerationId === generationId &&
-      activeOperation?.id === generationId &&
-      activeOperation.kind === 'async' &&
-      activeOperation.owner === this
-    );
+    if (
+      !activeOperation ||
+      activeOperation.kind !== 'async' ||
+      activeOperation.owner !== this ||
+      activeOperation.id !== generationId ||
+      this.activeGenerationId !== generationId
+    ) {
+      return null;
+    }
+    return activeOperation;
+  }
+
+  private isGenerating(generationId: number): boolean {
+    return this.getActiveAsyncOperation(generationId)?.phase === 'generating';
   }
 
   private finishAsyncGeneration(generationId: number): void {
-    if (!this.isActiveGeneration(generationId)) {
+    const activeOperation = this.getActiveAsyncOperation(generationId);
+    if (!activeOperation || activeOperation.phase !== 'generating') {
       return;
     }
 

--- a/src/AmaryllisHooks.tsx
+++ b/src/AmaryllisHooks.tsx
@@ -145,7 +145,10 @@ export const useInferenceAsync = (props: InferenceProps = {}) => {
           onErrorRef.current?.(
             err instanceof Error ? err : new Error('An unknown error occurred')
           );
-        } finally {
+          return;
+        }
+
+        if (!controller.subscribeAsyncLifecycle) {
           finishGeneration(generation, notifyComplete);
         }
       };
@@ -301,10 +304,11 @@ export const useContextInferenceAsync = (props: ContextInferenceProps = {}) => {
           return;
         }
         cancelled = true;
-        if (activeRequestRef.current === requestId) {
+        if (cancelBase) {
+          cancelBase();
+        } else if (activeRequestRef.current === requestId) {
           activeRequestRef.current = null;
         }
-        cancelBase?.();
       };
 
       try {

--- a/src/__tests__/Amaryllis.close.test.ts
+++ b/src/__tests__/Amaryllis.close.test.ts
@@ -4,6 +4,7 @@ import type {
   LlmEventSubscription,
   LlmNativeEngine,
 } from '../Types';
+import { GENERATION_IN_PROGRESS_CODE } from '../Errors';
 
 const eventEmitter: LlmEventEmitter = {
   addListener: (): LlmEventSubscription => ({ remove: jest.fn() }),
@@ -74,5 +75,68 @@ describe('LlmPipe close ownership', () => {
     );
 
     warnSpy.mockRestore();
+  });
+
+  it('keeps async ownership until native close returns', async () => {
+    let overlapDuringClose: Promise<void> | undefined;
+    const nativeModule = {
+      init: jest.fn(),
+      newSession: jest.fn(),
+      generate: jest.fn(),
+      generateAsync: jest.fn(() => Promise.resolve()),
+      cancelAsync: jest.fn(),
+      close: jest.fn(),
+    } as unknown as LlmNativeEngine;
+    const owner = new LlmPipe({ nativeModule, eventEmitter });
+    const contender = new LlmPipe({ nativeModule, eventEmitter });
+    const lifecycle = jest.fn();
+    owner.subscribeAsyncLifecycle(lifecycle);
+
+    (nativeModule.close as jest.Mock).mockImplementationOnce(() => {
+      overlapDuringClose = contender.generateAsync({ prompt: 'blocked' });
+    });
+
+    await owner.generateAsync({ prompt: 'active' });
+    owner.close();
+
+    expect(nativeModule.cancelAsync).toHaveBeenCalledTimes(1);
+    expect(nativeModule.close).toHaveBeenCalledTimes(1);
+    await expect(overlapDuringClose).rejects.toMatchObject({
+      code: GENERATION_IN_PROGRESS_CODE,
+    });
+    expect(lifecycle).toHaveBeenCalledTimes(1);
+    expect(lifecycle).toHaveBeenCalledWith({ type: 'closed' });
+
+    await expect(
+      contender.generateAsync({ prompt: 'after-close' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('retains async ownership when native close throws', async () => {
+    const closeError = new Error('native close failed');
+    const nativeModule = {
+      init: jest.fn(),
+      newSession: jest.fn(),
+      generate: jest.fn(),
+      generateAsync: jest.fn(() => Promise.resolve()),
+      cancelAsync: jest.fn(),
+      close: jest.fn(() => {
+        throw closeError;
+      }),
+    } as unknown as LlmNativeEngine;
+    const owner = new LlmPipe({ nativeModule, eventEmitter });
+    const contender = new LlmPipe({ nativeModule, eventEmitter });
+    const lifecycle = jest.fn();
+    owner.subscribeAsyncLifecycle(lifecycle);
+
+    await owner.generateAsync({ prompt: 'active' });
+
+    expect(() => owner.close()).toThrow(closeError);
+    expect(lifecycle).not.toHaveBeenCalled();
+    await expect(
+      contender.generateAsync({ prompt: 'blocked' })
+    ).rejects.toMatchObject({
+      code: GENERATION_IN_PROGRESS_CODE,
+    });
   });
 });

--- a/src/__tests__/Amaryllis.test.tsx
+++ b/src/__tests__/Amaryllis.test.tsx
@@ -23,6 +23,7 @@ const nativeMock = {
   EVENT_ON_PARTIAL_RESULT: 'onPartialResult',
   EVENT_ON_FINAL_RESULT: 'onFinalResult',
   EVENT_ON_ERROR: 'onError',
+  EVENT_ON_CANCELLED: 'onCancelled',
 };
 
 const emitterMock = {
@@ -55,11 +56,17 @@ const getLastRequestId = (): string => {
   return call[1];
 };
 
+const emitCancelled = (requestId: string) => {
+  listeners[nativeMock.EVENT_ON_CANCELLED]?.({ requestId });
+};
+
 describe('LlmPipe', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     nativeMock.generate.mockResolvedValue('result');
     nativeMock.generateAsync.mockResolvedValue(undefined);
+    nativeMock.cancelAsync.mockImplementation(() => {});
+    nativeMock.close.mockImplementation(() => {});
     listeners = {};
     pipe = new LlmPipe({
       nativeModule: nativeMock,
@@ -68,7 +75,11 @@ describe('LlmPipe', () => {
   });
 
   afterEach(() => {
-    pipe.cancelAsync();
+    try {
+      pipe.close();
+    } catch {
+      // Individual close-failure tests intentionally leave the native mock throwing.
+    }
   });
 
   it('calls native init', async () => {
@@ -98,6 +109,7 @@ describe('LlmPipe', () => {
     expect(listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]).toBeDefined();
     expect(listeners[nativeMock.EVENT_ON_FINAL_RESULT]).toBeDefined();
     expect(listeners[nativeMock.EVENT_ON_ERROR]).toBeDefined();
+    expect(listeners[nativeMock.EVENT_ON_CANCELLED]).toBeDefined();
 
     listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]?.('partial');
     expect(onEvent).toHaveBeenCalledWith({ type: 'partial', text: 'partial' });
@@ -294,7 +306,7 @@ describe('LlmPipe', () => {
     });
   });
 
-  it('notifies lifecycle observers when active work is cancelled externally', async () => {
+  it('keeps cancellation non-terminal until native confirms it', async () => {
     const lifecycleListener = jest.fn();
     pipe.subscribeAsyncLifecycle(lifecycleListener);
     await pipe.generateAsync(requestParams, { onEvent: jest.fn() });
@@ -303,32 +315,106 @@ describe('LlmPipe', () => {
     pipe.cancelAsync();
 
     expect(nativeMock.cancelAsync).toHaveBeenCalledWith(requestId);
+    expect(lifecycleListener).not.toHaveBeenCalled();
+    expect(listeners[nativeMock.EVENT_ON_CANCELLED]).toBeDefined();
+    await expect(
+      pipe.generateAsync({ prompt: 'blocked' }, { onEvent: jest.fn() })
+    ).rejects.toMatchObject({ code: GENERATION_IN_PROGRESS_CODE });
+
+    emitCancelled(requestId);
+
+    expect(lifecycleListener).toHaveBeenCalledTimes(1);
     expect(lifecycleListener).toHaveBeenCalledWith({ type: 'cancelled' });
+    expect(listeners).toEqual({});
+    await expect(pipe.generateAsync({ prompt: 'next' })).resolves.toBeUndefined();
   });
 
-  it('cancels only the active generation and ignores its late events', async () => {
+  it('makes repeated cancellation requests idempotent while cancelling', async () => {
+    await pipe.generateAsync(requestParams);
+    const requestId = getLastRequestId();
+
+    pipe.cancelAsync();
+    pipe.cancelAsync();
+
+    expect(nativeMock.cancelAsync).toHaveBeenCalledTimes(1);
+    expect(nativeMock.cancelAsync).toHaveBeenCalledWith(requestId);
+    emitCancelled(requestId);
+  });
+
+  it('restores generation ownership when native cancellation throws synchronously', async () => {
+    const cancelError = new Error('cancel failed');
+    const lifecycleListener = jest.fn();
+    const onEvent = jest.fn();
+    pipe.subscribeAsyncLifecycle(lifecycleListener);
+    nativeMock.cancelAsync.mockImplementationOnce(() => {
+      throw cancelError;
+    });
+    await pipe.generateAsync(requestParams, { onEvent });
+
+    expect(() => pipe.cancelAsync()).toThrow(cancelError);
+    expect(lifecycleListener).not.toHaveBeenCalled();
+
+    listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]?.('still-running');
+    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.('done');
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'partial',
+      text: 'still-running',
+    });
+    expect(onEvent).toHaveBeenCalledWith({ type: 'final', text: 'done' });
+    await expect(pipe.generateAsync({ prompt: 'next' })).resolves.toBeUndefined();
+  });
+
+  it('ignores final and error events while cancellation is pending', async () => {
+    const onEvent = jest.fn();
+    await pipe.generateAsync(requestParams, { onEvent });
+    const requestId = getLastRequestId();
+
+    pipe.cancelAsync();
+    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.({ requestId, text: 'late' });
+    listeners[nativeMock.EVENT_ON_ERROR]?.({
+      requestId,
+      message: 'late error',
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    await expect(pipe.generateAsync({ prompt: 'blocked' })).rejects.toMatchObject({
+      code: GENERATION_IN_PROGRESS_CODE,
+    });
+
+    emitCancelled(requestId);
+    await expect(pipe.generateAsync({ prompt: 'next' })).resolves.toBeUndefined();
+  });
+
+  it('does not let a stale cancellation settle a newer request', async () => {
     const firstOnEvent = jest.fn();
     const secondOnEvent = jest.fn();
 
     await pipe.generateAsync(requestParams, { onEvent: firstOnEvent });
     const firstRequestId = getLastRequestId();
-    const staleFinalListener = listeners[nativeMock.EVENT_ON_FINAL_RESULT];
-
+    const staleCancelledListener = listeners[nativeMock.EVENT_ON_CANCELLED];
     pipe.cancelAsync();
-
-    expect(nativeMock.cancelAsync).toHaveBeenCalledWith(firstRequestId);
-    expect(listeners).toEqual({});
+    emitCancelled(firstRequestId);
 
     await pipe.generateAsync({ prompt: 'second' }, { onEvent: secondOnEvent });
-    staleFinalListener?.('late-first');
+    const secondRequestId = getLastRequestId();
+    staleCancelledListener?.({ requestId: firstRequestId });
 
-    expect(firstOnEvent).not.toHaveBeenCalled();
-    expect(secondOnEvent).not.toHaveBeenCalled();
+    listeners[nativeMock.EVENT_ON_PARTIAL_RESULT]?.({
+      requestId: secondRequestId,
+      text: 'second-partial',
+    });
+    expect(secondOnEvent).toHaveBeenCalledWith({
+      type: 'partial',
+      text: 'second-partial',
+    });
 
-    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.('second');
+    listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.({
+      requestId: secondRequestId,
+      text: 'second-final',
+    });
     expect(secondOnEvent).toHaveBeenCalledWith({
       type: 'final',
-      text: 'second',
+      text: 'second-final',
     });
   });
 
@@ -337,6 +423,7 @@ describe('LlmPipe', () => {
 
     expect(listeners[nativeMock.EVENT_ON_FINAL_RESULT]).toBeDefined();
     expect(listeners[nativeMock.EVENT_ON_ERROR]).toBeDefined();
+    expect(listeners[nativeMock.EVENT_ON_CANCELLED]).toBeDefined();
 
     listeners[nativeMock.EVENT_ON_FINAL_RESULT]?.('done');
     await expect(pipe.generateAsync(requestParams)).resolves.toBeUndefined();

--- a/src/__tests__/AmaryllisHooks.cancellation.test.tsx
+++ b/src/__tests__/AmaryllisHooks.cancellation.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-native';
+import { LLMProvider } from '../AmaryllisContext';
+import { useInferenceAsync } from '../AmaryllisHooks';
+import { GenerationInProgressError } from '../Errors';
+import type {
+  LlmAsyncLifecycleEvent,
+  LlmCallbacks,
+  LlmEngine,
+  LlmEngineConfig,
+} from '../Types';
+
+const config: LlmEngineConfig = { modelPath: 'model.task' };
+
+const createLifecyclePipe = () => {
+  const callbacks: LlmCallbacks[] = [];
+  const lifecycleListeners = new Set<
+    (event: LlmAsyncLifecycleEvent) => void
+  >();
+  const pipe: LlmEngine = {
+    init: jest.fn(() => Promise.resolve()),
+    newSession: jest.fn(() => Promise.resolve()),
+    generate: jest.fn(() => Promise.resolve('result')),
+    generateAsync: jest.fn(async (_params, nextCallbacks) => {
+      callbacks.push(nextCallbacks ?? {});
+    }),
+    close: jest.fn(),
+    cancelAsync: jest.fn(),
+    subscribeAsyncLifecycle: (listener) => {
+      lifecycleListeners.add(listener);
+      return () => lifecycleListeners.delete(listener);
+    },
+  };
+
+  const emitLifecycle = (event: LlmAsyncLifecycleEvent) => {
+    lifecycleListeners.forEach((listener) => listener(event));
+  };
+
+  return { callbacks, emitLifecycle, pipe };
+};
+
+const createWrapper = (pipe: LlmEngine) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <LLMProvider config={config} llmPipe={pipe}>
+      {children}
+    </LLMProvider>
+  );
+};
+
+describe('useInferenceAsync terminal cancellation', () => {
+  it('waits for lifecycle cancellation before completing or accepting another request', async () => {
+    const { emitLifecycle, pipe } = createLifecyclePipe();
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+    const { result } = renderHook(
+      () => useInferenceAsync({ onComplete, onError }),
+      { wrapper: createWrapper(pipe) }
+    );
+
+    let cancel: (() => void) | undefined;
+    await act(async () => {
+      cancel = await result.current({ prompt: 'first' });
+    });
+
+    act(() => {
+      cancel?.();
+    });
+
+    expect(pipe.cancelAsync).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current({ prompt: 'blocked' });
+    });
+    expect(onError).toHaveBeenCalledWith(expect.any(GenerationInProgressError));
+    expect(pipe.generateAsync).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      emitLifecycle({ type: 'cancelled' });
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await result.current({ prompt: 'second' });
+    });
+    expect(pipe.generateAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the generation active when a cancellation request throws', async () => {
+    const cancelError = new Error('cancel failed');
+    const { callbacks, pipe } = createLifecyclePipe();
+    (pipe.cancelAsync as jest.Mock).mockImplementationOnce(() => {
+      throw cancelError;
+    });
+    const onComplete = jest.fn();
+    const onError = jest.fn();
+    const { result } = renderHook(
+      () => useInferenceAsync({ onComplete, onError }),
+      { wrapper: createWrapper(pipe) }
+    );
+
+    let cancel: (() => void) | undefined;
+    await act(async () => {
+      cancel = await result.current({ prompt: 'first' });
+    });
+
+    act(() => {
+      cancel?.();
+    });
+
+    expect(onError).toHaveBeenCalledWith(cancelError);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    act(() => {
+      callbacks[0]?.onEvent?.({ type: 'final', text: 'done' });
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Make asynchronous cancellation a terminal lifecycle transition across JavaScript, Android, and iOS so cancellation request A cannot authorize request B while A may still own MediaPipe state.

Closes #89

## What changed

### JavaScript ownership

- add explicit `generating | cancelling` state to async native-operation ownership;
- make `cancelAsync()` transition to `cancelling` without releasing listeners/ownership;
- add request-scoped native `onCancelled { requestId }` handling as the cancellation terminal signal;
- reject new sync/async work while cancellation is pending;
- restore `generating` if the native cancellation request throws synchronously;
- ignore final/error delivery while an operation is cancelling;
- keep close authoritative only after native `close()` returns;
- make lifecycle-aware React hooks wait for terminal cancellation before `onComplete`/reuse while retaining compatibility for custom engines without lifecycle subscription support.

### Android

- evolve `NativeRequestTracker` to explicit `GENERATING` / `CANCELLING` states;
- use an explicit retained `LlmInferenceSession` for every async generation, including an ephemeral default session for the existing no-session API;
- retain and observe the `ListenableFuture<String>` returned by MediaPipe 0.10.24;
- route callback/future terminal paths through one atomic settle helper;
- cancel the exact retained active session with `cancelGenerateResponseAsync()`;
- suppress partials after cancellation is requested;
- emit `onCancelled` instead of final/error after a cancelling request terminalizes;
- close ephemeral sessions at terminal settlement and clear module ownership only after native close returns.

### iOS

- evolve `AMRequestTracker` to the same generating/cancelling ownership contract;
- request physical cancellation through the existing pinned-runtime selector bridge when available without treating that request as terminal evidence;
- suppress output while cancelling and retain ownership until completion/error;
- translate completion/error of a cancelling request into request-scoped `onCancelled` only;
- clear request ownership after native close returns, not before.

### Tests and documentation

- cover retained ownership during cancellation on both native trackers;
- cover JS pending cancellation, overlap rejection, stale events, idempotent cancellation, synchronous cancel failure, and close ordering/failure;
- cover hook behavior while terminal cancellation is pending;
- update the async lifecycle documentation with cancelling/terminal semantics and Android/iOS physical-cancellation differences.

## Invariants

```text
Idle -> Generating(requestId)
Generating -> Cancelling | final/error -> Idle
Cancelling -> onCancelled/native terminal -> Idle
close() -> ownership release only after native close returns
```

A cancellation request is never itself evidence that the request is idle.

## Scope

This is the bounded #89 lifecycle slice. It does not include provider reconfiguration (#103), RxJS removal (#105), generalized boundary-test work (#94), or unrelated native cleanup.

## Validation

CI pending on this PR. The final branch is one commit directly on the #121 MediaPipe 0.10.24 baseline.