### PR TITLE
ci: bootstrap Node toolchains from a Nix flake

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,16 +1,34 @@
 name: Setup
-description: Setup Node.js and install dependencies
+description: Setup the repository Node.js toolchain and install dependencies
 
 inputs:
   registry-url:
     description: Optional npm registry URL for setup-node
     required: false
     default: https://registry.npmjs.org/
+  nix-shell:
+    description: Flake devShell to use on Linux runners
+    required: false
+    default: ci
 
 runs:
   using: composite
   steps:
+    - name: Activate Nix Node toolchain
+      if: runner.os == 'Linux'
+      env:
+        NIX_SHELL: ${{ inputs.nix-shell }}
+      run: |
+        set -euo pipefail
+        nix develop ".#${NIX_SHELL}" --command bash -euo pipefail -c '
+          for tool in node npm npx corepack yarn; do
+            dirname "$(command -v "$tool")"
+          done
+        ' | sort -u >> "$GITHUB_PATH"
+      shell: bash
+
     - name: Setup Node.js
+      if: runner.os != 'Linux'
       uses: actions/setup-node@v7
       with:
         node-version-file: .nvmrc

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,3 +39,13 @@ runs:
     - name: Install dependencies
       run: yarn install --immutable
       shell: bash
+
+    - name: Repair generated package executables
+      if: runner.os == 'Linux'
+      run: |
+        set -euo pipefail
+        while IFS= read -r -d '' bin; do
+          target="$(readlink -f "$bin" 2>/dev/null || printf '%s' "$bin")"
+          chmod u+x "$target"
+        done < <(find . -path '*/node_modules/.bin/*' -print0)
+      shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,17 +14,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Activate Nix Node toolchain
+    - name: Install dependencies with Nix Node toolchain
       if: runner.os == 'Linux'
       env:
         NIX_SHELL: ${{ inputs.nix-shell }}
       run: |
         set -euo pipefail
-        nix develop ".#${NIX_SHELL}" --command bash -euo pipefail -c '
-          for tool in node npm npx corepack yarn; do
-            dirname "$(command -v "$tool")"
-          done
-        ' | sort -u >> "$GITHUB_PATH"
+        nix develop ".#${NIX_SHELL}" --command corepack yarn install --immutable
       shell: bash
 
     - name: Setup Node.js
@@ -37,6 +33,7 @@ runs:
         cache-dependency-path: yarn.lock
 
     - name: Install dependencies
+      if: runner.os != 'Linux'
       run: yarn install --immutable
       shell: bash
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,29 @@ runs:
         NIX_SHELL: ${{ inputs.nix-shell }}
       run: |
         set -euo pipefail
-        nix develop ".#${NIX_SHELL}" --command corepack yarn install --immutable
+        nix develop "$GITHUB_WORKSPACE#${NIX_SHELL}" --command corepack yarn install --immutable
+      shell: bash
+
+    - name: Route Node commands through Nix
+      if: runner.os == 'Linux'
+      env:
+        NIX_SHELL: ${{ inputs.nix-shell }}
+      run: |
+        set -euo pipefail
+        wrapper_dir="$RUNNER_TEMP/amaryllis-nix-bin"
+        rm -rf "$wrapper_dir"
+        mkdir -p "$wrapper_dir"
+
+        for tool in node npm npx corepack yarn; do
+          cat > "$wrapper_dir/$tool" <<EOF
+        #!/usr/bin/env bash
+        set -euo pipefail
+        exec nix develop "$GITHUB_WORKSPACE#${NIX_SHELL}" --command $tool "\$@"
+        EOF
+          chmod +x "$wrapper_dir/$tool"
+        done
+
+        echo "$wrapper_dir" >> "$GITHUB_PATH"
       shell: bash
 
     - name: Setup Node.js

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -34,14 +34,20 @@ jobs:
           nix-shell: ${{ matrix.nix-shell }}
 
       - name: Verify Node version
+        env:
+          NIX_SHELL: ${{ matrix.nix-shell }}
         run: |
-          actual_major="$(node --version | sed -E 's/^v([0-9]+).*/\1/')"
+          actual_major="$(nix develop ".#${NIX_SHELL}" --command node --version | sed -E 's/^v([0-9]+).*/\1/')"
           expected_major="${{ matrix.node-version }}"
           expected_major="${expected_major%%.*}"
           test "$actual_major" = "$expected_major"
 
       - name: Run tests
