### PR TITLE
ci: provision Node for change classification

### DIFF
--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
       - name: Test change classification
         run: |
           node --test \


### PR DESCRIPTION
## Summary

Provision the repository-pinned Node runtime in the `changes` job before executing the Node-based CI contract and path-classification scripts.

## Why

The hardened/JIT `runner-amaryllis` environment does not provide ambient Node. Current `main` checks out the repository and immediately executes `node --test`, causing the shared change gate to fail before PR-specific validation can begin.

This is a CI-boundary fix, not an application-code workaround.

## Change

- add `actions/setup-node@v7` immediately after checkout in `jobs.changes`;
- use the existing `.nvmrc` as the single Node version authority;
- do not install dependencies or add caching in the classification job;
- satisfy the repository's Node-24-compatible GitHub Actions contract.

## Validation

Static review confirmed `scripts/ci-workflow-contract.test.mjs` rejects obsolete setup-node releases and accepts v7. PR CI should additionally prove that the `changes` job reaches and executes the existing classification contract. Once green, re-run/re-evaluate #136 so any remaining failures represent the cancellation implementation rather than missing runner tooling.

Refs #136.