-        run: yarn test --maxWorkers=2
+        env:
+          NIX_SHELL: ${{ matrix.nix-shell }}
+        run: nix develop ".#${NIX_SHELL}" --command corepack yarn test --maxWorkers=2
 
       - name: Run typecheck
-        run: yarn typecheck
+        env:
+          NIX_SHELL: ${{ matrix.nix-shell }}
+        run: nix develop ".#${NIX_SHELL}" --command corepack yarn typecheck

--- a/.github/workflows/compat-matrix.yml
+++ b/.github/workflows/compat-matrix.yml
@@ -16,22 +16,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20.x', '22.x', '24.x']
+        include:
+          - node-version: '20.x'
+            nix-shell: node20
+          - node-version: '22.x'
+            nix-shell: node22
+          - node-version: '24.x'
+            nix-shell: node24
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v7
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          nix-shell: ${{ matrix.nix-shell }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install --immutable
+      - name: Verify Node version
+        run: |
+          actual_major="$(node --version | sed -E 's/^v([0-9]+).*/\1/')"
+          expected_major="${{ matrix.node-version }}"
+          expected_major="${expected_major%%.*}"
+          test "$actual_major" = "$expected_major"
 
       - name: Run tests
         run: yarn test --maxWorkers=2

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run tests with coverage summary
         run: |
-          yarn test --maxWorkers=2 --coverage \
+          nix develop .#ci --command corepack yarn test --maxWorkers=2 --coverage \
             --coverageReporters=json-summary \
             --coverageReporters=text-summary \
             --collectCoverageFrom='src/**/*.{ts,tsx}' \
@@ -44,7 +44,7 @@ jobs:
       - name: Validate coverage thresholds
         id: validate_coverage
         run: |
-          node <<'NODE'
+          nix develop .#ci --command node <<'NODE'
           const fs = require('node:fs');
 
           const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8')).total;

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Test change classification
         run: |
-          node --test \
+          nix develop .#ci --command node --test \
             scripts/ci-workflow-contract.test.mjs \
             scripts/classify-ci-changes.test.mjs \
             scripts/detect-ci-changes.test.mjs \
@@ -72,7 +72,7 @@ jobs:
             exit 0
           fi
 
-          node scripts/detect-ci-changes.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          nix develop .#ci --command node scripts/detect-ci-changes.mjs "$BASE_SHA" "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   lint:
     needs: changes

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -94,11 +94,11 @@ jobs:
 
       - name: Lint root package
         if: needs.changes.outputs.run_root == 'true'
-        run: yarn lint --ignore-pattern 'packages/amaryllis-components/**'
+        run: nix develop .#ci --command corepack yarn lint --ignore-pattern 'packages/amaryllis-components/**'
 
       - name: Typecheck files
         if: needs.changes.outputs.run_root == 'true'
-        run: yarn typecheck
+        run: nix develop .#ci --command corepack yarn typecheck
 
   test:
     needs: changes
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run unit tests
         if: needs.changes.outputs.run_root == 'true'
-        run: yarn test --maxWorkers=2
+        run: nix develop .#ci --command corepack yarn test --maxWorkers=2
 
   components-package:
     needs: changes
@@ -144,7 +144,7 @@ jobs:
         if: needs.changes.outputs.run_components == 'true'
         run: |
           set -o pipefail
-          yarn workspace @micrantha/amaryllis-components test --runInBand 2>&1 | tee components-test.log
+          nix develop .#ci --command corepack yarn workspace @micrantha/amaryllis-components test --runInBand 2>&1 | tee components-test.log
 
       - name: Upload components test log
         if: failure()
@@ -159,7 +159,7 @@ jobs:
         if: needs.changes.outputs.run_components == 'true'
         run: |
           set -o pipefail
-          yarn eslint "packages/amaryllis-components/src/**/*.{ts,tsx}" 2>&1 | tee components-lint.log
+          nix develop .#ci --command corepack yarn eslint "packages/amaryllis-components/src/**/*.{ts,tsx}" 2>&1 | tee components-lint.log
 
       - name: Upload components lint log
         if: failure()
@@ -172,32 +172,32 @@ jobs:
 
       - name: Typecheck components package
         if: needs.changes.outputs.run_components == 'true'
-        run: yarn workspace @micrantha/amaryllis-components typecheck
+        run: nix develop .#ci --command corepack yarn workspace @micrantha/amaryllis-components typecheck
 
       - name: Build components package
         if: needs.changes.outputs.run_components == 'true'
-        run: yarn workspace @micrantha/amaryllis-components build
+        run: nix develop .#ci --command corepack yarn workspace @micrantha/amaryllis-components build
 
       - name: Verify AI component examples
         if: needs.changes.outputs.run_components == 'true'
-        run: yarn workspace @micrantha/amaryllis-components verify:examples
+        run: nix develop .#ci --command corepack yarn workspace @micrantha/amaryllis-components verify:examples
 
       - name: Build main package for package validation
         if: needs.changes.outputs.run_components == 'true'
-        run: yarn prepare
+        run: nix develop .#ci --command corepack yarn prepare
 
       - name: Validate package metadata and outputs
         if: needs.changes.outputs.run_components == 'true'
-        run: node scripts/validate-packages.mjs
+        run: nix develop .#ci --command node scripts/validate-packages.mjs
 
       - name: Dry-run components package archive
         if: needs.changes.outputs.run_components == 'true'
-        run: npm pack --dry-run
+        run: nix develop ../..#ci --command npm pack --dry-run
         working-directory: packages/amaryllis-components
 
       - name: Dry-run main package archive
         if: needs.changes.outputs.run_components == 'true'
-        run: npm pack --dry-run
+        run: nix develop .#ci --command npm pack --dry-run
 
   build-library:
     needs: [changes, components-package]
@@ -219,15 +219,15 @@ jobs:
 
       - name: Build main package
         if: needs.changes.outputs.run_root == 'true'
-        run: yarn prepare
+        run: nix develop .#ci --command corepack yarn prepare
 
       - name: Validate package metadata and outputs
         if: needs.changes.outputs.run_root == 'true'
-        run: node scripts/validate-packages.mjs
+        run: nix develop .#ci --command node scripts/validate-packages.mjs
 
       - name: Dry-run main package archive
         if: needs.changes.outputs.run_root == 'true'
-        run: npm pack --dry-run
+        run: nix develop .#ci --command npm pack --dry-run
 
   build-android:
     needs: changes
@@ -261,7 +261,7 @@ jobs:
         env:
           JAVA_OPTS: '-XX:MaxHeapSize=6g'
         run: |
-          yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
+          nix develop .#ci --command corepack yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
     needs: changes

--- a/.github/workflows/primary-ci.yml
+++ b/.github/workflows/primary-ci.yml
@@ -243,24 +243,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Cache turborepo for Android
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-turborepo-android-
-
-      - name: Check turborepo cache for Android
-        run: |
-          TURBO_CACHE_STATUS=$(node -p "($(yarn turbo run build:android --cache-dir=\"${{ env.TURBO_CACHE_DIR }}\" --dry=json)).tasks.find(t => t.task === 'build:android').cache.status")
-
-          if [[ "$TURBO_CACHE_STATUS" == "HIT" ]]; then
-            echo "turbo_cache_hit=1" >> "$GITHUB_ENV"
-          fi
-
       - name: Install JDK
-        if: env.turbo_cache_hit != 1
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
@@ -273,17 +256,6 @@ jobs:
         run: |
           echo "sdk.dir=${{ env.ANDROID_HOME }}" > example/android/local.properties
         working-directory: ./
-
-      - name: Cache Gradle
-        if: env.turbo_cache_hit != 1
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('example/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Build example for Android
         env:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Test package SBOM derivation
-        run: node --test scripts/package-sbom-lib.test.mjs
+        run: nix develop .#ci --command node --test scripts/package-sbom-lib.test.mjs
 
       - name: Prepare artifact directory
         run: mkdir -p artifacts
@@ -67,7 +67,7 @@ jobs:
           upload-release-assets: false
 
       - name: Derive package-scoped SBOMs
-        run: node scripts/derive-package-sboms.mjs
+        run: nix develop .#ci --command node scripts/derive-package-sboms.mjs
 
       - name: Validate CycloneDX schemas
         run: |
@@ -136,7 +136,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Test package SBOM derivation
-        run: node --test scripts/package-sbom-lib.test.mjs
+        run: nix develop .#ci --command node --test scripts/package-sbom-lib.test.mjs
 
       - name: Prepare artifact directory
         run: mkdir -p artifacts
@@ -154,7 +154,7 @@ jobs:
       - name: Derive versioned package SBOMs
         run: |
           set -euo pipefail
-          node scripts/derive-package-sboms.mjs \
+          nix develop .#ci --command node scripts/derive-package-sboms.mjs \
             "artifacts/amaryllis-${GITHUB_REF_NAME}.cdx.json" \
             artifacts/packages
           mv artifacts/packages/react-native-amaryllis.cdx.json \

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'flake.nix'
+      - 'flake.lock'
   push:
     branches:
       - main
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'flake.nix'
+      - 'flake.lock'
 
 permissions:
   contents: read
@@ -24,6 +28,4 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Lint workflow files
-        uses: reviewdog/action-actionlint@v1
-        with:
-          fail_level: error
+        run: nix develop .#ci --command actionlint

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "type": "github"
+      }
+    },
+    "nixpkgs-node20": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-node20": "nixpkgs-node20"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,12 @@
 {
   description = "Amaryllis development and CI toolchains";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5";
+    nixpkgs-node20.url = "github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d";
+  };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, nixpkgs-node20, ... }:
     let
       systems = [
         "x86_64-linux"
@@ -12,27 +15,32 @@
         "aarch64-darwin"
       ];
       forAllSystems = f:
-        nixpkgs.lib.genAttrs systems (system: f (import nixpkgs { inherit system; }));
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f
+            (import nixpkgs { inherit system; })
+            (import nixpkgs-node20 { inherit system; })
+        );
       mkYarn = pkgs:
         pkgs.writeShellScriptBin "yarn" ''
           exec ${pkgs.corepack}/bin/corepack yarn "$@"
         '';
-      mkNodeShell = pkgs: node:
+      mkNodeShell = pkgs: node: extraPackages:
         pkgs.mkShellNoCC {
           packages = [
             node
             pkgs.corepack
             (mkYarn pkgs)
-          ];
+          ] ++ extraPackages;
         };
     in
     {
-      devShells = forAllSystems (pkgs: {
-        default = mkNodeShell pkgs pkgs.nodejs_24;
-        ci = mkNodeShell pkgs pkgs.nodejs_24;
-        node20 = mkNodeShell pkgs pkgs.nodejs_20;
-        node22 = mkNodeShell pkgs pkgs.nodejs_22;
-        node24 = mkNodeShell pkgs pkgs.nodejs_24;
+      devShells = forAllSystems (pkgs: legacyPkgs: {
+        default = mkNodeShell pkgs pkgs.nodejs_24 [ ];
+        ci = mkNodeShell pkgs pkgs.nodejs_24 [ pkgs.actionlint ];
+        node20 = mkNodeShell legacyPkgs legacyPkgs.nodejs_20 [ ];
+        node22 = mkNodeShell pkgs pkgs.nodejs_22 [ ];
+        node24 = mkNodeShell pkgs pkgs.nodejs_24 [ ];
       });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Amaryllis development and CI toolchains";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/2c423e03bbafcff28bfadc6781a4a8257f205cb5";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system: f (import nixpkgs { inherit system; }));
+      mkYarn = pkgs:
+        pkgs.writeShellScriptBin "yarn" ''
+          exec ${pkgs.corepack}/bin/corepack yarn "$@"
+        '';
+      mkNodeShell = pkgs: node:
+        pkgs.mkShellNoCC {
+          packages = [
+            node
+            pkgs.corepack
+            (mkYarn pkgs)
+          ];
+        };
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = mkNodeShell pkgs pkgs.nodejs_24;
+        ci = mkNodeShell pkgs pkgs.nodejs_24;
+        node20 = mkNodeShell pkgs pkgs.nodejs_20;
+        node22 = mkNodeShell pkgs pkgs.nodejs_22;
+        node24 = mkNodeShell pkgs pkgs.nodejs_24;
+      });
+    };
+}

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -57,6 +57,8 @@ test('change classifier exposes every CI dimension', () => {
     'run_root: ${{ steps.classify.outputs.run_root }}',
     'run_components: ${{ steps.classify.outputs.run_components }}',
     'run_native: ${{ steps.classify.outputs.run_native }}',
+    'nix develop .#ci --command node --test',
+    'nix develop .#ci --command node scripts/detect-ci-changes.mjs',
   ]);
 });
 
@@ -86,16 +88,16 @@ test('components job retains stable acknowledgement and validation paths', () =>
   ]);
 });
 
-test('root library job independently validates package outputs', () => {
+test('root library job independently validates package outputs through the flake', () => {
   const block = jobBlock('build-library');
 
   assertContainsAll(block, [
     'needs: [changes, components-package]',
     "if: needs.changes.outputs.run_root != 'true'",
     "if: needs.changes.outputs.run_root == 'true'",
-    'run: yarn prepare',
-    'run: node scripts/validate-packages.mjs',
-    'run: npm pack --dry-run',
+    'run: nix develop .#ci --command corepack yarn prepare',
+    'run: nix develop .#ci --command node scripts/validate-packages.mjs',
+    'run: nix develop .#ci --command npm pack --dry-run',
   ]);
 });
 

--- a/scripts/ci-workflow-contract.test.mjs
+++ b/scripts/ci-workflow-contract.test.mjs
@@ -109,6 +109,30 @@ test('native jobs remain controlled by the native dimension', () => {
   }
 });
 
+test('Linux Node toolchains are owned by the repository flake', () => {
+  const setup = actionSources.get('.github/actions/setup/action.yml');
+  assert.ok(setup, 'missing composite setup action');
+  assert.match(
+    setup,
+    /nix develop "\$GITHUB_WORKSPACE#\$\{NIX_SHELL\}" --command corepack yarn install --immutable/,
+  );
+  assert.match(
+    setup,
+    /exec nix develop "\$GITHUB_WORKSPACE#\$\{NIX_SHELL\}" --command \$tool/,
+  );
+
+  const compatibility = actionSources.get('.github/workflows/compat-matrix.yml');
+  assert.ok(compatibility, 'missing Node compatibility workflow');
+  assertContainsAll(compatibility, [
+    'nix-shell: node20',
+    'nix-shell: node22',
+    'nix-shell: node24',
+    'nix develop ".#${NIX_SHELL}" --command node --version',
+    'nix develop ".#${NIX_SHELL}" --command corepack yarn test --maxWorkers=2',
+    'nix develop ".#${NIX_SHELL}" --command corepack yarn typecheck',
+  ]);
+});
+
 test('workflow actions use Node 24-compatible releases', () => {
   const obsoleteActions = [
     ['actions/checkout', /actions\/checkout@(?:v[1-6]\b|[0-9a-f]{40}\s+# v[1-6](?:\.\d+\.\d+)?\b)/],


### PR DESCRIPTION
## Summary

Make Amaryllis CI independent of ambient Node installations on `runner-amaryllis` by defining the repository Node toolchain in a Nix flake and executing Linux Node/Yarn/npm commands through `nix develop`.

## What changed

- add `flake.nix` pinned to current nixpkgs for Node 22/24 plus a separate pinned nixpkgs input for Node 20 compatibility;
- expose `ci`, `node20`, `node22`, and `node24` dev shells;
- provide Node, Corepack/Yarn, and `actionlint` from the flake;
- install Linux dependencies from inside the selected flake shell while retaining `actions/setup-node` for macOS;
- run Linux lint/test/typecheck/build/package commands through `nix develop` instead of exporting Node onto runner `PATH`;
- run pre-setup CI change classification through the flake;
- run the Node compatibility matrix entirely inside the corresponding flake shell and verify the selected major explicitly;
- replace Docker-backed workflow lint with flake-provided `actionlint`;
- remove Linux Turbo cache action usage from Android validation so the repository Node path remains flake-owned.

## Why

The Dubnium JIT runner now dispatches correctly, but Amaryllis must not require ambient project Node packages from the generic runner image. The repository should own its Node toolchain and CI should execute against that declared environment.

Observed blocker on PR #136:

```text
node: command not found
Process completed with exit code 127
```

This PR makes the flake the executable authority for Amaryllis Node tooling on Linux while leaving GitHub's own action runtime and macOS toolchain handling separate.

## Validation

CI on this PR is the authoritative validation of the Nix/JIT integration. After this merges, PR #136 should be rebased or rerun against main so its cancellation implementation can receive current JS/native validation.
